### PR TITLE
Scoring cleanup three fixes

### DIFF
--- a/packages/squiggle-lang/__tests__/Distributions/DistributionOperation_test.res
+++ b/packages/squiggle-lang/__tests__/Distributions/DistributionOperation_test.res
@@ -1,7 +1,7 @@
 open Jest
 open Expect
 
-let env: DistributionOperation.env = {
+let env: GenericDist.env = {
   sampleCount: 100,
   xyPointLength: 100,
 }

--- a/packages/squiggle-lang/__tests__/TestHelpers.res
+++ b/packages/squiggle-lang/__tests__/TestHelpers.res
@@ -29,7 +29,7 @@ let {toFloat, toDist, toString, toError, fmap} = module(DistributionOperation.Ou
 
 let fnImage = (theFn, inps) => Js.Array.map(theFn, inps)
 
-let env: DistributionOperation.env = {
+let env: GenericDist.env = {
   sampleCount: MagicNumbers.Environment.defaultSampleCount,
   xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
 }

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
@@ -146,7 +146,7 @@ let rec run = (~env, functionCallInfo: functionCallInfo): outputType => {
       }
     | #ToDist(Normalize) => dist->GenericDist.normalize->Dist
     | #ToScore(LogScore(answer, prior)) =>
-      GenericDist.Score.logScore(~estimate=Score_Dist(dist), ~answer, ~prior)
+      GenericDist.Score.logScore(~estimate=dist, ~answer, ~prior)
       ->E.R2.fmap(s => Float(s))
       ->OutputLocal.fromResult
     | #ToBool(IsNormalized) => dist->GenericDist.isNormalized->Bool

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.res
@@ -4,12 +4,9 @@ type error = DistributionTypes.error
 
 // TODO: It could be great to use a cache for some calculations (basically, do memoization). Also, better analytics/tracking could go a long way.
 
-type env = {
-  sampleCount: int,
-  xyPointLength: int,
-}
+type env = GenericDist.env
 
-let defaultEnv = {
+let defaultEnv:env = {
   sampleCount: MagicNumbers.Environment.defaultSampleCount,
   xyPointLength: MagicNumbers.Environment.defaultXYPointLength,
 }
@@ -93,7 +90,7 @@ module OutputLocal = {
     }
 }
 
-let rec run = (~env, functionCallInfo: functionCallInfo): outputType => {
+let rec run = (~env:env, functionCallInfo: functionCallInfo): outputType => {
   let {sampleCount, xyPointLength} = env
 
   let reCall = (~env=env, ~functionCallInfo=functionCallInfo, ()) => {
@@ -146,7 +143,7 @@ let rec run = (~env, functionCallInfo: functionCallInfo): outputType => {
       }
     | #ToDist(Normalize) => dist->GenericDist.normalize->Dist
     | #ToScore(LogScore(answer, prior)) =>
-      GenericDist.Score.logScore(~estimate=dist, ~answer, ~prior)
+      GenericDist.Score.logScore(~estimate=dist, ~answer, ~prior, ~env)
       ->E.R2.fmap(s => Float(s))
       ->OutputLocal.fromResult
     | #ToBool(IsNormalized) => dist->GenericDist.isNormalized->Bool

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
@@ -72,7 +72,7 @@ module Constructors: {
       ~env: env,
       genericDist,
       genericDist,
-      DistributionTypes.DistributionOperation.genericDistOrScalar,
+      genericDist,
     ) => result<float, error>
     @genType
     let distEstimateScalarAnswer: (~env: env, genericDist, float) => result<float, error>
@@ -81,7 +81,7 @@ module Constructors: {
       ~env: env,
       genericDist,
       float,
-      DistributionTypes.DistributionOperation.genericDistOrScalar,
+      genericDist,
     ) => result<float, error>
   }
   @genType

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionOperation.resi
@@ -1,11 +1,5 @@
 @genType
-type env = {
-  sampleCount: int,
-  xyPointLength: int,
-}
-
-@genType
-let defaultEnv: env
+let defaultEnv: GenericDist.env
 
 open DistributionTypes
 
@@ -19,14 +13,17 @@ type outputType =
   | GenDistError(error)
 
 @genType
-let run: (~env: env, DistributionTypes.DistributionOperation.genericFunctionCallInfo) => outputType
+let run: (
+  ~env: GenericDist.env,
+  DistributionTypes.DistributionOperation.genericFunctionCallInfo,
+) => outputType
 let runFromDist: (
-  ~env: env,
+  ~env: GenericDist.env,
   ~functionCallInfo: DistributionTypes.DistributionOperation.fromDist,
   genericDist,
 ) => outputType
 let runFromFloat: (
-  ~env: env,
+  ~env: GenericDist.env,
   ~functionCallInfo: DistributionTypes.DistributionOperation.fromFloat,
   float,
 ) => outputType
@@ -42,90 +39,147 @@ module Output: {
   let toBool: t => option<bool>
   let toBoolR: t => result<bool, error>
   let toError: t => option<error>
-  let fmap: (~env: env, t, DistributionTypes.DistributionOperation.singleParamaterFunction) => t
+  let fmap: (
+    ~env: GenericDist.env,
+    t,
+    DistributionTypes.DistributionOperation.singleParamaterFunction,
+  ) => t
 }
 
 module Constructors: {
   @genType
-  let mean: (~env: env, genericDist) => result<float, error>
+  let mean: (~env: GenericDist.env, genericDist) => result<float, error>
   @genType
-  let stdev: (~env: env, genericDist) => result<float, error>
+  let stdev: (~env: GenericDist.env, genericDist) => result<float, error>
   @genType
-  let variance: (~env: env, genericDist) => result<float, error>
+  let variance: (~env: GenericDist.env, genericDist) => result<float, error>
   @genType
-  let sample: (~env: env, genericDist) => result<float, error>
+  let sample: (~env: GenericDist.env, genericDist) => result<float, error>
   @genType
-  let cdf: (~env: env, genericDist, float) => result<float, error>
+  let cdf: (~env: GenericDist.env, genericDist, float) => result<float, error>
   @genType
-  let inv: (~env: env, genericDist, float) => result<float, error>
+  let inv: (~env: GenericDist.env, genericDist, float) => result<float, error>
   @genType
-  let pdf: (~env: env, genericDist, float) => result<float, error>
+  let pdf: (~env: GenericDist.env, genericDist, float) => result<float, error>
   @genType
-  let normalize: (~env: env, genericDist) => result<genericDist, error>
+  let normalize: (~env: GenericDist.env, genericDist) => result<genericDist, error>
   @genType
-  let isNormalized: (~env: env, genericDist) => result<bool, error>
+  let isNormalized: (~env: GenericDist.env, genericDist) => result<bool, error>
   module LogScore: {
     @genType
-    let distEstimateDistAnswer: (~env: env, genericDist, genericDist) => result<float, error>
+    let distEstimateDistAnswer: (
+      ~env: GenericDist.env,
+      genericDist,
+      genericDist,
+    ) => result<float, error>
     @genType
     let distEstimateDistAnswerWithPrior: (
-      ~env: env,
+      ~env: GenericDist.env,
       genericDist,
       genericDist,
       genericDist,
     ) => result<float, error>
     @genType
-    let distEstimateScalarAnswer: (~env: env, genericDist, float) => result<float, error>
+    let distEstimateScalarAnswer: (
+      ~env: GenericDist.env,
+      genericDist,
+      float,
+    ) => result<float, error>
     @genType
     let distEstimateScalarAnswerWithPrior: (
-      ~env: env,
+      ~env: GenericDist.env,
       genericDist,
       float,
       genericDist,
     ) => result<float, error>
   }
   @genType
-  let toPointSet: (~env: env, genericDist) => result<genericDist, error>
+  let toPointSet: (~env: GenericDist.env, genericDist) => result<genericDist, error>
   @genType
-  let toSampleSet: (~env: env, genericDist, int) => result<genericDist, error>
+  let toSampleSet: (~env: GenericDist.env, genericDist, int) => result<genericDist, error>
   @genType
-  let fromSamples: (~env: env, SampleSetDist.t) => result<genericDist, error>
+  let fromSamples: (~env: GenericDist.env, SampleSetDist.t) => result<genericDist, error>
   @genType
-  let truncate: (~env: env, genericDist, option<float>, option<float>) => result<genericDist, error>
+  let truncate: (
+    ~env: GenericDist.env,
+    genericDist,
+    option<float>,
+    option<float>,
+  ) => result<genericDist, error>
   @genType
-  let inspect: (~env: env, genericDist) => result<genericDist, error>
+  let inspect: (~env: GenericDist.env, genericDist) => result<genericDist, error>
   @genType
-  let toString: (~env: env, genericDist) => result<string, error>
+  let toString: (~env: GenericDist.env, genericDist) => result<string, error>
   @genType
-  let toSparkline: (~env: env, genericDist, int) => result<string, error>
+  let toSparkline: (~env: GenericDist.env, genericDist, int) => result<string, error>
   @genType
-  let algebraicAdd: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let algebraicAdd: (~env: GenericDist.env, genericDist, genericDist) => result<genericDist, error>
   @genType
-  let algebraicMultiply: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let algebraicMultiply: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let algebraicDivide: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let algebraicDivide: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let algebraicSubtract: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let algebraicSubtract: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let algebraicLogarithm: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let algebraicLogarithm: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let algebraicPower: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let algebraicPower: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let scaleLogarithm: (~env: env, genericDist, float) => result<genericDist, error>
+  let scaleLogarithm: (~env: GenericDist.env, genericDist, float) => result<genericDist, error>
   @genType
-  let scaleMultiply: (~env: env, genericDist, float) => result<genericDist, error>
+  let scaleMultiply: (~env: GenericDist.env, genericDist, float) => result<genericDist, error>
   @genType
-  let scalePower: (~env: env, genericDist, float) => result<genericDist, error>
+  let scalePower: (~env: GenericDist.env, genericDist, float) => result<genericDist, error>
   @genType
-  let pointwiseAdd: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let pointwiseAdd: (~env: GenericDist.env, genericDist, genericDist) => result<genericDist, error>
   @genType
-  let pointwiseMultiply: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let pointwiseMultiply: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let pointwiseDivide: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let pointwiseDivide: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let pointwiseSubtract: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let pointwiseSubtract: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let pointwiseLogarithm: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let pointwiseLogarithm: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
   @genType
-  let pointwisePower: (~env: env, genericDist, genericDist) => result<genericDist, error>
+  let pointwisePower: (
+    ~env: GenericDist.env,
+    genericDist,
+    genericDist,
+  ) => result<genericDist, error>
 }

--- a/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/DistributionTypes.res
@@ -100,7 +100,7 @@ module DistributionOperation = {
 
   type genericDistOrScalar = Score_Dist(genericDist) | Score_Scalar(float)
 
-  type toScore = LogScore(genericDistOrScalar, option<genericDistOrScalar>)
+  type toScore = LogScore(genericDistOrScalar, option<genericDist>)
 
   type fromFloat = [
     | #ToFloat(toFloat)

--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist.resi
@@ -26,9 +26,9 @@ let toFloatOperation: (
 
 module Score: {
   let logScore: (
-    ~estimate: DistributionTypes.DistributionOperation.genericDistOrScalar,
+    ~estimate: t,
     ~answer: DistributionTypes.DistributionOperation.genericDistOrScalar,
-    ~prior: option<DistributionTypes.DistributionOperation.genericDistOrScalar>,
+    ~prior: option<t>,
   ) => result<float, error>
 }
 

--- a/packages/squiggle-lang/src/rescript/Distributions/GenericDist.resi
+++ b/packages/squiggle-lang/src/rescript/Distributions/GenericDist.resi
@@ -5,6 +5,9 @@ type toSampleSetFn = t => result<SampleSetDist.t, error>
 type scaleMultiplyFn = (t, float) => result<t, error>
 type pointwiseAddFn = (t, t) => result<t, error>
 
+@genType
+type env = {sampleCount: int, xyPointLength: int}
+
 let sampleN: (t, int) => array<float>
 let sample: t => float
 
@@ -29,6 +32,7 @@ module Score: {
     ~estimate: t,
     ~answer: DistributionTypes.DistributionOperation.genericDistOrScalar,
     ~prior: option<t>,
+    ~env: env
   ) => result<float, error>
 }
 

--- a/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist_Scoring.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/PointSetDist/PointSetDist_Scoring.res
@@ -19,7 +19,7 @@ module WithDistAnswer = {
     float,
     Operation.Error.t,
   > =>
-    // We decided that negative infinity, not an error at answerElement = 0.0, is a desirable value.
+    // We decided that 0.0, not an error at answerElement = 0.0, is a desirable value.
     if answerElement == 0.0 {
       Ok(0.0)
     } else if estimateElement == 0.0 {

--- a/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Core.res
+++ b/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Core.res
@@ -42,7 +42,7 @@ and frValueDistOrNumber = FRValueNumber(float) | FRValueDist(DistributionTypes.g
 type fnDefinition = {
   name: string,
   inputs: array<frType>,
-  run: (array<frValue>, DistributionOperation.env) => result<internalExpressionValue, string>,
+  run: (array<frValue>, GenericDist.env) => result<internalExpressionValue, string>,
 }
 
 type function = {
@@ -322,7 +322,7 @@ module FnDefinition = {
     t.name ++ `(${inputs})`
   }
 
-  let run = (t: t, args: array<internalExpressionValue>, env: DistributionOperation.env) => {
+  let run = (t: t, args: array<internalExpressionValue>, env: GenericDist.env) => {
     let argValues = FRType.matchWithExpressionValueArray(t.inputs, args)
     switch argValues {
     | Some(values) => t.run(values, env)
@@ -377,7 +377,7 @@ module Registry = {
     ~registry: registry,
     ~fnName: string,
     ~args: array<internalExpressionValue>,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ) => {
     let matchToDef = m => Matcher.Registry.matchToDef(registry, m)
     //Js.log(toSimple(registry))

--- a/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Core.res
+++ b/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Core.res
@@ -8,6 +8,7 @@ type rec frType =
   | FRTypeNumber
   | FRTypeNumeric
   | FRTypeDistOrNumber
+  | FRTypeDist
   | FRTypeLambda
   | FRTypeRecord(frTypeRecord)
   | FRTypeDict(frType)
@@ -60,6 +61,7 @@ module FRType = {
     switch t {
     | FRTypeNumber => "number"
     | FRTypeNumeric => "numeric"
+    | FRTypeDist => "distribution"
     | FRTypeDistOrNumber => "distribution|number"
     | FRTypeRecord(r) => {
         let input = ((name, frType): frTypeRecordParam) => `${name}: ${toString(frType)}`
@@ -98,6 +100,7 @@ module FRType = {
     | (FRTypeDistOrNumber, IEvDistribution(Symbolic(#Float(f)))) =>
       Some(FRValueDistOrNumber(FRValueNumber(f)))
     | (FRTypeDistOrNumber, IEvDistribution(f)) => Some(FRValueDistOrNumber(FRValueDist(f)))
+    | (FRTypeDist, IEvDistribution(f)) => Some(FRValueDist(f))
     | (FRTypeNumeric, IEvNumber(f)) => Some(FRValueNumber(f))
     | (FRTypeNumeric, IEvDistribution(Symbolic(#Float(f)))) => Some(FRValueNumber(f))
     | (FRTypeLambda, IEvLambda(f)) => Some(FRValueLambda(f))

--- a/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Helpers.res
+++ b/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Helpers.res
@@ -27,6 +27,12 @@ module Prepare = {
         | _ => Error(impossibleError)
         }
 
+      let threeArgs = (inputs: ts): result<ts, err> =>
+        switch inputs {
+        | [FRValueRecord([(_, n1), (_, n2), (_, n3)])] => Ok([n1, n2, n3])
+        | _ => Error(impossibleError)
+        }
+
       let toArgs = (inputs: ts): result<ts, err> =>
         switch inputs {
         | [FRValueRecord(args)] => args->E.A2.fmap(((_, b)) => b)->Ok
@@ -57,6 +63,13 @@ module Prepare = {
       }
     }
 
+    let twoDist = (values: ts): result<(DistributionTypes.genericDist, DistributionTypes.genericDist), err> => {
+      switch values {
+      | [FRValueDist(a1), FRValueDist(a2)] => Ok(a1, a2)
+      | _ => Error(impossibleError)
+      }
+    }
+
     let twoNumbers = (values: ts): result<(float, float), err> => {
       switch values {
       | [FRValueNumber(a1), FRValueNumber(a2)] => Ok(a1, a2)
@@ -81,6 +94,9 @@ module Prepare = {
     module Record = {
       let twoDistOrNumber = (values: ts): result<(frValueDistOrNumber, frValueDistOrNumber), err> =>
         values->ToValueArray.Record.twoArgs->E.R.bind(twoDistOrNumber)
+
+      let twoDist = (values: ts): result<(DistributionTypes.genericDist, DistributionTypes.genericDist), err> =>
+        values->ToValueArray.Record.twoArgs->E.R.bind(twoDist)
     }
   }
 

--- a/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Helpers.res
+++ b/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Helpers.res
@@ -144,7 +144,7 @@ module Prepare = {
 module Process = {
   module DistOrNumberToDist = {
     module Helpers = {
-      let toSampleSet = (r, env: DistributionOperation.env) =>
+      let toSampleSet = (r, env: GenericDist.env) =>
         GenericDist.toSampleSetDist(r, env.sampleCount)
 
       let mapFnResult = r =>
@@ -182,7 +182,7 @@ module Process = {
     let oneValue = (
       ~fn: float => result<DistributionTypes.genericDist, string>,
       ~value: frValueDistOrNumber,
-      ~env: DistributionOperation.env,
+      ~env: GenericDist.env,
     ): result<DistributionTypes.genericDist, string> => {
       switch value {
       | FRValueNumber(a1) => fn(a1)
@@ -195,7 +195,7 @@ module Process = {
     let twoValues = (
       ~fn: ((float, float)) => result<DistributionTypes.genericDist, string>,
       ~values: (frValueDistOrNumber, frValueDistOrNumber),
-      ~env: DistributionOperation.env,
+      ~env: GenericDist.env,
     ): result<DistributionTypes.genericDist, string> => {
       switch values {
       | (FRValueNumber(a1), FRValueNumber(a2)) => fn((a1, a2))

--- a/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Library.res
+++ b/packages/squiggle-lang/src/rescript/FunctionRegistry/FunctionRegistry_Library.res
@@ -49,7 +49,7 @@ let inputsTodist = (inputs: array<FunctionRegistry_Core.frValue>, makeDist) => {
   expressionValue
 }
 
-let registry = [
+let registryStart = [
   Function.make(
     ~name="toContinuousPointSet",
     ~definitions=[
@@ -510,3 +510,58 @@ to(5,10)
     (),
   ),
 ]
+
+let runScoring = (estimate, answer, prior) => {
+  GenericDist.Score.logScore(~estimate, ~answer, ~prior)
+  ->E.R2.fmap(FunctionRegistry_Helpers.Wrappers.evNumber)
+  ->E.R2.errMap(DistributionTypes.Error.toString)
+}
+
+let scoreFunctions = [
+  Function.make(
+    ~name="Score",
+    ~definitions=[
+      FnDefinition.make(
+        ~name="logScore",
+        ~inputs=[
+          FRTypeRecord([
+            ("estimate", FRTypeDist),
+            ("answer", FRTypeDistOrNumber),
+            ("prior", FRTypeDist),
+          ]),
+        ],
+        ~run=(inputs, _) => {
+          switch FunctionRegistry_Helpers.Prepare.ToValueArray.Record.threeArgs(inputs) {
+          | Ok([FRValueDist(estimate), FRValueDistOrNumber(FRValueDist(d)), FRValueDist(prior)]) =>
+            runScoring(estimate, Score_Dist(d), Some(prior))
+          | Ok([
+              FRValueDist(estimate),
+              FRValueDistOrNumber(FRValueNumber(d)),
+              FRValueDist(prior),
+            ]) =>
+            runScoring(estimate, Score_Scalar(d), Some(prior))
+          | Error(e) => Error(e)
+          | _ => Error(FunctionRegistry_Helpers.impossibleError)
+          }
+        },
+      ),
+      FnDefinition.make(
+        ~name="logScore",
+        ~inputs=[FRTypeRecord([("estimate", FRTypeDist), ("answer", FRTypeDistOrNumber)])],
+        ~run=(inputs, _) => {
+          switch FunctionRegistry_Helpers.Prepare.ToValueArray.Record.twoArgs(inputs) {
+          | Ok([FRValueDist(estimate), FRValueDistOrNumber(FRValueDist(d))]) =>
+            runScoring(estimate, Score_Dist(d), None)
+          | Ok([FRValueDist(estimate), FRValueDistOrNumber(FRValueNumber(d))]) =>
+            runScoring(estimate, Score_Scalar(d), None)
+          | Error(e) => Error(e)
+          | _ => Error(FunctionRegistry_Helpers.impossibleError)
+          }
+        },
+      ),
+    ],
+    (),
+  ),
+]
+
+let registry = E.A.append(registryStart, scoreFunctions)

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_Date.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_Date.res
@@ -1,7 +1,7 @@
 module IEV = ReducerInterface_InternalExpressionValue
 type internalExpressionValue = IEV.t
 
-let dispatch = (call: IEV.functionCall, _: DistributionOperation.env): option<
+let dispatch = (call: IEV.functionCall, _: GenericDist.env): option<
   result<internalExpressionValue, QuriSquiggleLang.Reducer_ErrorValue.errorValue>,
 > => {
   switch call {

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_Duration.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_Duration.res
@@ -1,7 +1,7 @@
 module IEV = ReducerInterface_InternalExpressionValue
 type internalExpressionValue = IEV.t
 
-let dispatch = (call: IEV.functionCall, _: DistributionOperation.env): option<
+let dispatch = (call: IEV.functionCall, _: GenericDist.env): option<
   result<internalExpressionValue, QuriSquiggleLang.Reducer_ErrorValue.errorValue>,
 > => {
   switch call {

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_ExternalExpressionValue.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_ExternalExpressionValue.res
@@ -86,7 +86,7 @@ let toStringResult = x =>
   }
 
 @genType
-type environment = DistributionOperation.env
+type environment = GenericDist.env
 
 @genType
 let defaultEnvironment: environment = DistributionOperation.defaultEnv

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -231,10 +231,7 @@ let dispatchToGenericOutput = (call: IEV.functionCall, env: DistributionOperatio
       DistributionOperation.run(
         FromDist(
           #ToScore(
-            LogScore(
-              DistributionTypes.DistributionOperation.Score_Dist(answer),
-              Some(DistributionTypes.DistributionOperation.Score_Dist(prior)),
-            ),
+            LogScore(DistributionTypes.DistributionOperation.Score_Dist(answer), Some(prior)),
           ),
           prediction,
         ),
@@ -256,10 +253,7 @@ let dispatchToGenericOutput = (call: IEV.functionCall, env: DistributionOperatio
     DistributionOperation.run(
       FromDist(
         #ToScore(
-          LogScore(
-            DistributionTypes.DistributionOperation.Score_Scalar(answer),
-            DistributionTypes.DistributionOperation.Score_Dist(prior)->Some,
-          ),
+          LogScore(DistributionTypes.DistributionOperation.Score_Scalar(answer), prior->Some),
         ),
         prediction,
       ),

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -32,7 +32,7 @@ module Helpers = {
   let toFloatFn = (
     fnCall: DistributionTypes.DistributionOperation.toFloat,
     dist: DistributionTypes.genericDist,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ) => {
     FromDist(#ToFloat(fnCall), dist)->DistributionOperation.run(~env)->Some
   }
@@ -40,7 +40,7 @@ module Helpers = {
   let toStringFn = (
     fnCall: DistributionTypes.DistributionOperation.toString,
     dist: DistributionTypes.genericDist,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ) => {
     FromDist(#ToString(fnCall), dist)->DistributionOperation.run(~env)->Some
   }
@@ -48,7 +48,7 @@ module Helpers = {
   let toBoolFn = (
     fnCall: DistributionTypes.DistributionOperation.toBool,
     dist: DistributionTypes.genericDist,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ) => {
     FromDist(#ToBool(fnCall), dist)->DistributionOperation.run(~env)->Some
   }
@@ -56,12 +56,12 @@ module Helpers = {
   let toDistFn = (
     fnCall: DistributionTypes.DistributionOperation.toDist,
     dist,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ) => {
     FromDist(#ToDist(fnCall), dist)->DistributionOperation.run(~env)->Some
   }
 
-  let twoDiststoDistFn = (direction, arithmetic, dist1, dist2, ~env: DistributionOperation.env) => {
+  let twoDiststoDistFn = (direction, arithmetic, dist1, dist2, ~env: GenericDist.env) => {
     FromDist(
       #ToDistCombination(direction, arithmeticMap(arithmetic), #Dist(dist2)),
       dist1,
@@ -97,7 +97,7 @@ module Helpers = {
   let mixtureWithGivenWeights = (
     distributions: array<DistributionTypes.genericDist>,
     weights: array<float>,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ): DistributionOperation.outputType =>
     E.A.length(distributions) == E.A.length(weights)
       ? Mixture(Belt.Array.zip(distributions, weights))->DistributionOperation.run(~env)
@@ -107,7 +107,7 @@ module Helpers = {
 
   let mixtureWithDefaultWeights = (
     distributions: array<DistributionTypes.genericDist>,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ): DistributionOperation.outputType => {
     let length = E.A.length(distributions)
     let weights = Belt.Array.make(length, 1.0 /. Belt.Int.toFloat(length))
@@ -116,7 +116,7 @@ module Helpers = {
 
   let mixture = (
     args: array<internalExpressionValue>,
-    ~env: DistributionOperation.env,
+    ~env: GenericDist.env,
   ): DistributionOperation.outputType => {
     let error = (err: string): DistributionOperation.outputType =>
       err->DistributionTypes.ArgumentError->GenDistError
@@ -173,7 +173,7 @@ module SymbolicConstructors = {
     }
 }
 
-let dispatchToGenericOutput = (call: IEV.functionCall, env: DistributionOperation.env): option<
+let dispatchToGenericOutput = (call: IEV.functionCall, env: GenericDist.env): option<
   DistributionOperation.outputType,
 > => {
   let (fnName, args) = call
@@ -213,16 +213,6 @@ let dispatchToGenericOutput = (call: IEV.functionCall, env: DistributionOperatio
       ~env,
     )->Some
   | ("normalize", [IEvDistribution(dist)]) => Helpers.toDistFn(Normalize, dist, ~env)
-  | ("klDivergence", [IEvDistribution(prediction), IEvDistribution(answer)]) =>
-    Some(
-      DistributionOperation.run(
-        FromDist(
-          #ToScore(LogScore(DistributionTypes.DistributionOperation.Score_Dist(answer), None)),
-          prediction,
-        ),
-        ~env,
-      ),
-    )
   | ("isNormalized", [IEvDistribution(dist)]) => Helpers.toBoolFn(IsNormalized, dist, ~env)
   | ("toPointSet", [IEvDistribution(dist)]) => Helpers.toDistFn(ToPointSet, dist, ~env)
   | ("scaleLog", [IEvDistribution(dist)]) =>

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_GenericDistribution.res
@@ -223,54 +223,6 @@ let dispatchToGenericOutput = (call: IEV.functionCall, env: DistributionOperatio
         ~env,
       ),
     )
-  | (
-      "klDivergence",
-      [IEvDistribution(prediction), IEvDistribution(answer), IEvDistribution(prior)],
-    ) =>
-    Some(
-      DistributionOperation.run(
-        FromDist(
-          #ToScore(
-            LogScore(DistributionTypes.DistributionOperation.Score_Dist(answer), Some(prior)),
-          ),
-          prediction,
-        ),
-        ~env,
-      ),
-    )
-  | (
-    "logScoreWithPointAnswer",
-    [IEvDistribution(prediction), IEvNumber(answer), IEvDistribution(prior)],
-  )
-  | (
-    "logScoreWithPointAnswer",
-    [
-      IEvDistribution(prediction),
-      IEvDistribution(Symbolic(#Float(answer))),
-      IEvDistribution(prior),
-    ],
-  ) =>
-    DistributionOperation.run(
-      FromDist(
-        #ToScore(
-          LogScore(DistributionTypes.DistributionOperation.Score_Scalar(answer), prior->Some),
-        ),
-        prediction,
-      ),
-      ~env,
-    )->Some
-  | ("logScoreWithPointAnswer", [IEvDistribution(prediction), IEvNumber(answer)])
-  | (
-    "logScoreWithPointAnswer",
-    [IEvDistribution(prediction), IEvDistribution(Symbolic(#Float(answer)))],
-  ) =>
-    DistributionOperation.run(
-      FromDist(
-        #ToScore(LogScore(DistributionTypes.DistributionOperation.Score_Scalar(answer), None)),
-        prediction,
-      ),
-      ~env,
-    )->Some
   | ("isNormalized", [IEvDistribution(dist)]) => Helpers.toBoolFn(IsNormalized, dist, ~env)
   | ("toPointSet", [IEvDistribution(dist)]) => Helpers.toDistFn(ToPointSet, dist, ~env)
   | ("scaleLog", [IEvDistribution(dist)]) =>

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_Number.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_Number.res
@@ -24,7 +24,7 @@ module ScientificUnit = {
   }
 }
 
-let dispatch = (call: IEV.functionCall, _: DistributionOperation.env): option<
+let dispatch = (call: IEV.functionCall, _: GenericDist.env): option<
   result<internalExpressionValue, QuriSquiggleLang.Reducer_ErrorValue.errorValue>,
 > => {
   switch call {

--- a/packages/squiggle-lang/src/rescript/TypescriptInterface.res
+++ b/packages/squiggle-lang/src/rescript/TypescriptInterface.res
@@ -8,7 +8,7 @@ The below few seem to work fine. In the future there's definitely more work to d
 */
 
 @genType
-type samplingParams = DistributionOperation.env
+type samplingParams = GenericDist.env
 
 @genType
 type genericDist = DistributionTypes.genericDist


### PR DESCRIPTION
- Cleaned up Generic Dist Score function, as the prior can't be a point.
- Use function registry
- Moved env to GenericDist so that it could be used there (and it seemed appropriate). Use it in scoring. 