### PR TITLE
Reducer: Ternary operator (if then else)

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_MathJs/Reducer_MathJsParse_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_MathJs/Reducer_MathJsParse_test.res
@@ -66,4 +66,9 @@ describe("MathJs parse", () => {
   describe("comments", () => {
     testDescriptionParse("define", "1 # This is a comment", "1")
   })
+
+  describe("ternary operator", () => {
+    testParse("1 ? 2 : 3", "ternary(1, 2, 3)")
+    testParse("1 ? 2 : 3 ? 4 : 5", "ternary(1, 2, ternary(3, 4, 5))")
+  })
 })

--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_functionTricks_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_functionTricks_test.res
@@ -62,7 +62,7 @@ describe("call and bindings", () => {
   testEvalToBe("f(x)=x+1; g(x)=f(x)+1; g(2)", "Ok(4)")
 })
 
-describe("function trics", () => {
+describe("function tricks", () => {
   testParseToBe(
     "f(x)=f(y)=2; f(2)",
     "Ok((:$$block (:$$block (:$let :f (:$$lambda [x] (:$$block (:$let :f (:$$lambda [y] (:$$block 2)))))) (:f 2))))",

--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_ternaryOperator_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_ternaryOperator_test.res
@@ -1,12 +1,14 @@
 open Jest
 open Reducer_TestHelpers
 
-Skip.describe("Parse ternary operator", () => {
-  testParseToBe("true ? 'YES' : 'NO'", "Ok('YES')")
-  testParseToBe("false ? 'YES' : 'NO'", "Ok('NO')")
+describe("Parse ternary operator", () => {
+  testParseToBe("true ? 'YES' : 'NO'", "Ok((:$$block (:$$ternary true 'YES' 'NO')))")
 })
 
-Skip.describe("Evaluate ternary operator", () => {
+describe("Evaluate ternary operator", () => {
   testEvalToBe("true ? 'YES' : 'NO'", "Ok('YES')")
   testEvalToBe("false ? 'YES' : 'NO'", "Ok('NO')")
+  testEvalToBe("2 > 1 ? 'YES' : 'NO'", "Ok('YES')")
+  testEvalToBe("2 <= 1 ? 'YES' : 'NO'", "Ok('NO')")
+  testEvalToBe("1+1 ? 'YES' : 'NO'", "Error(Expected type: Boolean)")
 })

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_ErrorValue.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_ErrorValue.res
@@ -13,6 +13,7 @@ type errorValue =
   | RESymbolNotFound(string)
   | RESyntaxError(string)
   | RETodo(string) // To do
+  | REExpectedType(string)
 
 type t = errorValue
 
@@ -46,4 +47,5 @@ let errorToString = err =>
   | RESymbolNotFound(symbolName) => `${symbolName} is not defined`
   | RESyntaxError(desc) => `Syntax Error: ${desc}`
   | RETodo(msg) => `TODO: ${msg}`
+  | REExpectedType(typeName) => `Expected type: ${typeName}`
   }

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_MathJs/Reducer_MathJs_Parse.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_MathJs/Reducer_MathJs_Parse.res
@@ -9,7 +9,7 @@ type node = {"type": string, "isNode": bool, "comment": string}
 type arrayNode = {...node, "items": array<node>}
 type block = {"node": node}
 type blockNode = {...node, "blocks": array<block>}
-//conditionalNode
+type conditionalNode = {...node, "condition": node, "trueExpr": node, "falseExpr": node}
 type constantNode = {...node, "value": unit}
 type functionAssignmentNode = {...node, "name": string, "params": array<string>, "expr": node}
 type indexNode = {...node, "dimensions": array<node>}
@@ -31,6 +31,7 @@ external castAssignmentNode: node => assignmentNode = "%identity"
 external castAssignmentNodeWAccessor: node => assignmentNodeWAccessor = "%identity"
 external castAssignmentNodeWIndex: node => assignmentNodeWIndex = "%identity"
 external castBlockNode: node => blockNode = "%identity"
+external castConditionalNode: node => conditionalNode = "%identity"
 external castConstantNode: node => constantNode = "%identity"
 external castFunctionAssignmentNode: node => functionAssignmentNode = "%identity"
 external castFunctionNode: node => functionNode = "%identity"
@@ -58,6 +59,7 @@ type mathJsNode =
   | MjArrayNode(arrayNode)
   | MjAssignmentNode(assignmentNode)
   | MjBlockNode(blockNode)
+  | MjConditionalNode(conditionalNode)
   | MjConstantNode(constantNode)
   | MjFunctionAssignmentNode(functionAssignmentNode)
   | MjFunctionNode(functionNode)
@@ -82,6 +84,7 @@ let castNodeType = (node: node) => {
   | "ArrayNode" => node->castArrayNode->MjArrayNode->Ok
   | "AssignmentNode" => node->decideAssignmentNode
   | "BlockNode" => node->castBlockNode->MjBlockNode->Ok
+  | "ConditionalNode" => node->castConditionalNode->MjConditionalNode->Ok
   | "ConstantNode" => node->castConstantNode->MjConstantNode->Ok
   | "FunctionAssignmentNode" => node->castFunctionAssignmentNode->MjFunctionAssignmentNode->Ok
   | "FunctionNode" => node->castFunctionNode->MjFunctionNode->Ok
@@ -157,6 +160,10 @@ let rec toString = (mathJsNode: mathJsNode): string => {
   | MjAssignmentNode(aNode) =>
     `${aNode["object"]->toStringSymbolNode} = ${aNode["value"]->toStringMathJsNode}`
   | MjBlockNode(bNode) => `{${bNode["blocks"]->toStringBlocks}}`
+  | MjConditionalNode(cNode) =>
+    `ternary(${toStringMathJsNode(cNode["condition"])}, ${toStringMathJsNode(
+        cNode["trueExpr"],
+      )}, ${toStringMathJsNode(cNode["falseExpr"])})`
   | MjConstantNode(cNode) => cNode["value"]->toStringValue
   | MjFunctionAssignmentNode(faNode) => faNode->toStringFunctionAssignmentNode
   | MjFunctionNode(fNode) => fNode->toStringFunctionNode


### PR DESCRIPTION
```
describe("Evaluate ternary operator", () => {
  testEvalToBe("true ? 'YES' : 'NO'", "Ok('YES')")
  testEvalToBe("false ? 'YES' : 'NO'", "Ok('NO')")
  testEvalToBe("2 > 1 ? 'YES' : 'NO'", "Ok('YES')")
  testEvalToBe("2 <= 1 ? 'YES' : 'NO'", "Ok('NO')")
  testEvalToBe("1+1 ? 'YES' : 'NO'", "Error(Expected type: Boolean)")
})

```
Ternary operator does not evaluate the branches until the condition is evaluated. We have lazy evaluation capability.