### PR TITLE
Hotfix playground chart

### DIFF
--- a/packages/components/src/components/SquigglePlayground.tsx
+++ b/packages/components/src/components/SquigglePlayground.tsx
@@ -74,7 +74,7 @@ const Display = styled.div<TitleProps>`
 
 const Row = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 50% 50%;
 `;
 const Col = styled.div``;
 


### PR DESCRIPTION
Simply gets the playground to control the size of the chart rather than the other
way around
