### PR TITLE
Add partial functionality to storybook and update partial bindings async

### DIFF
--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -166,7 +166,7 @@ export let SquigglePartial: React.FC<SquigglePartialProps> = ({
   let [expression, setExpression] = React.useState(initialSquiggleString);
   let [error, setError] = React.useState<string | null>(null);
 
-  React.useEffect(() => {
+  let runSquiggleAndUpdateBindings = () => {
     let squiggleResult = runPartial(
       expression,
       bindings,
@@ -179,7 +179,9 @@ export let SquigglePartial: React.FC<SquigglePartialProps> = ({
     } else {
       setError(errorValueToString(squiggleResult.value));
     }
-  }, [expression]);
+  };
+
+  React.useEffect(runSquiggleAndUpdateBindings, [expression]);
 
   return (
     <div>

--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -166,10 +166,9 @@ export let SquigglePartial: React.FC<SquigglePartialProps> = ({
   let [expression, setExpression] = React.useState(initialSquiggleString);
   let [error, setError] = React.useState<string | null>(null);
 
-  // Runs squiggle and updates state/calls props apprropriately
-  let runSquiggle = (newExpression: string) => {
+  React.useEffect(() => {
     let squiggleResult = runPartial(
-      newExpression,
+      expression,
       bindings,
       samplingInputs,
       jsImports
@@ -180,21 +179,14 @@ export let SquigglePartial: React.FC<SquigglePartialProps> = ({
     } else {
       setError(errorValueToString(squiggleResult.value));
     }
-  };
-
-  // Run this once on mount, so that the next cells can get relevent values
-  React.useEffect(() => runSquiggle(expression), []);
+  }, [expression]);
 
   return (
     <div>
       <Input>
         <CodeEditor
           value={expression}
-          onChange={(x) => {
-            // When the code changes, rerun squiggle and inform next cells
-            setExpression(x);
-            runSquiggle(x);
-          }}
+          onChange={setExpression}
           oneLine={true}
           showGutter={false}
           height={20}

--- a/packages/components/src/stories/SquigglePartial.stories.mdx
+++ b/packages/components/src/stories/SquigglePartial.stories.mdx
@@ -1,0 +1,51 @@
+import { SquigglePartial, SquiggleEditor } from "../components/SquiggleEditor";
+import { useState } from "react";
+import { Canvas, Meta, Story, Props } from "@storybook/addon-docs";
+
+<Meta title="Squiggle/SquigglePartial" component={SquigglePartial} />
+
+export const Template = (props) => <SquigglePartial {...props} />;
+
+# Squiggle Partial
+
+A Squiggle Partial is an editor that does not return a graph to the user, but
+instead returns bindings that can be used by further Squiggle Editors.
+
+<Canvas>
+  <Story
+    name="Standalone"
+    args={{
+      initialSquiggleString: "x = normal(5,2)",
+    }}
+  >
+    {Template.bind({})}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="With Editor"
+    args={{
+      initialPartialString: "x = normal(5,2)",
+      initialEditorString: "x",
+    }}
+  >
+    {(props) => {
+      let [bindings, setBindings] = useState({});
+      return (
+        <>
+          <SquigglePartial
+            {...props}
+            initialSquiggleString={props.initialPartialString}
+            onChange={setBindings}
+          />
+          <SquiggleEditor
+            {...props}
+            initialSquiggleString={props.initialEditorString}
+            bindings={bindings}
+          />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -11,6 +11,7 @@ export {
   makeSampleSetDist,
   errorValueToString,
   distributionErrorToString,
+  distributionError,
 } from "../rescript/TypescriptInterface.gen";
 export type {
   samplingParams,


### PR DESCRIPTION
This adds partials into the storybook, mainly so that I can test whether they will work in reducer-dev.

Turns out the way that I originally coded it wasn't very good for use within react applications, because I call a prop onChange handler on the constructor of the component. So this not only adds the storybook, but attempts to make updating future cells more async.
