### PR TITLE
don't set playground height (fixes #660)

### DIFF
--- a/packages/components/src/components/SquigglePlayground.tsx
+++ b/packages/components/src/components/SquigglePlayground.tsx
@@ -438,7 +438,7 @@ export const SquigglePlayground: FC<PlaygroundProps> = ({
   );
 
   const withEditor = (
-    <div className="flex mt-1" style={{ height }}>
+    <div className="flex mt-1">
       <div className="w-1/2">{tabs}</div>
       <div className="w-1/2 p-2 pl-4">{squiggleChart}</div>
     </div>


### PR DESCRIPTION
I couldn't find the reason why it was needed (height is set both on chart and on editor separately).