### PR TITLE
Analytic normal

### DIFF
--- a/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
+++ b/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
@@ -50,6 +50,26 @@ describe("eval on distribution functions", () => {
     testEval("3+normal(5,2)", "Ok(Normal(8,2))")
     testEval("normal(5,2)+3", "Ok(Normal(8,2))")
   })
+  describe("subtract", () => {
+    testEval("10 - normal(5, 1)", "Ok(Normal(5,1))")
+    testEval("normal(5, 1) - 10", "Ok(Normal(-5,1))")
+  })
+  describe("multiply", () => {
+    testEval("normal(10, 2) * 2", "Ok(Normal(20,4))")
+    testEval("2 * normal(10, 2)", "Ok(Normal(20,4))")
+    testEval("lognormal(5,2) * lognormal(10,2)", "Ok(Lognormal(15,4))")
+    testEval("lognormal(10, 2) * lognormal(5, 2)", "Ok(Lognormal(15,4))")
+    testEval("2 * lognormal(5, 2)", "Ok(Lognormal(5.693147180559945,2))")
+    testEval("lognormal(5, 2) * 2", "Ok(Lognormal(5.693147180559945,2))")
+  })
+  describe("division", () => {
+    testEval("lognormal(5,2) / lognormal(10,2)", "Ok(Lognormal(-5,4))")
+    testEval("lognormal(10,2) / lognormal(5,2)", "Ok(Lognormal(5,4))")
+    testEval("lognormal(5, 2) / 2", "Ok(Lognormal(4.306852819440055,2))")
+    testEval("2 / lognormal(5, 2)", "Ok(Lognormal(-4.306852819440055,2))")
+    testEval("2 / normal(10, 2)", "Ok(Point Set Distribution)")
+    testEval("normal(10, 2) / 2", "Ok(Normal(5,1))")
+  })
   describe("truncate", () => {
     testEval("truncateLeft(normal(5,2), 3)", "Ok(Point Set Distribution)")
     testEval("truncateRight(normal(5,2), 3)", "Ok(Point Set Distribution)")
@@ -92,11 +112,6 @@ describe("eval on distribution functions", () => {
   describe("mixture", () => {
     testEval("mx(normal(5,2), normal(10,1), normal(15, 1))", "Ok(Point Set Distribution)")
     testEval("mixture(normal(5,2), normal(10,1), [0.2, 0.4])", "Ok(Point Set Distribution)")
-  })
-
-  describe("subtract", () => {
-    testEval("10 - normal(5, 1)", "Ok(Normal(5,1))")
-    testEval("normal(5, 1) - 10", "Ok(Normal(-5,1))")
   })
 })
 

--- a/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
+++ b/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
@@ -19,7 +19,7 @@ describe("eval on distribution functions", () => {
     testEval("lognormal(5,2)", "Ok(Lognormal(5,2))")
   })
   describe("unaryMinus", () => {
-    testEval("mean(-normal(5,2))", "Ok(-5.002887370380851)")
+    testEval("mean(-normal(5,2))", "Ok(-5)")
   })
   describe("to", () => {
     testEval("5 to 2", "Error(TODO: Low value must be less than high value.)")
@@ -45,10 +45,10 @@ describe("eval on distribution functions", () => {
   describe("add", () => {
     testEval("add(normal(5,2), normal(10,2))", "Ok(Normal(15,2.8284271247461903))")
     testEval("add(normal(5,2), lognormal(10,2))", "Ok(Sample Set Distribution)")
-    testEval("add(normal(5,2), 3)", "Ok(Point Set Distribution)")
-    testEval("add(3, normal(5,2))", "Ok(Point Set Distribution)")
-    testEval("3+normal(5,2)", "Ok(Point Set Distribution)")
-    testEval("normal(5,2)+3", "Ok(Point Set Distribution)")
+    testEval("add(normal(5,2), 3)", "Ok(Normal(8,2))")
+    testEval("add(3, normal(5,2))", "Ok(Normal(8,2))")
+    testEval("3+normal(5,2)", "Ok(Normal(8,2))")
+    testEval("normal(5,2)+3", "Ok(Normal(8,2))")
   })
   describe("truncate", () => {
     testEval("truncateLeft(normal(5,2), 3)", "Ok(Point Set Distribution)")
@@ -93,6 +93,11 @@ describe("eval on distribution functions", () => {
     testEval("mx(normal(5,2), normal(10,1), normal(15, 1))", "Ok(Point Set Distribution)")
     testEval("mixture(normal(5,2), normal(10,1), [0.2, 0.4])", "Ok(Point Set Distribution)")
   })
+
+  describe("subtract", () => {
+    testEval("10 - normal(5, 1)", "Ok(Normal(5,1))")
+    testEval("normal(5, 1) - 10", "Ok(Normal(-5,1))")
+  })
 })
 
 describe("parse on distribution functions", () => {
@@ -100,6 +105,10 @@ describe("parse on distribution functions", () => {
     testParse("normal(5,2) ^ normal(5,1)", "Ok((:pow (:normal 5 2) (:normal 5 1)))")
     testParse("3 ^ normal(5,1)", "Ok((:pow 3 (:normal 5 1)))")
     testParse("normal(5,2) ^ 3", "Ok((:pow (:normal 5 2) 3))")
+  })
+  describe("subtraction", () => {
+    testParse("10 - normal(5,1)", "Ok((:subtract 10 (:normal 5 1)))")
+    testParse("normal(5,1) - 10", "Ok((:subtract (:normal 5 1) 10))")
   })
   describe("pointwise arithmetic expressions", () => {
     testParse(~skip=true, "normal(5,2) .+ normal(5,1)", "Ok((:dotAdd (:normal 5 2) (:normal 5 1)))")

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -117,7 +117,8 @@ module Helpers = {
         | Error(err) => GenDistError(ArgumentError(err))
         }
       }
-    | Some(EvDistribution(b)) => switch parseDistributionArray(args) {
+    | Some(EvDistribution(b)) =>
+      switch parseDistributionArray(args) {
       | Ok(distributions) => mixtureWithDefaultWeights(distributions)
       | Error(err) => GenDistError(ArgumentError(err))
       }


### PR DESCRIPTION
This adds analytic simplifacations for more operations, specifically for floats. This fixes the precise issue expressed in #120, although is a bit of a cheat by keeping the distributions symbolic. I'm not therefore going to close #120 until I can work out what the issue is with an expression like `1 / normal(10, 1)` Which should not be normal but is. (likely with point set distributions)