### PR TITLE
Normalize after truncate

### DIFF
--- a/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
+++ b/packages/squiggle-lang/__tests__/ReducerInterface/ReducerInterface_Distribution_test.res
@@ -80,6 +80,7 @@ describe("eval on distribution functions", () => {
     testEval("truncateLeft(normal(5,2), 3)", "Ok(Point Set Distribution)")
     testEval("truncateRight(normal(5,2), 3)", "Ok(Point Set Distribution)")
     testEval("truncate(normal(5,2), 3, 8)", "Ok(Point Set Distribution)")
+    testEval("isNormalized(truncate(normal(5,2), 3, 8))", "Ok(true)")
   })
 
   describe("exp", () => {

--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist.res
@@ -214,7 +214,9 @@ module Truncate = {
       | Some(r) => Ok(r)
       | None =>
         toPointSetFn(t)->E.R2.fmap(t => {
-          DistributionTypes.PointSet(PointSetDist.T.truncate(leftCutoff, rightCutoff, t)->PointSetDist.T.normalize)
+          DistributionTypes.PointSet(
+            PointSetDist.T.truncate(leftCutoff, rightCutoff, t)->PointSetDist.T.normalize,
+          )
         })
       }
     }

--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist.res
@@ -214,7 +214,7 @@ module Truncate = {
       | Some(r) => Ok(r)
       | None =>
         toPointSetFn(t)->E.R2.fmap(t => {
-          DistributionTypes.PointSet(PointSetDist.T.truncate(leftCutoff, rightCutoff, t))
+          DistributionTypes.PointSet(PointSetDist.T.truncate(leftCutoff, rightCutoff, t)->PointSetDist.T.normalize)
         })
       }
     }


### PR DESCRIPTION
A few of us have been burned about truncate not normalizing. Later we could add a version that doesn't normalize.

I added a super simple test.