### PR TITLE
grammar document

### DIFF
--- a/packages/website/docs/Internal/Grammar.md
+++ b/packages/website/docs/Internal/Grammar.md
@@ -1,0 +1,53 @@
+---
+title: Grammar
+urlcolor: blue
+author:
+  - Quinn Dougherty
+---
+
+Formal grammar specification, reference material for parser implementation.
+
+_In all likelihood the reference will have to be debugged as we see what tests pass and don't pass during implementation_.
+
+## Lexical descriptions of constants and identifiers
+
+- `<number>` ::= `[-]? [0-9]+ (.[0-9]+)? | [-]? [0-9]+ (.[0-9]+)? [e] [-]? [0-9]+`
+- `<symbol>` ::= `[a-zA-Z]+ [a-zA-Z0-9]?`
+- `<baseDistribution>` ::= `(normal(<number>, <number>) | beta(<number>, <number>) | triangular(<number>, <number>, <number>) | cauchy(<number>, <number>) | lognormal(<number>, <number>)) | uniform(<number>, <number>) | <number> to <number> | exponential(<number>)`
+
+## Expressions
+
+Think of javascript's list unpacking notation to read our variable-argument function `mixture`.
+
+```
+<expr> ::= <term> + <expr> | <term> - <expr> | <expr> .+ <expr> | <expr> .- <expr> | <term> | sample(<baseDistribution>) | mixture(...<array>, <array>) | mx(...<array>, <array>) | exp(<expr>) | log(<expr>, <number>?) | log10(<expr>) | dotLog(<expr>, <number>?) | normalize(<expr>)
+<term> ::= <power> * <term> | <power> <term> | <power> / <term> | <power> .* <term> | <power ./ <term> | <power>
+<power> ::= <factor> ^ <power> | <factor> .^ <power> | <factor>
+<factor> ::= <number> | <baseDistribution> | <symbol> | ( <expr> )
+```
+
+## Data structures
+
+```
+<array> ::= [] | [<expr>] | [<expr>, <expr>] | ...
+<record> ::= {} | {<symbol>: <expr>} | {<symbol>: <expr>, <symbol>: <expr>} | ...
+```
+
+## Statements
+
+```
+<stmnt> ::= <asgn> | <asgnFn>
+<asgn> ::= <symbol> = <expr>
+<asgnFn> ::= <symbol>(<symbol>) = <expr>
+```
+
+## A squiggle file
+
+To be valid and raise no errors as of current (apr22) interpreter,
+
+```
+<delim> ::= ; | \n
+<code> ::= <expr> | <stmnt> <delim> <expr> | <stmnt> <delim> <stmnt> <delim> <expr> | ...
+```
+
+This isn't strictly speaking true; the interpreter allows expressions outside of the final line.

--- a/packages/website/docs/Internal/Grammar.md
+++ b/packages/website/docs/Internal/Grammar.md
@@ -10,10 +10,11 @@ _In all likelihood the reference will have to be debugged as we see what tests p
 
 ## Lexical descriptions of constants and identifiers
 
-- `<number>` ::= `[-]? [0-9]+ (.[0-9]+)? | [-]? [0-9]+ (.[0-9]+)? [e] [-]? [0-9]+`
-- `<symbol>` ::= `[a-zA-Z]+ [a-zA-Z0-9]?`
-- `<baseDistribution>` ::= `normal(<number>, <number>) | beta(<number>, <number>) | triangular(<number>, <number>, <number>) | cauchy(<number>, <number>) | lognormal(<number>, <number>)) | uniform(<number>, <number>) | <number> to <number> | exponential(<number>)`
-- `<bool>` ::= `true | false`
+```
+<number> ::= [-]? [0-9]+ (.[0-9]+)? | [-]? [0-9]+ (.[0-9]+)? [e] [-]? [0-9]+
+<symbol> ::= [a-zA-Z]+ [a-zA-Z0-9]?
+<bool> ::= true | false
+```
 
 ## Expressions
 
@@ -22,10 +23,10 @@ The following gives no typing information. You can obey the grammar and still wr
 Think of javascript's list unpacking notation to read our variable-argument function `mixture`.
 
 ```
-<expr> ::= <term> + <expr> | <term> - <expr> | <expr> .+ <expr> | <expr> .- <expr> | <term> | sample(<baseDistribution>) | mixture(...<array>, <array>) | mx(...<array>, <array>) | exp(<expr>) | log(<expr>, <number>?) | log10(<expr>) | dotLog(<expr>, <number>?) | normalize(<expr>) | isNormalized(<expr>) | pdf(<expr>, <expr>) | cdf(<expr>, <expr>) | inv(<expr>, <expr>) | mean(<expr>) | truncate(<expr>, <expr>, <expr>) | truncateLeft(<expr>, <expr>) | truncateRight(<expr>, <expr>)
+<expr> ::= <term> + <expr> | <term> - <expr> | <expr> .+ <expr> | <expr> .- <expr> | <term>
 <term> ::= <power> * <term> | <power> <term> | <power> / <term> | <power> .* <term> | <power ./ <term> | <power>
 <power> ::= <factor> ^ <power> | <factor> .^ <power> | <factor>
-<factor> ::= <number> | <baseDistribution> | <bool> | <symbol> | ( <expr> )
+<factor> ::= <number> | <bool> | <symbol> | ( <expr> ) | <symbol>(<symbol>)
 ```
 
 ## Data structures

--- a/packages/website/docs/Internal/Grammar.md
+++ b/packages/website/docs/Internal/Grammar.md
@@ -26,7 +26,7 @@ Think of javascript's list unpacking notation to read our variable-argument func
 <expr> ::= <term> + <expr> | <term> - <expr> | <expr> .+ <expr> | <expr> .- <expr> | <term>
 <term> ::= <power> * <term> | <power> <term> | <power> / <term> | <power> .* <term> | <power ./ <term> | <power>
 <power> ::= <factor> ^ <power> | <factor> .^ <power> | <factor>
-<factor> ::= <number> | <bool> | <symbol> | ( <expr> ) | <symbol>(<symbol>)
+<factor> ::= <number> | <bool> | <symbol> | ( <expr> ) | <array> | <record> | <record>.<symbol> | <symbol> => <expr> | <symbol>(<symbol>) | <symbol>(<symbol>, <symbol>) | ...
 ```
 
 ## Data structures
@@ -41,7 +41,7 @@ Think of javascript's list unpacking notation to read our variable-argument func
 ```
 <statement> ::= <assign> | <assignFunction>
 <assign> ::= <symbol> = <expr>
-<assignFunction> ::= <symbol>(<symbol>) = <expr>
+<assignFunction> ::= <symbol>(<symbol>) = <expr> | <symbol>(<symbol>, <symbol>) = <expr> | ...
 ```
 
 ## A squiggle file

--- a/packages/website/docs/Internal/Grammar.md
+++ b/packages/website/docs/Internal/Grammar.md
@@ -1,6 +1,5 @@
 ---
 title: Grammar
-urlcolor: blue
 author:
   - Quinn Dougherty
 ---
@@ -13,17 +12,20 @@ _In all likelihood the reference will have to be debugged as we see what tests p
 
 - `<number>` ::= `[-]? [0-9]+ (.[0-9]+)? | [-]? [0-9]+ (.[0-9]+)? [e] [-]? [0-9]+`
 - `<symbol>` ::= `[a-zA-Z]+ [a-zA-Z0-9]?`
-- `<baseDistribution>` ::= `(normal(<number>, <number>) | beta(<number>, <number>) | triangular(<number>, <number>, <number>) | cauchy(<number>, <number>) | lognormal(<number>, <number>)) | uniform(<number>, <number>) | <number> to <number> | exponential(<number>)`
+- `<baseDistribution>` ::= `normal(<number>, <number>) | beta(<number>, <number>) | triangular(<number>, <number>, <number>) | cauchy(<number>, <number>) | lognormal(<number>, <number>)) | uniform(<number>, <number>) | <number> to <number> | exponential(<number>)`
+- `<bool>` ::= `true | false`
 
 ## Expressions
+
+The following gives no typing information. You can obey the grammar and still write nonsensical code.
 
 Think of javascript's list unpacking notation to read our variable-argument function `mixture`.
 
 ```
-<expr> ::= <term> + <expr> | <term> - <expr> | <expr> .+ <expr> | <expr> .- <expr> | <term> | sample(<baseDistribution>) | mixture(...<array>, <array>) | mx(...<array>, <array>) | exp(<expr>) | log(<expr>, <number>?) | log10(<expr>) | dotLog(<expr>, <number>?) | normalize(<expr>)
+<expr> ::= <term> + <expr> | <term> - <expr> | <expr> .+ <expr> | <expr> .- <expr> | <term> | sample(<baseDistribution>) | mixture(...<array>, <array>) | mx(...<array>, <array>) | exp(<expr>) | log(<expr>, <number>?) | log10(<expr>) | dotLog(<expr>, <number>?) | normalize(<expr>) | isNormalized(<expr>) | pdf(<expr>, <expr>) | cdf(<expr>, <expr>) | inv(<expr>, <expr>) | mean(<expr>) | truncate(<expr>, <expr>, <expr>) | truncateLeft(<expr>, <expr>) | truncateRight(<expr>, <expr>)
 <term> ::= <power> * <term> | <power> <term> | <power> / <term> | <power> .* <term> | <power ./ <term> | <power>
 <power> ::= <factor> ^ <power> | <factor> .^ <power> | <factor>
-<factor> ::= <number> | <baseDistribution> | <symbol> | ( <expr> )
+<factor> ::= <number> | <baseDistribution> | <bool> | <symbol> | ( <expr> )
 ```
 
 ## Data structures
@@ -36,9 +38,9 @@ Think of javascript's list unpacking notation to read our variable-argument func
 ## Statements
 
 ```
-<stmnt> ::= <asgn> | <asgnFn>
-<asgn> ::= <symbol> = <expr>
-<asgnFn> ::= <symbol>(<symbol>) = <expr>
+<statement> ::= <assign> | <assignFunction>
+<assign> ::= <symbol> = <expr>
+<assignFunction> ::= <symbol>(<symbol>) = <expr>
 ```
 
 ## A squiggle file
@@ -47,7 +49,7 @@ To be valid and raise no errors as of current (apr22) interpreter,
 
 ```
 <delim> ::= ; | \n
-<code> ::= <expr> | <stmnt> <delim> <expr> | <stmnt> <delim> <stmnt> <delim> <expr> | ...
+<code> ::= <expr> | <statement> <delim> <expr> | <statement> <delim> <statement> <delim> <expr> | ...
 ```
 
 This isn't strictly speaking true; the interpreter allows expressions outside of the final line.


### PR DESCRIPTION
# Replaces #110 

Not sure if we should leave #26 open, because this'll be iterated on as we get closer to and during parser development. 

# Todo

- [x] anonymous functions
- [x] figure out if grammar really needs to specify inventory function symbols 
- [x] add `functionCall` to `<expr>` 