### PR TITLE
Reducer lambda context, hiddenNameSpace

### DIFF
--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_ExternalExpressionValue.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_ExternalExpressionValue.res
@@ -30,13 +30,15 @@ type rec externalExpressionValue =
   | EvType(record)
   | EvVoid
 and record = Js.Dict.t<externalExpressionValue>
-and externalBindings = record
 and lambdaValue = {
   parameters: array<string>,
   context: hiddenNameSpace,
   body: internalCode,
 }
 and lambdaDeclaration = Declaration.declaration<lambdaValue>
+
+@genType
+type externalBindings = record
 
 @genType
 type t = externalExpressionValue

--- a/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_ExternalExpressionValue.res
+++ b/packages/squiggle-lang/src/rescript/ReducerInterface/ReducerInterface_ExternalExpressionValue.res
@@ -7,6 +7,9 @@ module ErrorValue = Reducer_ErrorValue
 @genType.opaque
 type internalCode = Object
 
+@genType.opaque
+type hiddenNameSpace = Object
+
 @genType
 type rec externalExpressionValue =
   | EvArray(array<externalExpressionValue>)
@@ -30,7 +33,7 @@ and record = Js.Dict.t<externalExpressionValue>
 and externalBindings = record
 and lambdaValue = {
   parameters: array<string>,
-  context: externalBindings,
+  context: hiddenNameSpace,
   body: internalCode,
 }
 and lambdaDeclaration = Declaration.declaration<lambdaValue>


### PR DESCRIPTION
ReducerInterface_ExternalExpressionValue.lambdaValue.context has now type hiddenNameSpace (TypeScript fix is needed)

This - as a quick workaround -  reduces memory consumption somewhat and will prevent some of the out of memory problems.

However, the real problem is not gone until we kill the current Rescript to TypeScript conversion.

Bindings that contain lambdas are a Directed Acyclic Graph. Current conversion is converting it to a straight tree and totally duplicating the memory usage many times.

I have been discussing it in https://app.slack.com/client/TEQ28RPAN/C030T49UHSS/thread/C030T49UHSS-1659176091.121849
Maybe I should copy that discussion to GitHub sometime
