### PR TITLE
Add Dictionary Viewer and Recursive Array viewer

### DIFF
--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -44,6 +44,8 @@ export const VariableBox: React.FC<{
   );
 };
 
+let RecordKeyHeader = styled.h3``;
+
 export interface SquiggleItemProps {
   /** The input string for squiggle */
   expression: squiggleExpression;
@@ -101,6 +103,17 @@ const SquiggleItem: React.FC<SquiggleItemProps> = ({
         <VariableBox heading="Array">
           {expression.value.map((r) => (
             <SquiggleItem expression={r} width={width - 20} height={50} />
+          ))}
+        </VariableBox>
+      );
+    case "record":
+      return (
+        <VariableBox heading="Record">
+          {Object.entries(expression.value).map(([key, r]) => (
+            <>
+              <RecordKeyHeader>{key}</RecordKeyHeader>
+              <SquiggleItem expression={r} width={width - 20} height={50} />
+            </>
           ))}
         </VariableBox>
       );

--- a/packages/squiggle-lang/__tests__/TS/JS_test.ts
+++ b/packages/squiggle-lang/__tests__/TS/JS_test.ts
@@ -42,6 +42,39 @@ describe("Log function", () => {
   });
 });
 
+describe("Array", () => {
+  test("nested Array", () => {
+    expect(testRun("[[1]]")).toEqual({
+      tag: "array",
+      value: [
+        {
+          tag: "array",
+          value: [
+            {
+              tag: "number",
+              value: 1,
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("Record", () => {
+  test("Return record", () => {
+    expect(testRun("{a: 1}")).toEqual({
+      tag: "record",
+      value: {
+        a: {
+          tag: "number",
+          value: 1,
+        },
+      },
+    });
+  });
+});
+
 describe("Distribution", () => {
   //It's important that sampleCount is less than 9. If it's more, than that will create randomness
   //Also, note, the value should be created using makeSampleSetDist() later on.

--- a/packages/squiggle-lang/src/rescript/TypescriptInterface.res
+++ b/packages/squiggle-lang/src/rescript/TypescriptInterface.res
@@ -14,6 +14,12 @@ type samplingParams = DistributionOperation.env
 type genericDist = DistributionTypes.genericDist
 
 @genType
+type sampleSetDist = SampleSetDist.t
+
+@genType
+type symbolicDist = SymbolicDistTypes.symbolicDist
+
+@genType
 type distributionError = DistributionTypes.error
 
 @genType


### PR DESCRIPTION
This pull request adds a recursive array and dictionary viewer.

Turns out, the reason we have problems with deeper arrays and records is because
`genType` doesn't convert the entire data structure. `genType`, as well as creating
data types based on the code, converts the data types into something more readable.
Something like `{TAG: 0, _0: string}` becomes something like `{tag: "EvCall", value: string}`.
The only problem is that `genType` gives up half way and does not convert arrays
beyond two levels of recursion, and doesn't convert JS dictionaries at all.

This PR is really ugly, but basically is a workaround where the code that converts
the rescript interface to the typescript interface swaps between the `genType`
converted representation to the original rescript representation at the points
where `genType` gives up.

I might spend some time trying to refactor and move some of this around, because
it's really dirty as it currently stands.
