### PR TITLE
Reducer: Foreign Function Interface

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_mapReduce_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_mapReduce_test.res
@@ -9,3 +9,8 @@ describe("map reduce", () => {
   testEvalToBe("arr=[1,2,3]; reverse(arr)", "Ok([3,2,1])")
   testEvalToBe("check(x)=(x==2);arr=[1,2,3]; keep(arr,check)", "Ok([2])")
 })
+
+Skip.describe("map reduce (sam)", () => {
+  testEvalToBe("addone(x)=x+1; map(2, addone)", "Error???")
+  testEvalToBe("addone(x)=x+1; map(2, {x: addone})", "Error???")
+})

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer.res
@@ -19,12 +19,7 @@ let foreignFunctionInterface = (
   argArray: array<expressionValue>,
   environment: ExpressionValue.environment,
 ) => {
-  Lambda.foreignFunctionInterface(
-    lambdaValue,
-    argArray,
-    environment,
-    Expression.reduceExpression,
-  )
+  Lambda.foreignFunctionInterface(lambdaValue, argArray, environment, Expression.reduceExpression)
 }
 
 let defaultEnvironment = ExpressionValue.defaultEnvironment

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer.res
@@ -1,11 +1,32 @@
 module ErrorValue = Reducer_ErrorValue
 module Expression = Reducer_Expression
+module ExpressionValue = ReducerInterface_ExpressionValue
+module Lambda = Reducer_Expression_Lambda
 
 type environment = ReducerInterface_ExpressionValue.environment
 type errorValue = Reducer_ErrorValue.errorValue
 type expressionValue = ReducerInterface_ExpressionValue.expressionValue
 type externalBindings = ReducerInterface_ExpressionValue.externalBindings
+type lambdaValue = ExpressionValue.lambdaValue
+
 let evaluate = Expression.evaluate
 let evaluateUsingOptions = Expression.evaluateUsingOptions
 let evaluatePartialUsingExternalBindings = Expression.evaluatePartialUsingExternalBindings
 let parse = Expression.parse
+
+let foreignFunctionInterface = (
+  lambdaValue: lambdaValue,
+  argArray: array<expressionValue>,
+  environment: ExpressionValue.environment,
+) => {
+  Lambda.foreignFunctionInterface(
+    lambdaValue,
+    argArray,
+    environment,
+    Expression.reduceExpression,
+  )
+}
+
+let defaultEnvironment = ExpressionValue.defaultEnvironment
+
+let defaultExternalBindings = ExpressionValue.defaultExternalBindings

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer.resi
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer.resi
@@ -12,7 +12,6 @@ type externalBindings = ReducerInterface_ExpressionValue.externalBindings
 @genType
 type lambdaValue = ReducerInterface_ExpressionValue.lambdaValue
 
-
 @genType
 let evaluateUsingOptions: (
   ~environment: option<QuriSquiggleLang.ReducerInterface_ExpressionValue.environment>,

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer.resi
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer.resi
@@ -9,6 +9,9 @@ type errorValue = Reducer_ErrorValue.errorValue
 type expressionValue = ReducerInterface_ExpressionValue.expressionValue
 @genType
 type externalBindings = ReducerInterface_ExpressionValue.externalBindings
+@genType
+type lambdaValue = ReducerInterface_ExpressionValue.lambdaValue
+
 
 @genType
 let evaluateUsingOptions: (
@@ -26,3 +29,16 @@ let evaluatePartialUsingExternalBindings: (
 let evaluate: string => result<expressionValue, errorValue>
 
 let parse: string => result<Expression.expression, errorValue>
+
+@genType
+let foreignFunctionInterface: (
+  QuriSquiggleLang.ReducerInterface_ExpressionValue.lambdaValue,
+  array<QuriSquiggleLang.ReducerInterface_ExpressionValue.expressionValue>,
+  QuriSquiggleLang.ReducerInterface_ExpressionValue.environment,
+) => result<expressionValue, errorValue>
+
+@genType
+let defaultEnvironment: environment
+
+@genType
+let defaultExternalBindings: externalBindings

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression_Lambda.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression_Lambda.res
@@ -57,3 +57,13 @@ let applyParametersToLambda = (
 
 let doLambdaCall = (lambdaValue: ExpressionValue.lambdaValue, args, environment, reducer) =>
   applyParametersToLambda(lambdaValue, args, environment, reducer)
+
+let foreignFunctionInterface = (
+  lambdaValue: ExpressionValue.lambdaValue,
+  argArray: array<expressionValue>,
+  environment: ExpressionValue.environment,
+  reducer: ExpressionT.reducerFn,
+): result<expressionValue, 'e> => {
+  let args = argArray->Belt.List.fromArray
+  applyParametersToLambda(lambdaValue, args, environment, reducer)
+}


### PR DESCRIPTION
Reducer.resi has a new function
```
@genType
let foreignFunctionInterface: (
  QuriSquiggleLang.ReducerInterface_ExpressionValue.lambdaValue,
  array<QuriSquiggleLang.ReducerInterface_ExpressionValue.expressionValue>,
  QuriSquiggleLang.ReducerInterface_ExpressionValue.environment,
) => result<expressionValue, errorValue>

```
In external bindings,  all function definitions are returned  as lambda values. You can pass arguments to those lambda values.

There are no extra tests defined for this function because invoking lambda values with arguments is already tested. And it is the only way to call functions internally in the language.

