### PR TITLE
Void bug fixes

### DIFF
--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -59,6 +59,13 @@ export const ExpressionViewer: React.FC<Props> = ({
   expression,
   width,
 }) => {
+  if (typeof expression !== "object") {
+    return (
+      <VariableList path={path} heading="Error">
+        {() => `Unknown expression: ${expression}`}
+      </VariableList>
+    );
+  }
   switch (expression.tag) {
     case "number":
       return (
@@ -281,10 +288,16 @@ export const ExpressionViewer: React.FC<Props> = ({
       );
     default: {
       return (
-        <div>
-          <span>No display for type: </span>{" "}
-          <span className="font-semibold text-slate-600">{expression.tag}</span>
-        </div>
+        <VariableList path={path} heading="Error">
+          {() => (
+            <div>
+              <span>No display for type: </span>{" "}
+              <span className="font-semibold text-slate-600">
+                {expression.tag}
+              </span>
+            </div>
+          )}
+        </VariableList>
       );
     }
   }

--- a/packages/squiggle-lang/src/js/rescript_interop.ts
+++ b/packages/squiggle-lang/src/js/rescript_interop.ts
@@ -18,6 +18,7 @@ import { tagged, tag } from "./types";
 
 // Raw rescript types.
 export type rescriptExport =
+  | 0 // EvVoid
   | {
       TAG: 0; // EvArray
       _0: rescriptExport[];
@@ -140,6 +141,10 @@ export function convertRawToTypescript(
   result: rescriptExport,
   environment: environment
 ): squiggleExpression {
+  if (typeof result === "number") {
+    // EvVoid
+    return tag("void", "");
+  }
   switch (result.TAG) {
     case 0: // EvArray
       return tag(


### PR DESCRIPTION
Fixes #910.

- extra check if an expression is an object, in ExpressionViewer (maybe I didn't have to do that and should've just added and ErrorBoundary, but whatever)
- fix EvVoid bug in rescript_interop