### PR TITLE
hotfix: hash links in playground

### DIFF
--- a/packages/website/src/pages/playground.js
+++ b/packages/website/src/pages/playground.js
@@ -36,11 +36,16 @@ function setHashData(data) {
 }
 
 export default function PlaygroundPage() {
+  const hashData = getHashData();
+  if (hashData.initialSquiggleString) {
+    hashData.defaultCode = String(hashData.initialSquiggleString);
+    delete hashData.initialSquiggleString;
+  }
   const playgroundProps = {
     defaultCode: "normal(0,1)",
     height: 700,
     showTypes: true,
-    ...getHashData(),
+    ...hashData,
     onCodeChange: (code) => setHashData({ initialSquiggleString: code }),
     onSettingsChange: (settings) => {
       const { showTypes, showControls, showSummary, showEditor } = settings;


### PR DESCRIPTION
Hash links don't work because of props rename in #759.