### PR TITLE
fixed typescript (to `reducer-dev`) apr29

### DIFF
--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -4,6 +4,7 @@ import {
   samplingParams,
   environment,
   evaluatePartialUsingExternalBindings,
+  evaluateUsingOptions,
   externalBindings,
   expressionValue,
   recordEV,
@@ -110,7 +111,10 @@ export function run(
     ? samplingInputs
     : defaultSamplingInputs;
   let e = environ ? environ : defaultEnvironment;
-  let res: result<expressionValue, errorValue> = eval(squiggleString); // , b, e);
+  let res: result<expressionValue, errorValue> = evaluateUsingOptions(
+    { externalBindings: b, environment: e },
+    squiggleString
+  ); // , b, e);
   return resultMap(res, (x) => createTsExport(x, si));
 }
 

--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -231,6 +231,8 @@ function convertRawToTypescript(
       return tag("string", result._0);
     case 7: // EvSymbol
       return tag("symbol", result._0);
+    case 8: // EvArrayString
+      return tag("arrayString", result._0);
   }
 }
 
@@ -287,6 +289,10 @@ type rescriptExport =
   | {
       TAG: 7; // EvSymbol
       _0: string;
+    }
+  | {
+      TAG: 8; // EvArrayString
+      _0: string[];
     };
 
 type rescriptDist =

--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -2,9 +2,11 @@ import * as _ from "lodash";
 import {
   genericDist,
   samplingParams,
+  environment,
   evaluatePartialUsingExternalBindings,
   externalBindings,
   expressionValue,
+  recordEV,
   errorValue,
   distributionError,
   toPointSet,
@@ -15,6 +17,8 @@ import {
   mixedShape,
   sampleSetDist,
   symbolicDist,
+  defaultEnvironment,
+  defaultSamplingEnv,
 } from "../rescript/TypescriptInterface.gen";
 export {
   makeSampleSetDist,
@@ -50,10 +54,7 @@ import {
 } from "../rescript/Distributions/DistributionOperation/DistributionOperation.gen";
 export type { samplingParams, errorValue, externalBindings as bindings };
 
-export let defaultSamplingInputs: samplingParams = {
-  sampleCount: 10000,
-  xyPointLength: 10000,
-};
+export let defaultSamplingInputs: samplingParams = defaultSamplingEnv;
 
 export type result<a, b> =
   | {
@@ -90,8 +91,9 @@ export type squiggleExpression =
   | tagged<"symbol", string>
   | tagged<"string", string>
   | tagged<"call", string>
-  | tagged<"lambda", [string[], internalCode]>
+  | tagged<"lambda", [string[], recordEV, internalCode]>
   | tagged<"array", squiggleExpression[]>
+  | tagged<"arrayString", string[]>
   | tagged<"boolean", boolean>
   | tagged<"distribution", Distribution>
   | tagged<"number", number>
@@ -100,16 +102,16 @@ export type squiggleExpression =
 export function run(
   squiggleString: string,
   bindings?: externalBindings,
-  samplingInputs?: samplingParams
+  samplingInputs?: samplingParams,
+  environ?: environment
 ): result<squiggleExpression, errorValue> {
   let b = bindings ? bindings : {};
   let si: samplingParams = samplingInputs
     ? samplingInputs
     : defaultSamplingInputs;
-
-  let result: result<expressionValue, errorValue> =
-    evaluateUsingExternalBindings(squiggleString, b);
-  return resultMap(result, (x) => createTsExport(x, si));
+  let e = environ ? environ : defaultEnvironment;
+  let res: result<expressionValue, errorValue> = eval(squiggleString); // , b, e);
+  return resultMap(res, (x) => createTsExport(x, si));
 }
 
 // Run Partial. A partial is a block of code that doesn't return a value
@@ -118,7 +120,11 @@ export function runPartial(
   bindings: externalBindings,
   _samplingInputs?: samplingParams
 ): result<externalBindings, errorValue> {
-  return evaluatePartialUsingExternalBindings(squiggleString, bindings);
+  return evaluatePartialUsingExternalBindings(
+    squiggleString,
+    bindings,
+    defaultEnvironment
+  );
 }
 
 function createTsExport(
@@ -158,6 +164,8 @@ function createTsExport(
           }
         })
       );
+    case "EvArrayString":
+      return tag("arrayString", x.value);
     case "EvBool":
       return tag("boolean", x.value);
     case "EvCall":

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltIn.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltIn.res
@@ -21,7 +21,7 @@ let callInternal = (call: functionCall, _environment): result<'b, errorValue> =>
     }
 
   let constructRecord = arrayOfPairs => {
-    Belt.Array.map(arrayOfPairs, pairValue => 
+    Belt.Array.map(arrayOfPairs, pairValue =>
       switch pairValue {
       | EvArray([EvString(key), valueValue]) => (key, valueValue)
       | _ => ("wrong key type", pairValue->toStringWithType->EvString)

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltInMacros.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltInMacros.res
@@ -19,7 +19,7 @@ let dispatchMacroCall = (
   environment,
   reduceExpression: ExpressionT.reducerFn,
 ): result<expression, errorValue> => {
-  let doBindStatement = (bindingExpr: expression, statement: expression, environment) => 
+  let doBindStatement = (bindingExpr: expression, statement: expression, environment) =>
     switch statement {
     | ExpressionT.EList(list{ExpressionT.EValue(EvCall("$let")), symbolExpr, statement}) => {
         let rExternalBindingsValue = reduceExpression(bindingExpr, bindings, environment)
@@ -37,9 +37,8 @@ let dispatchMacroCall = (
       }
     | _ => REAssignmentExpected->Error
     }
-  
 
-  let doBindExpression = (bindingExpr: expression, statement: expression, environment) => 
+  let doBindExpression = (bindingExpr: expression, statement: expression, environment) =>
     switch statement {
     | ExpressionT.EList(list{ExpressionT.EValue(EvCall("$let")), symbolExpr, statement}) => {
         let rExternalBindingsValue = reduceExpression(
@@ -74,7 +73,7 @@ let dispatchMacroCall = (
         })
       }
     }
-  
+
   let doBlock = (exprs: list<expression>, _bindings: ExpressionT.bindings, _environment): result<
     expression,
     errorValue,

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression.res
@@ -32,7 +32,7 @@ let parse = (mathJsCode: string): result<t, errorValue> =>
 let rec reduceExpression = (expression: t, bindings: T.bindings, environment: environment): result<
   expressionValue,
   'e,
-> => 
+> =>
   switch expression {
   | T.EValue(value) => value->Ok
   | T.EList(list) =>
@@ -119,10 +119,15 @@ let evaluatePartialUsingExternalBindings = (
   externalBindings: ReducerInterface_ExpressionValue.externalBindings,
   environment: ReducerInterface_ExpressionValue.environment,
 ): result<externalBindings, errorValue> => {
-  let rAnswer = evaluateUsingOptions(~environment=Some(environment), ~externalBindings=Some(externalBindings), code)
+  let rAnswer = evaluateUsingOptions(
+    ~environment=Some(environment),
+    ~externalBindings=Some(externalBindings),
+    code,
+  )
   switch rAnswer {
-    | Ok(EvRecord(externalBindings)) => Ok(externalBindings)
-    | Ok(_) => Error(Reducer_ErrorValue.RESyntaxError(`Partials must end with an assignment or record`))
-    | Error(err) => err->Error
+  | Ok(EvRecord(externalBindings)) => Ok(externalBindings)
+  | Ok(_) =>
+    Error(Reducer_ErrorValue.RESyntaxError(`Partials must end with an assignment or record`))
+  | Error(err) => err->Error
   }
 }

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Js/Reducer_Js_Gate.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Js/Reducer_Js_Gate.res
@@ -8,11 +8,10 @@ external castString: unit => string = "%identity"
 /*
   As JavaScript returns us any type, we need to type check and cast type propertype before using it
 */
-let jsToEv = (jsValue): result<expressionValue, errorValue> => 
+let jsToEv = (jsValue): result<expressionValue, errorValue> =>
   switch Js.typeof(jsValue) {
   | "boolean" => jsValue->castBool->EvBool->Ok
   | "number" => jsValue->castNumber->EvNumber->Ok
   | "string" => jsValue->castString->EvString->Ok
   | other => RETodo(`Unhandled MathJs literal type: ${Js.String.make(other)}`)->Error
   }
-

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -2,13 +2,11 @@ module ExpressionValue = ReducerInterface_ExpressionValue
 type expressionValue = ReducerInterface_ExpressionValue.expressionValue
 
 let defaultEnv: DistributionOperation.env = {
-    sampleCount: MagicNumbers.Environment.defaultSampleCount,
-    xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
-  }
+  sampleCount: MagicNumbers.Environment.defaultSampleCount,
+  xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
+}
 
-let runGenericOperation = DistributionOperation.run(
-  ~env=defaultEnv,
-)
+let runGenericOperation = DistributionOperation.run(~env=defaultEnv)
 
 module Helpers = {
   let arithmeticMap = r =>
@@ -30,14 +28,13 @@ module Helpers = {
   let catchAndConvertTwoArgsToDists = (args: array<expressionValue>): option<(
     DistributionTypes.genericDist,
     DistributionTypes.genericDist,
-  )> => 
+  )> =>
     switch args {
     | [EvDistribution(a), EvDistribution(b)] => Some((a, b))
     | [EvNumber(a), EvDistribution(b)] => Some((GenericDist.fromFloat(a), b))
     | [EvDistribution(a), EvNumber(b)] => Some((a, GenericDist.fromFloat(b)))
     | _ => None
     }
-  
 
   let toFloatFn = (
     fnCall: DistributionTypes.DistributionOperation.toFloat,
@@ -121,7 +118,7 @@ module Helpers = {
     mixtureWithGivenWeights(distributions, weights)
   }
 
-  let mixture = (args: array<expressionValue>): DistributionOperation.outputType => 
+  let mixture = (args: array<expressionValue>): DistributionOperation.outputType =>
     switch E.A.last(args) {
     | Some(EvArray(b)) => {
         let weights = parseNumberArray(b)
@@ -140,7 +137,6 @@ module Helpers = {
       }
     | _ => GenDistError(ArgumentError("Last argument of mx must be array or distribution"))
     }
-  
 }
 
 module SymbolicConstructors = {

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -1,11 +1,13 @@
 module ExpressionValue = ReducerInterface_ExpressionValue
 type expressionValue = ReducerInterface_ExpressionValue.expressionValue
 
-let runGenericOperation = DistributionOperation.run(
-  ~env={
+let defaultEnv: DistributionOperation.env = {
     sampleCount: MagicNumbers.Environment.defaultSampleCount,
     xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
-  },
+  }
+
+let runGenericOperation = DistributionOperation.run(
+  ~env=defaultEnv,
 )
 
 module Helpers = {

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.resi
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.resi
@@ -1,3 +1,4 @@
+let defaultEnv: DistributionOperation.env
 let dispatch: (
   ReducerInterface_ExpressionValue.functionCall,
   ReducerInterface_ExpressionValue.environment,

--- a/packages/squiggle-lang/src/rescript/TypescriptInterface.res
+++ b/packages/squiggle-lang/src/rescript/TypescriptInterface.res
@@ -50,6 +50,9 @@ type externalBindings = Reducer.externalBindings
 type expressionValue = ReducerInterface_ExpressionValue.expressionValue
 
 @genType
+type recordEV = ReducerInterface_ExpressionValue.record
+
+@genType
 type errorValue = Reducer_ErrorValue.errorValue
 
 @genType
@@ -72,3 +75,12 @@ let distributionErrorToString = DistributionTypes.Error.toString
 
 @genType
 type internalCode = ReducerInterface_ExpressionValue.internalCode
+
+@genType
+let defaultSamplingEnv = ReducerInterface_GenericDistribution.defaultEnv
+
+@genType
+type environment = ReducerInterface_ExpressionValue.environment
+
+@genType
+let defaultEnvironment = ReducerInterface_ExpressionValue.defaultEnvironment


### PR DESCRIPTION
I want to have @Hazelfire validate that the functionality is as desired before I do a cleanup pass, getting rid of vacuous arguments. 