### PR TITLE
Fix convolution for negative multiplication

### DIFF
--- a/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/AlgebraicShapeCombination.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/AlgebraicShapeCombination.res
@@ -230,13 +230,12 @@ let combineShapesContinuousDiscrete = (
           i,
           (
             fn(continuousShape.xs[i], discreteShape.xs[j]),
-            continuousShape.ys[i] *. discreteShape.ys[j] /. discreteShape.xs[j],
+            continuousShape.ys[i] *. discreteShape.ys[j] /. Js.Math.abs_float(discreteShape.xs[j]),
           ),
         ) |> ignore
         ()
       }
       Belt.Array.set(outXYShapes, j, dxyShape) |> ignore
-      ()
     }
   }
 
@@ -244,12 +243,11 @@ let combineShapesContinuousDiscrete = (
   |> E.A.fmap(XYShape.T.fromZippedArray)
   |> E.A.fold_left(
     (acc, x) =>
-      XYShape.PointwiseCombination.combine(
-        (a, b) => Ok(a +. b),
+      XYShape.PointwiseCombination.addCombine(
         XYShape.XtoY.continuousInterpolator(#Linear, #UseZero),
         acc,
         x,
-      )->E.R.toExn("Error, unexpected failure", _),
+      ),
     XYShape.T.empty,
   )
 }


### PR DESCRIPTION
This fixes a really bad error I didn't know we don't have an issue for

`-1 * toPointSet(normal(5, 2))` returns an upside down distribution! This is because whoever wrote the convolution code forget the absolute sign in the product of random variables formula:
![image](https://user-images.githubusercontent.com/13807753/164947066-fb34f708-601b-4860-9d79-c86ae271f2d7.png)

Would like to work out how to write tests for these types of issues.