### PR TITLE
Vscode ext 0.3

### DIFF
--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -117,7 +117,7 @@
     "vscode:prepublish": "yarn run compile",
     "compile:tsc": "tsc -b",
     "compile:grammar": "js-yaml syntaxes/squiggle.tmLanguage.yaml >syntaxes/squiggle.tmLanguage.json",
-    "compile:vendor": "(cd ../squiggle-lang && yarn run build) && (cd ../components && yarn run bundle && yarn run build:css) && mkdir -p media/vendor && cp ../components/dist/bundle.js media/vendor/components.js && cp ../components/dist/main.css media/vendor/components.css && cp ../../node_modules/react/umd/react.production.min.js media/vendor/react.js && cp ../../node_modules/react-dom/umd/react-dom.production.min.js media/vendor/react-dom.js && cp ../website/static/img/quri-logo.png media/vendor/icon.png",
+    "compile:vendor": "(cd ../squiggle-lang && yarn run build) && (cd ../components && yarn run bundle && yarn run build:css) && mkdir -p media/vendor && cp ../components/dist/bundle.js media/vendor/components.js && cp ../components/dist/main.css media/vendor/components.css && cp ../../node_modules/react/umd/react.production.min.js media/vendor/react.js && cp ../../node_modules/react-dom/umd/react-dom.production.min.js media/vendor/react-dom.js && cp ../website/static/img/squiggle-logo.png media/vendor/icon.png",
     "compile": "yarn run compile:vendor && yarn run compile:grammar && yarn run compile:tsc",
     "watch": "tsc -b -watch",
     "pretest": "yarn run compile && yarn run lint",

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -3,7 +3,7 @@
   "displayName": "Squiggle",
   "description": "Squiggle language support",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "QURI",
   "repository": {
     "type": "git",
@@ -11,7 +11,7 @@
   },
   "icon": "media/vendor/icon.png",
   "engines": {
-    "vscode": "^1.68.0"
+    "vscode": "^1.69.0"
   },
   "categories": [
     "Programming Languages",


### PR DESCRIPTION
Just a new build from `develop` branch, with updated icon.

Note: this release is troubled by #910, but it's less critical in vscode, which recovers the preview window automatically. (But when the bug is active, playground menu disappears, and all settings are reset, so it's still a problem).