### PR TITLE
Fix example in squiggle-lang README

### DIFF
--- a/packages/squiggle-lang/README.md
+++ b/packages/squiggle-lang/README.md
@@ -20,7 +20,7 @@ environment created from the squiggle code.
 ```js
 import { run } from "@quri/squiggle-lang";
 run(
-  "normal(0, 1) * fromSamples([-3,-2,-1,1,2,3,3,3,4,9]"
+  "normal(0, 1) * SampleSet.fromList([-3, 2,-1,1,2,3,3,3,4,9])"
 ).value.value.toSparkline().value;
 ```
 


### PR DESCRIPTION
The example in the squiggle-lang README was missing a close paren.

Also, it was using `fromSamples`, which seems  (as far as I can tell from a quick look at the git history) to have been replaced with `SampleSet.fromList([-3, 2,-1,1,2,3,3,3,4,9])` at some point.