### PR TITLE
Make sure pointSetDist toPointSet is normalized

### DIFF
--- a/packages/squiggle-lang/__tests__/Distributions/Invariants/AlgebraicCombination_test.res
+++ b/packages/squiggle-lang/__tests__/Distributions/Invariants/AlgebraicCombination_test.res
@@ -51,7 +51,6 @@ describe("(Algebraic) addition of distributions", () => {
       ->toBe(Some(2.5e1))
     })
 
-
     test("uniform(low=9, high=10) + beta(alpha=2, beta=5)", () => {
       // let uniformMean = (9.0 +. 10.0) /. 2.0
       // let betaMean = 1.0 /. (1.0 +. 5.0 /. 2.0)

--- a/packages/squiggle-lang/__tests__/Distributions/Invariants/AlgebraicCombination_test.res
+++ b/packages/squiggle-lang/__tests__/Distributions/Invariants/AlgebraicCombination_test.res
@@ -51,6 +51,7 @@ describe("(Algebraic) addition of distributions", () => {
       ->toBe(Some(2.5e1))
     })
 
+
     test("uniform(low=9, high=10) + beta(alpha=2, beta=5)", () => {
       // let uniformMean = (9.0 +. 10.0) /. 2.0
       // let betaMean = 1.0 /. (1.0 +. 5.0 /. 2.0)
@@ -65,7 +66,8 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=2.
-      | Some(x) => x->expect->toBeSoCloseTo(0.01927225696028752, ~digits=1) // (uniformMean +. betaMean)
+      // Answer found from WolframAlpha: ``mean(uniform(9,10)) + mean(betaDistribution(2,5))``
+      | Some(x) => x->expect->toBeSoCloseTo(9.786, ~digits=1) // (uniformMean +. betaMean)
       }
     })
     test("beta(alpha=2, beta=5) + uniform(low=9, high=10)", () => {
@@ -82,7 +84,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=2.
-      | Some(x) => x->expect->toBeSoCloseTo(0.019275414920485248, ~digits=1) // (uniformMean +. betaMean)
+      | Some(x) => x->expect->toBeSoCloseTo(9.786, ~digits=1) // (uniformMean +. betaMean)
       }
     })
   })
@@ -163,7 +165,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=4.
-      | Some(x) => x->expect->toBeSoCloseTo(0.001978994877226945, ~digits=3)
+      | Some(x) => x->expect->toBeSoCloseTo(1.025, ~digits=1)
       }
     })
     test("(beta(alpha=2, beta=5) + uniform(low=9, high=10)).pdf(10)", () => {
@@ -178,7 +180,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=4.
-      | Some(x) => x->expect->toBeSoCloseTo(0.001978994877226945, ~digits=3)
+      | Some(x) => x->expect->toBeSoCloseTo(0.98, ~digits=1)
       }
     })
   })
@@ -254,7 +256,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=4.
-      | Some(x) => x->expect->toBeSoCloseTo(0.0013961779932477507, ~digits=3)
+      | Some(x) => x->expect->toBeSoCloseTo(0.70, ~digits=1)
       }
     })
     test("(beta(alpha=2, beta=5) + uniform(low=9, high=10)).cdf(10)", () => {
@@ -269,7 +271,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=4.
-      | Some(x) => x->expect->toBeSoCloseTo(0.001388898111625753, ~digits=3)
+      | Some(x) => x->expect->toBeSoCloseTo(0.71, ~digits=1)
       }
     })
   })
@@ -346,7 +348,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=2.
-      | Some(x) => x->expect->toBeSoCloseTo(10.927078217530806, ~digits=0)
+      | Some(x) => x->expect->toBeSoCloseTo(9.174960348568693, ~digits=0)
       }
     })
     test("(beta(alpha=2, beta=5) + uniform(low=9, high=10)).inv(2e-2)", () => {
@@ -361,7 +363,7 @@ describe("(Algebraic) addition of distributions", () => {
       | None => "algebraicAdd has"->expect->toBe("failed")
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=2.
-      | Some(x) => x->expect->toBeSoCloseTo(10.915396627014363, ~digits=0)
+      | Some(x) => x->expect->toBeSoCloseTo(9.168291999681523, ~digits=0)
       }
     })
   })

--- a/packages/squiggle-lang/__tests__/TS/JS_test.ts
+++ b/packages/squiggle-lang/__tests__/TS/JS_test.ts
@@ -56,16 +56,16 @@ describe("Distribution", () => {
   );
 
   test("mean", () => {
-    expect(dist.mean().value).toBeCloseTo(3.737);
+    expect(dist.mean().value).toBeCloseTo(5.3913);
   });
   test("pdf", () => {
     expect(dist.pdf(5.0).value).toBeCloseTo(0.0431);
   });
   test("cdf", () => {
-    expect(dist.cdf(5.0).value).toBeCloseTo(0.155);
+    expect(dist.cdf(5.0).value).toBeCloseTo(0.224);
   });
   test("inv", () => {
-    expect(dist.inv(0.5).value).toBeCloseTo(9.458);
+    expect(dist.inv(0.5).value).toBeCloseTo(6.0);
   });
   test("toPointSet", () => {
     expect(
@@ -87,6 +87,6 @@ describe("Distribution", () => {
       resultMap(dist.pointwiseAdd(dist2), (r: Distribution) =>
         r.toSparkline(20)
       ).value
-    ).toEqual(Ok("▁▂▅██▅▅▅▆▇█▆▅▃▃▂▂▁▁▁"));
+    ).toEqual(Ok("▁▂▅█▇▅▅▆▇██▇▅▄▃▃▃▂▁▁"));
   });
 });

--- a/packages/squiggle-lang/__tests__/TS/SampleSet_test.ts
+++ b/packages/squiggle-lang/__tests__/TS/SampleSet_test.ts
@@ -46,7 +46,7 @@ describe("cumulative density function", () => {
     );
   });
 
-  test("at the highest number in the sample is close to 1", () => {
+  test("at the highest number in the sample to be approximately 1", () => {
     fc.assert(
       fc.property(arrayGen(), (xs_) => {
         let xs = Array.from(xs_);
@@ -57,13 +57,7 @@ describe("cumulative density function", () => {
           { sampleCount: n, xyPointLength: 100 }
         );
         let cdfValue = dist.cdf(max).value;
-        let min = Math.min(...xs);
-        let epsilon = 5e-3;
-        if (max - min < epsilon) {
-          expect(cdfValue).toBeLessThan(1 - epsilon);
-        } else {
-          expect(dist.cdf(max).value).toBeGreaterThan(1 - epsilon);
-        }
+        expect(cdfValue).toBeCloseTo(1.0, 2)
       })
     );
   });

--- a/packages/squiggle-lang/__tests__/TS/SampleSet_test.ts
+++ b/packages/squiggle-lang/__tests__/TS/SampleSet_test.ts
@@ -57,7 +57,7 @@ describe("cumulative density function", () => {
           { sampleCount: n, xyPointLength: 100 }
         );
         let cdfValue = dist.cdf(max).value;
-        expect(cdfValue).toBeCloseTo(1.0, 2)
+        expect(cdfValue).toBeCloseTo(1.0, 2);
       })
     );
   });

--- a/packages/squiggle-lang/src/rescript/Distributions/SampleSetDist/SampleSetDist_ToPointSet.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/SampleSetDist/SampleSetDist_ToPointSet.res
@@ -133,9 +133,17 @@ let toPointSetDist = (
     ~discrete=Some(discrete),
   )
 
+  /*
+   I'm surprised that this doesn't come out normalized. My guess is that the KDE library
+  we're using is standardizing on something else. If we ever change that library, we should
+  check to see if we still need to do this.
+ */
+
+  let normalizedPointSet = pointSetDist->E.O2.fmap(PointSetDist.T.normalize)
+
   let samplesParse: Internals.Types.outputs = {
     continuousParseParams: pdf |> E.O.fmap(snd),
-    pointSetDist: pointSetDist,
+    pointSetDist: normalizedPointSet,
   }
 
   samplesParse


### PR DESCRIPTION
This fixes https://github.com/quantified-uncertainty/squiggle/issues/255.

One major issue of this, apparently, is that:
1. Some of our key math results were wrong.
2. For some reason, there seems to be significantly more randomness in the tests than there was before. It's become significantly more difficult to make the property tests pass reliably.