### PR TITLE
fix: Update vscode ext manifest repository link

### DIFF
--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -7,7 +7,7 @@
   "publisher": "QURI",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/quantified-uncertainty/squiggle.git"
+    "url": "https://github.com/quantified-uncertainty/squiggle.git"
   },
   "icon": "media/vendor/icon.png",
   "engines": {


### PR DESCRIPTION
One liner - Updates the vscode extension repository link in the manifest so as not to get the following error in vscode:

<img width="1012" alt="Screen Shot 2022-08-22 at 11 11 10" src="https://user-images.githubusercontent.com/363965/185968259-b3a65167-93b1-4bed-a643-efe9636753ed.png">

When clicking the repo link in the vscode extension page:
<img width="1206" alt="Screen Shot 2022-08-22 at 11 09 18" src="https://user-images.githubusercontent.com/363965/185968360-00baa048-5f5f-4400-a69f-806e5bc27765.png">

