### PR TITLE
Prevent negative standard deviation in symbolic multiplication

### DIFF
--- a/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
+++ b/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
@@ -20,6 +20,7 @@ describe("eval on distribution functions", () => {
   })
   describe("unaryMinus", () => {
     testEval("mean(-normal(5,2))", "Ok(-5)")
+    testEval("-normal(5,2)", "Ok(Normal(-5,2))")
   })
   describe("to", () => {
     testEval("5 to 2", "Error(Math Error: Low value must be less than high value.)")

--- a/packages/squiggle-lang/src/rescript/Distributions/SymbolicDist/SymbolicDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/SymbolicDist/SymbolicDist.res
@@ -52,7 +52,7 @@ module Normal = {
     switch operation {
     | #Add => Some(#Normal({mean: n1 +. n2.mean, stdev: n2.stdev}))
     | #Subtract => Some(#Normal({mean: n1 -. n2.mean, stdev: n2.stdev}))
-    | #Multiply => Some(#Normal({mean: n1 *. n2.mean, stdev: n1 *. n2.stdev}))
+    | #Multiply => Some(#Normal({mean: n1 *. n2.mean, stdev: Js.Math.abs_float(n1) *. n2.stdev}))
     | _ => None
     }
 
@@ -60,8 +60,8 @@ module Normal = {
     switch operation {
     | #Add => Some(#Normal({mean: n1.mean +. n2, stdev: n1.stdev}))
     | #Subtract => Some(#Normal({mean: n1.mean -. n2, stdev: n1.stdev}))
-    | #Multiply => Some(#Normal({mean: n1.mean *. n2, stdev: n1.stdev *. n2}))
-    | #Divide => Some(#Normal({mean: n1.mean /. n2, stdev: n1.stdev /. n2}))
+    | #Multiply => Some(#Normal({mean: n1.mean *. n2, stdev: n1.stdev *. Js.Math.abs_float(n2)}))
+    | #Divide => Some(#Normal({mean: n1.mean /. n2, stdev: n1.stdev /. Js.Math.abs_float(n2)}))
     | _ => None
     }
 }


### PR DESCRIPTION
Introduced in #242

Basically `-normal(5, 2)` created `normal(-5, -2)`. This puts a stop to that.