### PR TITLE
Quick additions of Stdev, Variance, and Mode for SampleSet, and Min and Max for all

### DIFF
--- a/packages/components/src/components/DistributionChart.tsx
+++ b/packages/components/src/components/DistributionChart.tsx
@@ -153,6 +153,7 @@ type SummaryTableProps = {
 
 const SummaryTable: React.FC<SummaryTableProps> = ({ distribution }) => {
   const mean = distribution.mean();
+  const stdev = distribution.stdev();
   const p5 = distribution.inv(0.05);
   const p10 = distribution.inv(0.1);
   const p25 = distribution.inv(0.25);
@@ -160,6 +161,9 @@ const SummaryTable: React.FC<SummaryTableProps> = ({ distribution }) => {
   const p75 = distribution.inv(0.75);
   const p90 = distribution.inv(0.9);
   const p95 = distribution.inv(0.95);
+
+  const hasResult = (x: result<number, distributionError>): boolean =>
+    x.tag === "Ok";
 
   const unwrapResult = (
     x: result<number, distributionError>
@@ -180,6 +184,7 @@ const SummaryTable: React.FC<SummaryTableProps> = ({ distribution }) => {
       <thead className="bg-slate-50">
         <tr>
           <TableHeadCell>{"Mean"}</TableHeadCell>
+          {hasResult(stdev) && <TableHeadCell>{"Stdev"}</TableHeadCell>}
           <TableHeadCell>{"5%"}</TableHeadCell>
           <TableHeadCell>{"10%"}</TableHeadCell>
           <TableHeadCell>{"25%"}</TableHeadCell>
@@ -192,6 +197,7 @@ const SummaryTable: React.FC<SummaryTableProps> = ({ distribution }) => {
       <tbody>
         <tr>
           <Cell>{unwrapResult(mean)}</Cell>
+          {hasResult(stdev) && <Cell>{unwrapResult(stdev)}</Cell>}
           <Cell>{unwrapResult(p5)}</Cell>
           <Cell>{unwrapResult(p10)}</Cell>
           <Cell>{unwrapResult(p25)}</Cell>

--- a/packages/squiggle-lang/src/js/distribution.ts
+++ b/packages/squiggle-lang/src/js/distribution.ts
@@ -11,6 +11,7 @@ import {
 import { result, resultMap, Ok } from "./types";
 import {
   Constructors_mean,
+  Constructors_stdev,
   Constructors_sample,
   Constructors_pdf,
   Constructors_cdf,
@@ -67,6 +68,10 @@ export class Distribution {
 
   mean(): result<number, distributionError> {
     return Constructors_mean({ env: this.env }, this.t);
+  }
+
+  stdev(): result<number, distributionError> {
+    return Constructors_stdev({ env: this.env }, this.t);
   }
 
   sample(): result<number, distributionError> {

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
@@ -265,6 +265,8 @@ module Constructors = {
   module C = DistributionTypes.Constructors.UsingDists
   open OutputLocal
   let mean = (~env, dist) => C.mean(dist)->run(~env)->toFloatR
+  let stdev = (~env, dist) => C.stdev(dist)->run(~env)->toFloatR
+  let variance = (~env, dist) => C.variance(dist)->run(~env)->toFloatR
   let sample = (~env, dist) => C.sample(dist)->run(~env)->toFloatR
   let cdf = (~env, dist, f) => C.cdf(dist, f)->run(~env)->toFloatR
   let inv = (~env, dist, f) => C.inv(dist, f)->run(~env)->toFloatR

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
@@ -49,6 +49,10 @@ module Constructors: {
   @genType
   let mean: (~env: env, genericDist) => result<float, error>
   @genType
+  let stdev: (~env: env, genericDist) => result<float, error>
+  @genType
+  let variance: (~env: env, genericDist) => result<float, error>
+  @genType
   let sample: (~env: env, genericDist) => result<float, error>
   @genType
   let cdf: (~env: env, genericDist, float) => result<float, error>

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
@@ -30,9 +30,9 @@ module Error = {
   @genType
   let toString = (err: error): string =>
     switch err {
-    | NotYetImplemented => "Function Not Yet Implemented"
+    | NotYetImplemented => "Function not yet implemented"
     | Unreachable => "Unreachable"
-    | DistributionVerticalShiftIsInvalid => "Distribution Vertical Shift is Invalid"
+    | DistributionVerticalShiftIsInvalid => "Distribution vertical shift is invalid"
     | ArgumentError(s) => `Argument Error ${s}`
     | LogarithmOfDistributionError(s) => `Logarithm of input error: ${s}`
     | SampleSetError(TooFewSamples) => "Too Few Samples"
@@ -68,6 +68,11 @@ module DistributionOperation = {
     | #Mean
     | #Sample
     | #IntegralSum
+    | #Mode
+    | #Stdev
+    | #Min
+    | #Max
+    | #Variance
   ]
 
   type toScaleFn = [
@@ -117,6 +122,11 @@ module DistributionOperation = {
     | ToFloat(#Cdf(r)) => `cdf(${E.Float.toFixed(r)})`
     | ToFloat(#Inv(r)) => `inv(${E.Float.toFixed(r)})`
     | ToFloat(#Mean) => `mean`
+    | ToFloat(#Min) => `min`
+    | ToFloat(#Max) => `max`
+    | ToFloat(#Stdev) => `stdev`
+    | ToFloat(#Variance) => `variance`
+    | ToFloat(#Mode) => `mode`
     | ToFloat(#Pdf(r)) => `pdf(${E.Float.toFixed(r)})`
     | ToFloat(#Sample) => `sample`
     | ToFloat(#IntegralSum) => `integralSum`

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
@@ -161,6 +161,8 @@ module Constructors = {
   module UsingDists = {
     @genType
     let mean = (dist): t => FromDist(ToFloat(#Mean), dist)
+    let stdev = (dist): t => FromDist(ToFloat(#Stdev), dist)
+    let variance = (dist): t => FromDist(ToFloat(#Variance), dist)
     let sample = (dist): t => FromDist(ToFloat(#Sample), dist)
     let cdf = (dist, x): t => FromDist(ToFloat(#Cdf(x)), dist)
     let inv = (dist, x): t => FromDist(ToFloat(#Inv(x)), dist)

--- a/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist.res
@@ -254,6 +254,8 @@ let operate = (distToFloatOp: Operation.distToFloatOperation, s): float =>
   | #Inv(f) => inv(f, s)
   | #Sample => sample(s)
   | #Mean => T.mean(s)
+  | #Min => T.minX(s)
+  | #Max => T.maxX(s)
   }
 
 let toSparkline = (t: t, bucketCount): result<string, PointSetTypes.sparklineError> =>

--- a/packages/squiggle-lang/src/rescript/Distributions/SymbolicDist/SymbolicDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/SymbolicDist/SymbolicDist.res
@@ -449,6 +449,8 @@ module T = {
     | #Cdf(f) => Ok(cdf(f, s))
     | #Pdf(f) => Ok(pdf(f, s))
     | #Inv(f) => Ok(inv(f, s))
+    | #Min => Ok(min(s))
+    | #Max => Ok(max(s))
     | #Sample => Ok(sample(s))
     | #Mean => mean(s)
     }

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -209,7 +209,18 @@ let dispatchToGenericOutput = (
   | ("sample", [EvDistribution(dist)]) => Helpers.toFloatFn(#Sample, dist, ~env)
   | ("sampleN", [EvDistribution(dist), EvNumber(n)]) =>
     Some(FloatArray(GenericDist.sampleN(dist, Belt.Int.fromFloat(n))))
-  | ("mean", [EvDistribution(dist)]) => Helpers.toFloatFn(#Mean, dist, ~env)
+  | (("mean" | "stdev" | "variance" | "min" | "max" | "mode") as op, [EvDistribution(dist)]) => {
+      let fn = switch op {
+      | "mean" => #Mean
+      | "stdev" => #Stdev
+      | "variance" => #Variance
+      | "min" => #Min
+      | "max" => #Max
+      | "mode" => #Mode
+      | _ => #Mean
+      }
+      Helpers.toFloatFn(fn, dist, ~env)
+    }
   | ("integralSum", [EvDistribution(dist)]) => Helpers.toFloatFn(#IntegralSum, dist, ~env)
   | ("toString", [EvDistribution(dist)]) => Helpers.toStringFn(ToString, dist, ~env)
   | ("toSparkline", [EvDistribution(dist)]) =>

--- a/packages/squiggle-lang/src/rescript/Utility/Operation.res
+++ b/packages/squiggle-lang/src/rescript/Utility/Operation.res
@@ -26,6 +26,8 @@ type distToFloatOperation = [
   | #Inv(float)
   | #Mean
   | #Sample
+  | #Min
+  | #Max
 ]
 
 module Convolution = {


### PR DESCRIPTION
There's no tests, but the math just goes to lower level libraries we already use. The sampleset ones are just referring to Jstat, which I trust. 

The stdev/variance/mode only work for Sampleset. It's related to https://github.com/quantified-uncertainty/squiggle/issues/530