### PR TITLE
fix: Make lodash a dependency, rather than a dev dependency

### DIFF
--- a/packages/squiggle-lang/package.json
+++ b/packages/squiggle-lang/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@stdlib/stats": "^0.0.13",
     "jstat": "^1.9.5",
+    "lodash": "^4.17.21",
     "mathjs": "^10.6.0",
     "pdfast": "^0.2.0",
     "rescript": "^9.1.4"
@@ -53,7 +54,6 @@
     "fast-check": "^2.25.0",
     "gentype": "^4.4.0",
     "jest": "^27.5.1",
-    "lodash": "^4.17.21",
     "moduleserve": "^0.9.1",
     "nyc": "^15.1.0",
     "peggy": "^2.0.1",


### PR DESCRIPTION
I'm hoping this fixes my current error when using the
npm package.

Looking at the compiled outputs into js, the first line is:

import * as _ from "lodash";

But, because lodash is not a dependency, but rather a dev dependency,
this brings up an error when downloading and using from npm,
so the current npm package does not run

I am hoping that this simple fix will fix that.