### PR TITLE
Padding and loading spinner improvements for the website

### DIFF
--- a/packages/components/src/components/SquigglePlayground.tsx
+++ b/packages/components/src/components/SquigglePlayground.tsx
@@ -533,7 +533,7 @@ export const SquigglePlayground: FC<PlaygroundProps> = ({
     <SquiggleContainer>
       <StyledTab.Group>
         <div className="pb-4">
-          <div className="flex justify-between items-center mt-2">
+          <div className="flex justify-between items-center">
             <StyledTab.List>
               <StyledTab
                 name={vars.showEditor ? "Code" : "Display"}

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-rc.1",
     "@docusaurus/preset-classic": "2.0.0-rc.1",
+    "@heroicons/react": "^1.0.6",
     "@quri/squiggle-components": "^0.2.20",
     "base64-js": "^1.5.1",
     "clsx": "^1.2.1",

--- a/packages/website/src/components/FallbackSpinner.jsx
+++ b/packages/website/src/components/FallbackSpinner.jsx
@@ -3,7 +3,7 @@ import { RefreshIcon } from "@heroicons/react/solid";
 import styles from "./FallbackSpinner.module.css";
 
 export const FallbackSpinner = ({ height }) => {
-  const [show, setShow] = useState(false);
+  const [show, setShow] = useState(/* false */ true);
   useEffect(() => {
     setTimeout(() => {
       setShow(true);

--- a/packages/website/src/components/FallbackSpinner.jsx
+++ b/packages/website/src/components/FallbackSpinner.jsx
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+import { RefreshIcon } from "@heroicons/react/solid";
+import styles from "./FallbackSpinner.module.css";
+
+export const FallbackSpinner = ({ height }) => {
+    const [show, setShow] = useState(false);
+    useEffect(() => {
+        setTimeout(() => {
+            setShow(true);
+        }, 500);
+    }, []);
+    return <div className={styles.container} style={{height}}>{
+        show ? <RefreshIcon className={styles.icon} /> : null
+    }</div>;
+};

--- a/packages/website/src/components/FallbackSpinner.jsx
+++ b/packages/website/src/components/FallbackSpinner.jsx
@@ -3,13 +3,15 @@ import { RefreshIcon } from "@heroicons/react/solid";
 import styles from "./FallbackSpinner.module.css";
 
 export const FallbackSpinner = ({ height }) => {
-    const [show, setShow] = useState(false);
-    useEffect(() => {
-        setTimeout(() => {
-            setShow(true);
-        }, 500);
-    }, []);
-    return <div className={styles.container} style={{height}}>{
-        show ? <RefreshIcon className={styles.icon} /> : null
-    }</div>;
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    setTimeout(() => {
+      setShow(true);
+    }, 500);
+  }, []);
+  return (
+    <div className={styles.container} style={{ height }}>
+      {show ? <RefreshIcon className={styles.icon} /> : null}
+    </div>
+  );
 };

--- a/packages/website/src/components/FallbackSpinner.module.css
+++ b/packages/website/src/components/FallbackSpinner.module.css
@@ -1,9 +1,9 @@
 .container {
-    /* height must be set explicitly */
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  /* height must be set explicitly */
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .icon {

--- a/packages/website/src/components/FallbackSpinner.module.css
+++ b/packages/website/src/components/FallbackSpinner.module.css
@@ -1,0 +1,24 @@
+.container {
+    /* height must be set explicitly */
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.icon {
+  width: 80px;
+  height: 80px;
+  color: #aaa;
+
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/packages/website/src/components/SquiggleEditor.jsx
+++ b/packages/website/src/components/SquiggleEditor.jsx
@@ -3,7 +3,7 @@ import { FallbackSpinner } from "./FallbackSpinner";
 
 export function SquiggleEditor(props) {
   return (
-    <BrowserOnly fallback={<FallbackSpinner height={280} />}>
+    <BrowserOnly fallback={<FallbackSpinner height={292} />}>
       {() => {
         const LibComponent =
           require("@quri/squiggle-components").SquiggleEditor;

--- a/packages/website/src/components/SquiggleEditor.jsx
+++ b/packages/website/src/components/SquiggleEditor.jsx
@@ -1,8 +1,9 @@
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { FallbackSpinner } from "./FallbackSpinner";
 
 export function SquiggleEditor(props) {
   return (
-    <BrowserOnly fallback={<div>Loading...</div>}>
+    <BrowserOnly fallback={<FallbackSpinner height={280} />}>
       {() => {
         const LibComponent =
           require("@quri/squiggle-components").SquiggleEditor;

--- a/packages/website/src/components/SquigglePlayground.jsx
+++ b/packages/website/src/components/SquigglePlayground.jsx
@@ -1,8 +1,9 @@
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import { FallbackSpinner } from "./FallbackSpinner";
 
 export function SquigglePlayground(props) {
   return (
-    <BrowserOnly fallback={<div>Loading...</div>}>
+    <BrowserOnly fallback={<FallbackSpinner height="100vh" />}>
       {() => {
         const LibComponent =
           require("@quri/squiggle-components").SquigglePlayground;

--- a/packages/website/src/pages/playground.js
+++ b/packages/website/src/pages/playground.js
@@ -57,6 +57,7 @@ export default function PlaygroundPage() {
       <div
         style={{
           maxWidth: 2000,
+          padding: 8,
         }}
       >
         <SquigglePlayground {...playgroundProps} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4796,7 +4796,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^18.0.1", "@types/react@^18.0.9":
+"@types/react@*", "@types/react@^18.0.9":
   version "18.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
   integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
@@ -15225,7 +15225,7 @@ react-vega@^7.6.0:
     prop-types "^15.8.1"
     vega-embed "^6.5.1"
 
-react@^18.0.0, react@^18.1.0:
+react@^18.1.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
1) Added padding for the /playground
2) Added a spinner - right now /playground and SquiggleEditor components in the docs show the plain "Loading..." text; I replaced it with the rotating RefreshIcon

Funny thing: the spinner icon doesn't really show. That's because I added a 500ms timeout for it to show, to avoid flickering, and turns out that there's no real client-side latency (even if I set the timeout to zero); editor and playground components are probably bundled together by docusaurus with other JS code, so there's no need to render it at all.

But we should still keep the code since that can change with docusaurus updates and webpack configuration changes.

Just for the reference, spinner would look like this:
<img width="1512" alt="Screenshot 2022-07-23 at 21 53 14" src="https://user-images.githubusercontent.com/89368/180617106-67ed0486-3dcb-46ed-9da2-812721f855e4.png">

Another thing to note is that I had to set the loading component's height manually for the embedded SquiggleEditor instances. I set it to 292px, since that's the current default height of the SquiggleEditor, but that can change in the future. The older version looked like this, and then everything jumped due to height changes:

<img width="891" alt="Screenshot 2022-07-23 at 21 54 11" src="https://user-images.githubusercontent.com/89368/180617150-3b1d5e77-932e-4773-a1e4-a9bf65dcdaf3.png">
.