### PR TITLE
`klDivergence` on mixed distributions

### DIFF
--- a/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/Mixed.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/Mixed.res
@@ -302,10 +302,9 @@ module T = Dist({
   }
 
   let klDivergence = (prediction: t, answer: t) => {
-    Error(Operation.NotYetImplemented)
-    //    combinePointwise(PointSetDist_Scoring.KLDivergence.integrand, prediction, answer) |> E.R.fmap(
-    //     integralEndY,
-    //   )
+    let klDiscretePart = Discrete.T.klDivergence(prediction.discrete, answer.discrete)
+    let klContinuousPart = Continuous.T.klDivergence(prediction.continuous, answer.continuous)
+    E.R.merge(klDiscretePart, klContinuousPart)->E.R2.fmap(t => fst(t) +. snd(t))
   }
 })
 

--- a/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist.res
@@ -200,6 +200,7 @@ module T = Dist({
     switch (t1, t2) {
     | (Continuous(t1), Continuous(t2)) => Continuous.T.klDivergence(t1, t2)
     | (Discrete(t1), Discrete(t2)) => Discrete.T.klDivergence(t1, t2)
+    | (Mixed(t1), Mixed(t2)) => Mixed.T.klDivergence(t1, t2)
     | _ => Error(NotYetImplemented)
     }
 })


### PR DESCRIPTION
Closes #505 

- [ ] Get one test case to work with integral for comparing continuous part normal to continuous part uniform. 
- [ ] add more test cases
    - [ ] continuous part uniform against continuous part uniform is a clear candidate