### PR TITLE
`MagicNumbers.res` 

### DIFF
--- a/packages/squiggle-lang/__tests__/TestHelpers.res
+++ b/packages/squiggle-lang/__tests__/TestHelpers.res
@@ -30,8 +30,8 @@ let {toFloat, toDist, toString, toError, fmap} = module(DistributionOperation.Ou
 let fnImage = (theFn, inps) => Js.Array.map(theFn, inps)
 
 let env: DistributionOperation.env = {
-  sampleCount: 10000,
-  xyPointLength: 1000,
+  sampleCount: MagicNumbers.Environment.defaultSampleCount,
+  xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
 }
 
 let run = DistributionOperation.run(~env)

--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist/GenericDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist/GenericDist.res
@@ -186,13 +186,17 @@ module AlgebraicCombination = {
  */
   let getLogarithmInputError = (t1: t, t2: t, ~toPointSetFn: toPointSetFn): option<error> => {
     let firstOperandIsGreaterThanZero =
-      toFloatOperation(t1, ~toPointSetFn, ~distToFloatOperation=#Cdf(1e-10)) |> E.R.fmap(r =>
-        r > 0.
-      )
+      toFloatOperation(
+        t1,
+        ~toPointSetFn,
+        ~distToFloatOperation=#Cdf(MagicNumbers.Epsilon.ten),
+      ) |> E.R.fmap(r => r > 0.)
     let secondOperandIsGreaterThanZero =
-      toFloatOperation(t2, ~toPointSetFn, ~distToFloatOperation=#Cdf(1e-10)) |> E.R.fmap(r =>
-        r > 0.
-      )
+      toFloatOperation(
+        t2,
+        ~toPointSetFn,
+        ~distToFloatOperation=#Cdf(MagicNumbers.Epsilon.ten),
+      ) |> E.R.fmap(r => r > 0.)
     let items = E.A.R.firstErrorOrOpen([
       firstOperandIsGreaterThanZero,
       secondOperandIsGreaterThanZero,
@@ -224,12 +228,12 @@ module AlgebraicCombination = {
   //I'm (Ozzie) really just guessing here, very little idea what's best
   let expectedConvolutionCost: t => int = x =>
     switch x {
-    | Symbolic(#Float(_)) => 1
-    | Symbolic(_) => 1000
+    | Symbolic(#Float(_)) => MagicNumbers.OpCost.floatCost
+    | Symbolic(_) => MagicNumbers.OpCost.symbolicCost
     | PointSet(Discrete(m)) => m.xyShape->XYShape.T.length
-    | PointSet(Mixed(_)) => 1000
-    | PointSet(Continuous(_)) => 1000
-    | _ => 1000
+    | PointSet(Mixed(_)) => MagicNumbers.OpCost.mixedCost
+    | PointSet(Continuous(_)) => MagicNumbers.OpCost.continuousCost
+    | _ => MagicNumbers.OpCost.wildcardCost
     }
 
   type calculationStrategy = MonteCarloStrat | ConvolutionStrat(Operation.convolutionOperation)
@@ -245,7 +249,7 @@ module AlgebraicCombination = {
     | #Logarithm =>
       MonteCarloStrat
     | (#Add | #Subtract | #Multiply) as convOp =>
-      expectedConvolutionCost(t1) * expectedConvolutionCost(t2) > 10000
+      expectedConvolutionCost(t1) * expectedConvolutionCost(t2) > MagicNumbers.OpCost.monteCarloCost
         ? MonteCarloStrat
         : ConvolutionStrat(convOp)
     }

--- a/packages/squiggle-lang/src/rescript/MagicNumbers.res
+++ b/packages/squiggle-lang/src/rescript/MagicNumbers.res
@@ -1,0 +1,24 @@
+module Math = {
+  let e = Js.Math._E
+  let pi = Js.Math._PI
+}
+
+module Epsilon = {
+  let ten = 1e-10
+  let seven = 1e-7
+}
+
+module Environment = {
+  let defaultXYPointLength = 1000
+  let defaultSampleCount = 10000
+}
+
+module OpCost = {
+  let floatCost = 1
+  let symbolicCost = 1000
+  // Discrete cost is the length of the xyShape
+  let mixedCost = 1000
+  let continuousCost = 1000
+  let wildcardCost = 1000
+  let monteCarloCost = Environment.defaultSampleCount
+}

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -1,12 +1,10 @@
 module ExpressionValue = ReducerInterface_ExpressionValue
 type expressionValue = ReducerInterface_ExpressionValue.expressionValue
 
-let defaultSampleCount = 10000
-
 let runGenericOperation = DistributionOperation.run(
   ~env={
-    sampleCount: defaultSampleCount,
-    xyPointLength: 1000,
+    sampleCount: MagicNumbers.Environment.defaultSampleCount,
+    xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
   },
 )
 
@@ -176,10 +174,6 @@ module SymbolicConstructors = {
     }
 }
 
-module Math = {
-  let e = 2.718281828459
-}
-
 let dispatchToGenericOutput = (call: ExpressionValue.functionCall): option<
   DistributionOperation.outputType,
 > => {
@@ -208,7 +202,12 @@ let dispatchToGenericOutput = (call: ExpressionValue.functionCall): option<
     Helpers.toStringFn(ToSparkline(Belt.Float.toInt(n)), dist)
   | ("exp", [EvDistribution(a)]) =>
     // https://mathjs.org/docs/reference/functions/exp.html
-    Helpers.twoDiststoDistFn(Algebraic(AsDefault), "pow", GenericDist.fromFloat(Math.e), a)->Some
+    Helpers.twoDiststoDistFn(
+      Algebraic(AsDefault),
+      "pow",
+      GenericDist.fromFloat(MagicNumbers.Math.e),
+      a,
+    )->Some
   | ("normalize", [EvDistribution(dist)]) => Helpers.toDistFn(Normalize, dist)
   | ("isNormalized", [EvDistribution(dist)]) => Helpers.toBoolFn(IsNormalized, dist)
   | ("toPointSet", [EvDistribution(dist)]) => Helpers.toDistFn(ToPointSet, dist)
@@ -218,7 +217,7 @@ let dispatchToGenericOutput = (call: ExpressionValue.functionCall): option<
   | ("toSampleSet", [EvDistribution(dist), EvNumber(float)]) =>
     Helpers.toDistFn(ToSampleSet(Belt.Int.fromFloat(float)), dist)
   | ("toSampleSet", [EvDistribution(dist)]) =>
-    Helpers.toDistFn(ToSampleSet(defaultSampleCount), dist)
+    Helpers.toDistFn(ToSampleSet(MagicNumbers.Environment.defaultSampleCount), dist)
   | ("inspect", [EvDistribution(dist)]) => Helpers.toDistFn(Inspect, dist)
   | ("truncateLeft", [EvDistribution(dist), EvNumber(float)]) =>
     Helpers.toDistFn(Truncate(Some(float), None), dist)
@@ -228,7 +227,12 @@ let dispatchToGenericOutput = (call: ExpressionValue.functionCall): option<
     Helpers.toDistFn(Truncate(Some(float1), Some(float2)), dist)
   | ("mx" | "mixture", args) => Helpers.mixture(args)->Some
   | ("log", [EvDistribution(a)]) =>
-    Helpers.twoDiststoDistFn(Algebraic(AsDefault), "log", a, GenericDist.fromFloat(Math.e))->Some
+    Helpers.twoDiststoDistFn(
+      Algebraic(AsDefault),
+      "log",
+      a,
+      GenericDist.fromFloat(MagicNumbers.Math.e),
+    )->Some
   | ("log10", [EvDistribution(a)]) =>
     Helpers.twoDiststoDistFn(Algebraic(AsDefault), "log", a, GenericDist.fromFloat(10.0))->Some
   | ("unaryMinus", [EvDistribution(a)]) =>
@@ -249,7 +253,12 @@ let dispatchToGenericOutput = (call: ExpressionValue.functionCall): option<
       Helpers.twoDiststoDistFn(Pointwise, arithmetic, fst, snd)
     )
   | ("dotExp", [EvDistribution(a)]) =>
-    Helpers.twoDiststoDistFn(Pointwise, "dotPow", GenericDist.fromFloat(Math.e), a)->Some
+    Helpers.twoDiststoDistFn(
+      Pointwise,
+      "dotPow",
+      GenericDist.fromFloat(MagicNumbers.Math.e),
+      a,
+    )->Some
   | _ => None
   }
 }


### PR DESCRIPTION
Closes https://github.com/quantified-uncertainty/squiggle/issues/325 

# I'd like to piggyback: 
removing `GenericDist/` and `DistributionOperation` directory structure, for a flatter tree (which is recommended in ocaml style guides).