### PR TITLE
Fix CSS entry making JS module empty

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quri/squiggle-components",
-  "version": "0.2.20",
+  "version": "0.2.22",
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.6.4",

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -4,8 +4,10 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = {
   mode: "production",
   devtool: "source-map",
-  profile: true,
-  entry: ["./src/index.ts", "./src/styles/main.css"],
+  entry: {
+    main: ["./src/index.ts"],
+    style: ["./src/styles/main.css"],
+  },
   module: {
     rules: [
       {
@@ -20,7 +22,11 @@ module.exports = {
       },
     ],
   },
-  plugins: [new MiniCssExtractPlugin()],
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+  ],
   resolve: {
     extensions: [".js", ".tsx", ".ts"],
     alias: {
@@ -28,7 +34,7 @@ module.exports = {
     },
   },
   output: {
-    filename: "bundle.js",
+    filename: "[name].js",
     path: path.resolve(__dirname, "dist"),
     library: {
       name: "squiggle_components",


### PR DESCRIPTION
I had some trouble getting a bundle working in components. For some reason it created empty js modules whenever I would add a second CSS entry point. Required tweaking the webpack to get a working result. Bumps to 0.2.22 as well
