### PR TITLE
fixed #597

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression_test.res
@@ -148,6 +148,29 @@ describe("Peggy to Expression", () => {
       ~v="0",
       (),
     ) // nested ternary
+    describe("ternary bindings", () => {
+      testToExpression(
+        // expression binding
+        "f(a) = a > 5 ? 1 : 0; f(6)",
+        "(:$$_block_$$ (:$_let_$ :f (:$$_lambda_$$ [a] (:$$_block_$$ (:$$_ternary_$$ (:larger :a 5) 1 0)))) (:f 6))",
+        ~v="1",
+        (),
+      )
+      testToExpression(
+        // when true binding
+        "f(a) = a > 5 ? a : 0; f(6)",
+        "(:$$_block_$$ (:$_let_$ :f (:$$_lambda_$$ [a] (:$$_block_$$ (:$$_ternary_$$ (:larger :a 5) :a 0)))) (:f 6))",
+        ~v="6",
+        (),
+      )
+      testToExpression(
+        // when false binding
+        "f(a) = a < 5 ? 1 : a; f(6)",
+        "(:$$_block_$$ (:$_let_$ :f (:$$_lambda_$$ [a] (:$$_block_$$ (:$$_ternary_$$ (:smaller :a 5) 1 :a)))) (:f 6))",
+        ~v="6",
+        (),
+      )
+    })
   })
 
   describe("if then else", () => {

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltInMacros.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltInMacros.res
@@ -144,8 +144,14 @@ let dispatchMacroCall = (
     let rCondition = reduceExpression(blockCondition, bindings, environment)
     rCondition->Result.flatMap(conditionValue =>
       switch conditionValue {
-      | ExpressionValue.EvBool(false) => ExpressionWithContext.noContext(ifFalse)->Ok
-      | ExpressionValue.EvBool(true) => ExpressionWithContext.noContext(ifTrue)->Ok
+      | ExpressionValue.EvBool(false) => {
+          let ifFalseBlock = eBlock(list{ifFalse})
+          ExpressionWithContext.withContext(ifFalseBlock, bindings)->Ok
+        }
+      | ExpressionValue.EvBool(true) => {
+          let ifTrueBlock = eBlock(list{ifTrue})
+          ExpressionWithContext.withContext(ifTrueBlock, bindings)->Ok
+        }
       | _ => REExpectedType("Boolean")->Error
       }
     )

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_ExpressionWithContext.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_ExpressionWithContext.res
@@ -24,14 +24,11 @@ let callReducer = (
   reducer: reducerFn,
 ): result<expressionValue, errorValue> => {
   switch expressionWithContext {
-  | ExpressionNoContext(
-      expr,
-    ) => // Js.log(`callReducer: bindings ${Bindings.toString(bindings)} expr ${ExpressionT.toString(expr)}`)
+  | ExpressionNoContext(expr) =>
+    // Js.log(`callReducer: bindings ${Bindings.toString(bindings)} expr ${ExpressionT.toString(expr)}`)
     reducer(expr, bindings, environment)
-  | ExpressionWithContext(
-      expr,
-      context,
-    ) => // Js.log(`callReducer: context ${Bindings.toString(context)} expr ${ExpressionT.toString(expr)}`)
+  | ExpressionWithContext(expr, context) =>
+    // Js.log(`callReducer: context ${Bindings.toString(context)} expr ${ExpressionT.toString(expr)}`)
     reducer(expr, context, environment)
   }
 }

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_ExpressionWithContext.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_ExpressionWithContext.res
@@ -22,11 +22,19 @@ let callReducer = (
   bindings: bindings,
   environment: environment,
   reducer: reducerFn,
-): result<expressionValue, errorValue> =>
+): result<expressionValue, errorValue> => {
   switch expressionWithContext {
-  | ExpressionNoContext(expr) => reducer(expr, bindings, environment)
-  | ExpressionWithContext(expr, context) => reducer(expr, context, environment)
+  | ExpressionNoContext(
+      expr,
+    ) => // Js.log(`callReducer: bindings ${Bindings.toString(bindings)} expr ${ExpressionT.toString(expr)}`)
+    reducer(expr, bindings, environment)
+  | ExpressionWithContext(
+      expr,
+      context,
+    ) => // Js.log(`callReducer: context ${Bindings.toString(context)} expr ${ExpressionT.toString(expr)}`)
+    reducer(expr, context, environment)
   }
+}
 
 let withContext = (expression, context) => ExpressionWithContext(expression, context)
 let noContext = expression => ExpressionNoContext(expression)


### PR DESCRIPTION
fixes https://github.com/quantified-uncertainty/squiggle/issues/597
```
    describe("ternary bindings", () => {
      testToExpression(
        // expression binding
        "f(a) = a > 5 ? 1 : 0; f(6)",
        "(:$$_block_$$ (:$_let_$ :f (:$$_lambda_$$ [a] (:$$_block_$$ (:$$_ternary_$$ (:larger :a 5) 1 0)))) (:f 6))",
        ~v="1",
        (),
      )
      testToExpression(
        // when true binding
        "f(a) = a > 5 ? a : 0; f(6)",
        "(:$$_block_$$ (:$_let_$ :f (:$$_lambda_$$ [a] (:$$_block_$$ (:$$_ternary_$$ (:larger :a 5) :a 0)))) (:f 6))",
        ~v="6",
        (),
      )
      testToExpression(
        // when false binding
        "f(a) = a < 5 ? 1 : a; f(6)",
        "(:$$_block_$$ (:$_let_$ :f (:$$_lambda_$$ [a] (:$$_block_$$ (:$$_ternary_$$ (:smaller :a 5) 1 :a)))) (:f 6))",
        ~v="6",
        (),
      )
    })
```