### PR TITLE
the last property of a record can have a following comma

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
@@ -27,6 +27,15 @@ describe("eval", () => {
     test("index", () => expectEvalToBe("r = {a: 1}; r.a", "Ok(1)"))
     test("index", () => expectEvalToBe("r = {a: 1}; r.b", "Error(Record property not found: b)"))
     testEvalError("{a: 1}.b") // invalid syntax
+    test("always the same property ending", () =>
+      expectEvalToBe(
+        `{
+      a: 1, 
+      b: 2,
+    }`,
+        "Ok({a: 1,b: 2})",
+      )
+    )
   })
 
   describe("multi-line", () => {

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_GeneratedParser.peggy
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_GeneratedParser.peggy
@@ -277,8 +277,12 @@ arrayConstructor 'array'
     { return [head, ...tail]; }
 
 recordConstructor  'record'
-  = '{' _nl args:array_recordArguments _nl '}' 
+  = '{' _nl args:array_recordArguments _nl end_of_record
   { return h.constructRecord(args); }
+
+  end_of_record 
+    = '}'
+    / ',' _nl '}'
 
   array_recordArguments 
     = head:keyValuePair tail:(_ ',' _nl @keyValuePair)* 


### PR DESCRIPTION
```
    test("always the same property ending", () =>
      expectEvalToBe(
        `{
      a: 1, 
      b: 2,
    }`,
        "Ok({a: 1,b: 2})",
      )
    )

```