### PR TITLE
fix compiler warnings

### DIFF
--- a/packages/squiggle-lang/src/rescript/FunctionRegistry/Library/FR_Sampleset.res
+++ b/packages/squiggle-lang/src/rescript/FunctionRegistry/Library/FR_Sampleset.res
@@ -259,7 +259,7 @@ let library = [
         ~run=(inputs, _, env, reducer) =>
           switch inputs {
           | [IEvArray(dists), IEvLambda(lambda)] =>
-            Internal.mapN(dists, lambda, env, reducer)->E.R2.errMap(e => {
+            Internal.mapN(dists, lambda, env, reducer)->E.R2.errMap(_e => {
               "AHHH doesn't work"
             })
           | _ => Error(impossibleError)

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltIn.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltIn.res
@@ -119,7 +119,7 @@ let callInternal = (call: functionCall, environment, reducer: ExpressionT.reduce
       E.A.O.openIfAllSome(E.A.fmap(parseSampleSet, arr))
     }
 
-    let mapN = (aValueArray: array<internalExpressionValue>, aLambdaValue) => {
+    let _mapN = (aValueArray: array<internalExpressionValue>, aLambdaValue) => {
       switch parseSampleSetArray(aValueArray) {
       | Some(t1) =>
         let fn = a => doLambdaCall(aLambdaValue, list{IEvArray(E.A.fmap(x => IEvNumber(x), a))})

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_InternalExpressionValue.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_InternalExpressionValue.res
@@ -183,6 +183,7 @@ let externalValueToValueType = (value: ExternalExpressionValue.t) =>
   | EvTimeDuration(_) => EvtTimeDuration
   | EvType(_) => EvtType
   | EvTypeIdentifier(_) => EvtTypeIdentifier
+  | EvVoid => EvtVoid
   }
 
 let functionCallToCallSignature = (functionCall: functionCall): functionCallSignature => {


### PR DESCRIPTION
Missing `| EvVoid => EvtVoid`  below is a serious merge introduced bug.

The others are unused variable fixes. Adding _ before variables silences the unused warning as well as not producing the related code.  Until they are used sometime...