### PR TITLE
Add functions to implementation file to fix warnings

### DIFF
--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist/GenericDist.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist/GenericDist.resi
@@ -69,3 +69,6 @@ let mixture: (
   ~scaleMultiplyFn: scaleMultiplyFn,
   ~pointwiseAddFn: pointwiseAddFn,
 ) => result<t, error>
+
+let isSymbolic: t => bool
+let isPointSet: t => bool


### PR DESCRIPTION
Just fixes two unused variable warnings
