### PR TITLE
Memo the sampling of functions

### DIFF
--- a/packages/components/src/components/FunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart.tsx
@@ -76,28 +76,32 @@ export const FunctionChart: React.FC<FunctionChartProps> = ({
     chartSettings.count
   );
   type point = { x: number; value: result<Distribution, string> };
-  let valueData: point[] = data1.map((x) => {
-    let result = runForeign(fn, [x], environment);
-    if (result.tag === "Ok") {
-      if (result.value.tag == "distribution") {
-        return { x, value: { tag: "Ok", value: result.value.value } };
-      } else {
-        return {
-          x,
-          value: {
-            tag: "Error",
-            value:
-              "Cannot currently render functions that don't return distributions",
-          },
-        };
-      }
-    } else {
-      return {
-        x,
-        value: { tag: "Error", value: errorValueToString(result.value) },
-      };
-    }
-  });
+  let valueData: point[] = React.useMemo(
+    () =>
+      data1.map((x) => {
+        let result = runForeign(fn, [x], environment);
+        if (result.tag === "Ok") {
+          if (result.value.tag == "distribution") {
+            return { x, value: { tag: "Ok", value: result.value.value } };
+          } else {
+            return {
+              x,
+              value: {
+                tag: "Error",
+                value:
+                  "Cannot currently render functions that don't return distributions",
+              },
+            };
+          }
+        } else {
+          return {
+            x,
+            value: { tag: "Error", value: errorValueToString(result.value) },
+          };
+        }
+      }),
+    [environment, fn]
+  );
 
   let initialPartition: [
     { x: number; value: Distribution }[],


### PR DESCRIPTION
This PR closes #514. It does have a slight issue in that useMemo should not really be used to fix any bug / implement a feature, it should be a performance thing, and react is apparently not obliged to follow the memo. This however is something that should be done considering how expensive this is.

A cleaner fix may include allowing specifying seeds.
