### PR TITLE
Fix externals; move react dep to peerDependencies (fixes #494)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -12,7 +12,6 @@
     "lodash": "^4.17.21",
     "react": "^18.1.0",
     "react-ace": "^10.1.0",
-    "react-dom": "^18.1.0",
     "react-hook-form": "^7.32.0",
     "react-use": "^17.4.0",
     "react-vega": "^7.5.1",
@@ -46,6 +45,8 @@
     "postcss-cli": "^9.1.0",
     "postcss-import": "^14.1.0",
     "postcss-loader": "^7.0.0",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
     "react-scripts": "^5.0.1",
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.1.2",
@@ -56,6 +57,10 @@
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.9.2"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0 || ^17 || ^18",
+    "react-dom": "^16.8.0 || ^17 || ^18"
   },
   "scripts": {
     "start": "cross-env REACT_APP_FAST_REFRESH=false && start-storybook -p 6006 -s public",

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -37,7 +37,17 @@ module.exports = {
     port: 9000,
   },
   externals: {
-    react: "React",
-    "react-dom": "ReactDOM",
+    react: {
+      commonjs: "react",
+      commonjs2: "react",
+      amd: "react",
+      root: "React",
+    },
+    "react-dom": {
+      commonjs: "react-dom",
+      commonjs2: "react-dom",
+      amd: "react-dom",
+      root: "ReactDOM",
+    },
   },
 };


### PR DESCRIPTION
Two fixes to avoid tight coupling with React:

1) In #703 I had to remove React from the packages/components webpack bundle, to be able to use React for other purposes. But turns out I configured externals slightly wrong, and it broke observable.

@Hazelfire, you'll have to update the observable's require code after the next npm release to this:

```
squiggle = await require.alias({
  react: 'react@18/umd/react.production.min.js',
  'react-dom': 'react-dom@18/umd/react-dom.production.min.js',
})(require(`@quri/squiggle-components@${squiggle_version}/dist/bundle.js`))
```

Btw, here's how I tested a bundle on observable without uploading a new version of the package:

- build a webpack bundle locally
- attach it to the observable's notebook
- load it like this:

```
squiggle = await require.alias({
  react: 'react@18/umd/react.production.min.js',
  'react-dom': 'react-dom@18/umd/react-dom.production.min.js',
})(await FileAttachment("bundle.js").url())
```

2) I finally fixed #494. Everything seems fine and yarn.lock haven't even changed because the website still depends on react. 16.9.0 is the first React version with hooks; I'm not sure if squiggle-components really is compatible with 16.9, and I'm too lazy to check, but that doesn't seem too important.

We shouldn't depend on React 18 until we need any particular features from it, though, since v18 is still pretty fresh. (E.g., stradam is still on v17)