### PR TITLE
Add percentile charted to as environment option

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quri/squiggle-components",
-  "version": "0.2.20",
+  "version": "0.2.23",
   "license": "MIT",
   "dependencies": {
     "@headlessui/react": "^1.6.6",

--- a/packages/components/src/components/SquiggleItem.tsx
+++ b/packages/components/src/components/SquiggleItem.tsx
@@ -219,6 +219,7 @@ export const SquiggleItem: React.FC<SquiggleItemProps> = ({
             distributionPlotSettings={distributionPlotSettings}
             height={height}
             environment={{
+              ...environment,
               sampleCount: environment.sampleCount / 10,
               xyPointLength: environment.xyPointLength / 10,
             }}
@@ -234,6 +235,7 @@ export const SquiggleItem: React.FC<SquiggleItemProps> = ({
             distributionPlotSettings={distributionPlotSettings}
             height={height}
             environment={{
+              ...environment,
               sampleCount: environment.sampleCount / 10,
               xyPointLength: environment.xyPointLength / 10,
             }}
@@ -246,7 +248,7 @@ export const SquiggleItem: React.FC<SquiggleItemProps> = ({
         <VariableBox heading="Module" showTypes={showTypes}>
           <div className="space-y-3">
             {Object.entries(expression.value)
-              .filter(([key, r]) => key !== "Math")
+              .filter(([key, _]) => key !== "Math")
               .map(([key, r]) => (
                 <div key={key} className="flex space-x-2">
                   <div className="flex-none">

--- a/packages/components/src/components/SquigglePlayground.tsx
+++ b/packages/components/src/components/SquigglePlayground.tsx
@@ -55,6 +55,7 @@ const schema = yup.object({}).shape({
     .default(1000)
     .min(10)
     .max(10000),
+  percentile: yup.number().required().positive().default(0.9998).min(0).max(1),
   chartHeight: yup.number().required().positive().integer().default(350),
   leftSizePercent: yup
     .number()
@@ -152,6 +153,20 @@ const SamplingSettings: React.FC<{ register: UseFormRegister<FormFields> }> = ({
         <Text>
           When distributions are converted into PointSet shapes, we need to know
           how many coordinates to use.
+        </Text>
+      </div>
+    </div>
+    <div>
+      <InputItem
+        name="percentile"
+        type="number"
+        label="Symbolic Distribution Percentile"
+        register={register}
+      />
+      <div className="mt-2">
+        <Text>
+          When converting symbolic distributions to PointSet distributions, what
+          percentile to sample the points within.
         </Text>
       </div>
     </div>
@@ -436,6 +451,7 @@ export const SquigglePlayground: FC<PlaygroundProps> = ({
   const { register, control } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
+      percentile: 0.9998,
       sampleCount: 1000,
       xyPointLength: 1000,
       chartHeight: 150,
@@ -468,6 +484,7 @@ export const SquigglePlayground: FC<PlaygroundProps> = ({
 
   const env: environment = useMemo(
     () => ({
+      percentile: Number(vars.percentile),
       sampleCount: Number(vars.sampleCount),
       xyPointLength: Number(vars.xyPointLength),
     }),

--- a/packages/components/src/lib/distributionSpecBuilder.ts
+++ b/packages/components/src/lib/distributionSpecBuilder.ts
@@ -42,7 +42,7 @@ export let linearYScale: LinearScale = {
   name: "yscale",
   type: "linear",
   range: "height",
-  zero: false,
+  zero: true,
   domain: {
     fields: [
       {
@@ -84,7 +84,7 @@ export let expYScale: PowScale = {
   type: "pow",
   exponent: 0.1,
   range: "height",
-  zero: false,
+  zero: true,
   nice: false,
   domain: {
     fields: [

--- a/packages/squiggle-lang/__tests__/Distributions/DistributionOperation_test.res
+++ b/packages/squiggle-lang/__tests__/Distributions/DistributionOperation_test.res
@@ -1,10 +1,6 @@
 open Jest
 open Expect
-
-let env: DistributionOperation.env = {
-  sampleCount: 100,
-  xyPointLength: 100,
-}
+open TestHelpers
 
 let {
   normalDist5,

--- a/packages/squiggle-lang/__tests__/TestHelpers.res
+++ b/packages/squiggle-lang/__tests__/TestHelpers.res
@@ -30,6 +30,7 @@ let {toFloat, toDist, toString, toError, fmap} = module(DistributionOperation.Ou
 let fnImage = (theFn, inps) => Js.Array.map(theFn, inps)
 
 let env: DistributionOperation.env = {
+  percentile: 0.9998,
   sampleCount: MagicNumbers.Environment.defaultSampleCount,
   xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
 }

--- a/packages/squiggle-lang/src/js/distribution.ts
+++ b/packages/squiggle-lang/src/js/distribution.ts
@@ -105,14 +105,7 @@ export class Distribution {
   }
 
   pointSet(): result<shape, distributionError> {
-    let pointSet = toPointSet(
-      this.t,
-      {
-        xyPointLength: this.env.xyPointLength,
-        sampleCount: this.env.sampleCount,
-      },
-      undefined
-    );
+    let pointSet = toPointSet(this.t, this.env, undefined);
     if (pointSet.tag === "Ok") {
       let distribution = pointSet.value;
       if (distribution.tag === "Continuous") {

--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -39,20 +39,17 @@ export type { result, shape, environment, lambdaValue, squiggleExpression };
 
 export { parse } from "./parse";
 
-export let defaultSamplingInputs: environment = {
-  sampleCount: 10000,
-  xyPointLength: 10000,
-};
-
 export function run(
   squiggleString: string,
   bindings?: externalBindings,
-  environment?: environment,
+  environment?: Partial<environment>,
   imports?: jsImports
 ): result<squiggleExpression, errorValue> {
   let b = bindings ? bindings : defaultBindings;
   let i = imports ? imports : defaultImports;
-  let e = environment ? environment : defaultEnvironment;
+  let e = environment
+    ? _.merge(defaultEnvironment, environment)
+    : defaultEnvironment;
   let res: result<expressionValue, errorValue> = evaluateUsingOptions(
     { externalBindings: mergeImportsWithBindings(b, i), environment: e },
     squiggleString
@@ -64,12 +61,14 @@ export function run(
 export function runPartial(
   squiggleString: string,
   bindings?: externalBindings,
-  environment?: environment,
+  environment?: Partial<environment>,
   imports?: jsImports
 ): result<externalBindings, errorValue> {
   let b = bindings ? bindings : defaultBindings;
   let i = imports ? imports : defaultImports;
-  let e = environment ? environment : defaultEnvironment;
+  let e = environment
+    ? _.merge(defaultEnvironment, environment)
+    : defaultEnvironment;
 
   return evaluatePartialUsingExternalBindings(
     squiggleString,

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
@@ -5,11 +5,13 @@ type error = DistributionTypes.error
 // TODO: It could be great to use a cache for some calculations (basically, do memoization). Also, better analytics/tracking could go a long way.
 
 type env = {
+  percentile: float,
   sampleCount: int,
   xyPointLength: int,
 }
 
 let defaultEnv = {
+  percentile: 0.9998,
   sampleCount: MagicNumbers.Environment.defaultSampleCount,
   xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
 }
@@ -137,7 +139,7 @@ let rec run = (~env, functionCallInfo: functionCallInfo): outputType => {
       ->OutputLocal.fromResult
     | ToString(ToString) => dist->GenericDist.toString->String
     | ToString(ToSparkline(bucketCount)) =>
-      GenericDist.toSparkline(dist, ~sampleCount, ~bucketCount, ())
+      GenericDist.toSparkline(dist, ~percentile=env.percentile, ~sampleCount, ~bucketCount, ())
       ->E.R2.fmap(r => String(r))
       ->OutputLocal.fromResult
     | ToDist(Inspect) => {
@@ -170,7 +172,7 @@ let rec run = (~env, functionCallInfo: functionCallInfo): outputType => {
       ->OutputLocal.fromResult
     | ToDist(ToPointSet) =>
       dist
-      ->GenericDist.toPointSet(~xyPointLength, ~sampleCount, ())
+      ->GenericDist.toPointSet(~percentile=env.percentile, ~xyPointLength, ~sampleCount, ())
       ->E.R2.fmap(r => Dist(PointSet(r)))
       ->OutputLocal.fromResult
     | ToDist(Scale(#LogarithmWithThreshold(eps), f)) =>

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
@@ -1,5 +1,6 @@
 @genType
 type env = {
+  percentile: float,
   sampleCount: int,
   xyPointLength: int,
 }

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
@@ -70,8 +70,8 @@ module DistributionOperation = {
     | #IntegralSum
     | #Mode
     | #Stdev
-    | #Min
-    | #Max
+    | #Min(float)
+    | #Max(float)
     | #Variance
   ]
 
@@ -123,8 +123,8 @@ module DistributionOperation = {
     | ToFloat(#Cdf(r)) => `cdf(${E.Float.toFixed(r)})`
     | ToFloat(#Inv(r)) => `inv(${E.Float.toFixed(r)})`
     | ToFloat(#Mean) => `mean`
-    | ToFloat(#Min) => `min`
-    | ToFloat(#Max) => `max`
+    | ToFloat(#Min(_)) => `min`
+    | ToFloat(#Max(_)) => `max`
     | ToFloat(#Stdev) => `stdev`
     | ToFloat(#Variance) => `variance`
     | ToFloat(#Mode) => `mode`

--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist.resi
@@ -37,12 +37,19 @@ module Score: {
 @genType
 let toPointSet: (
   t,
+  ~percentile: float,
   ~xyPointLength: int,
   ~sampleCount: int,
   ~xSelection: DistributionTypes.DistributionOperation.pointsetXSelection=?,
   unit,
 ) => result<PointSetTypes.pointSetDist, error>
-let toSparkline: (t, ~sampleCount: int, ~bucketCount: int=?, unit) => result<string, error>
+let toSparkline: (
+  t,
+  ~percentile: float,
+  ~sampleCount: int,
+  ~bucketCount: int=?,
+  unit,
+) => result<string, error>
 
 let truncate: (
   t,

--- a/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist.res
@@ -254,8 +254,8 @@ let operate = (distToFloatOp: Operation.distToFloatOperation, s): float =>
   | #Inv(f) => inv(f, s)
   | #Sample => sample(s)
   | #Mean => T.mean(s)
-  | #Min => T.minX(s)
-  | #Max => T.maxX(s)
+  | #Min(_) => T.minX(s)
+  | #Max(_) => T.maxX(s)
   }
 
 let toSparkline = (t: t, bucketCount): result<string, PointSetTypes.sparklineError> =>

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -216,8 +216,8 @@ let dispatchToGenericOutput = (call: IEV.functionCall, env: DistributionOperatio
       | "mean" => #Mean
       | "stdev" => #Stdev
       | "variance" => #Variance
-      | "min" => #Min
-      | "max" => #Max
+      | "min" => #Min(env.percentile)
+      | "max" => #Max(env.percentile)
       | "mode" => #Mode
       | _ => #Mean
       }

--- a/packages/squiggle-lang/src/rescript/Utility/Operation.res
+++ b/packages/squiggle-lang/src/rescript/Utility/Operation.res
@@ -26,8 +26,8 @@ type distToFloatOperation = [
   | #Inv(float)
   | #Mean
   | #Sample
-  | #Min
-  | #Max
+  | #Min(float)
+  | #Max(float)
 ]
 
 module Convolution = {


### PR DESCRIPTION
This PR is an attempt to achieve #765 in a cleaner way, simply offering the hard coded 99.98% confidence interval number to be changed by the user by setting a percentile.

Couple of interesting design choices:

 - I chose to put the percentile as an argument in the Min and Max operation. If you think this is not the right semantics, happy to change to something like passing the percentile argument all the way down the operation chain.
 - This is considered a sampling option, in that it is only relavent when converting symbolic distributions to point set distributions. This means that uniform + triangular + distrete distributions are unaffected by this argument. I thought this to be reasonable.

Otherwise, I consider this PR to be quite safe to merge. I tested it out and it works fine! Included options in the playground as well.
