### PR TITLE
Reducer dev: map, reduce, reduceReverse, keep

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_debugging_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_debugging_test.res
@@ -12,5 +12,4 @@ open Reducer_TestHelpers
 describe("Debugging", () => {
   testEvalToBe("inspect(1)", "Ok(1)")
   testEvalToBe("inspect(1, \"one\")", "Ok(1)")
-  testEvalToBe("inspectPerformance(1, \"one\")", "Ok(1)")
 })

--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_mapReduce_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_mapReduce_test.res
@@ -1,0 +1,11 @@
+open Jest
+open Reducer_TestHelpers
+
+describe("map reduce", () => {
+  testEvalToBe("double(x)=2*x; arr=[1,2,3]; map(arr, double)", "Ok([2,4,6])")
+  testEvalToBe("myadd(acc,x)=acc+x; arr=[1,2,3]; reduce(arr, 0, myadd)", "Ok(6)")
+  testEvalToBe("change(acc,x)=acc*x+x; arr=[1,2,3]; reduce(arr, 0, change)", "Ok(15)")
+  testEvalToBe("change(acc,x)=acc*x+x; arr=[1,2,3]; reduceReverse(arr, 0, change)", "Ok(9)")
+  testEvalToBe("arr=[1,2,3]; reverse(arr)", "Ok([3,2,1])")
+  testEvalToBe("check(x)=(x==2);arr=[1,2,3]; keep(arr,check)", "Ok([2])")
+})

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression.res
@@ -77,7 +77,8 @@ and reduceValueList = (valueList: list<expressionValue>, environment): result<
   'e,
 > =>
   switch valueList {
-  | list{EvCall(fName), ...args} => (fName, args->Belt.List.toArray)->BuiltIn.dispatch(environment)
+  | list{EvCall(fName), ...args} =>
+    (fName, args->Belt.List.toArray)->BuiltIn.dispatch(environment, reduceExpression)
 
   | list{EvLambda(lamdaCall), ...args} =>
     Lambda.doLambdaCall(lamdaCall, args, environment, reduceExpression)

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression_Lambda.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression_Lambda.res
@@ -55,6 +55,5 @@ let applyParametersToLambda = (
   )
 }
 
-let doLambdaCall = (lambdaValue: ExpressionValue.lambdaValue, args, environment, reducer) => {
+let doLambdaCall = (lambdaValue: ExpressionValue.lambdaValue, args, environment, reducer) =>
   applyParametersToLambda(lambdaValue, args, environment, reducer)
-}


### PR DESCRIPTION
```
describe("map reduce", () => {
  testEvalToBe("double(x)=2*x; arr=[1,2,3]; map(arr, double)", "Ok([2,4,6])")
  testEvalToBe("myadd(acc,x)=acc+x; arr=[1,2,3]; reduce(arr, 0, myadd)", "Ok(6)")
  testEvalToBe("change(acc,x)=acc*x+x; arr=[1,2,3]; reduce(arr, 0, change)", "Ok(15)")
  testEvalToBe("change(acc,x)=acc*x+x; arr=[1,2,3]; reduceReverse(arr, 0, change)", "Ok(9)")
  testEvalToBe("arr=[1,2,3]; reverse(arr)", "Ok([3,2,1])")
  testEvalToBe("check(x)=(x==2);arr=[1,2,3]; keep(arr,check)", "Ok([2])")
})

```