### PR TITLE
Changed getByWithFn to not need two function calls

### DIFF
--- a/packages/squiggle-lang/__tests__/E/A_test.res
+++ b/packages/squiggle-lang/__tests__/E/A_test.res
@@ -1,21 +1,21 @@
 open Jest
 open TestHelpers
 
-describe("E.A.getByWithFn", () => {
-  makeTest("Empty list returns None", E.A.getByWithFn([], x => x + 1, x => mod(x, 2) == 0), None)
+describe("E.A.getByFmap", () => {
+  makeTest("Empty list returns None", E.A.getByFmap([], x => x + 1, x => mod(x, 2) == 0), None)
   makeTest(
     "Never predicate returns None",
-    E.A.getByWithFn([1, 2, 3, 4, 5, 6], x => x + 1, _ => false),
+    E.A.getByFmap([1, 2, 3, 4, 5, 6], x => x + 1, _ => false),
     None,
   )
   makeTest(
     "function evaluates",
-    E.A.getByWithFn([1, 1, 1, 1, 1, 1, 1, 2, 1, 1], x => 3 * x, x => x > 4),
+    E.A.getByFmap([1, 1, 1, 1, 1, 1, 1, 2, 1, 1], x => 3 * x, x => x > 4),
     Some(6),
   )
   makeTest(
     "always predicate returns fn(fst(a))",
-    E.A.getByWithFn([0, 1, 2, 3, 4, 5, 6], x => 10 + x, _ => true),
+    E.A.getByFmap([0, 1, 2, 3, 4, 5, 6], x => 10 + x, _ => true),
     Some(10),
   )
 })

--- a/packages/squiggle-lang/__tests__/E/A_test.res
+++ b/packages/squiggle-lang/__tests__/E/A_test.res
@@ -1,0 +1,21 @@
+open Jest
+open TestHelpers
+
+describe("E.A.getByWithFn", () => {
+  makeTest("Empty list returns None", E.A.getByWithFn([], x => x + 1, x => mod(x, 2) == 0), None)
+  makeTest(
+    "Never predicate returns None",
+    E.A.getByWithFn([1, 2, 3, 4, 5, 6], x => x + 1, _ => false),
+    None,
+  )
+  makeTest(
+    "function evaluates",
+    E.A.getByWithFn([1, 1, 1, 1, 1, 1, 1, 2, 1, 1], x => 3 * x, x => x > 4),
+    Some(6),
+  )
+  makeTest(
+    "always predicate returns fn(fst(a))",
+    E.A.getByWithFn([0, 1, 2, 3, 4, 5, 6], x => 10 + x, _ => true),
+    Some(10),
+  )
+})

--- a/packages/squiggle-lang/src/rescript/Utility/E.res
+++ b/packages/squiggle-lang/src/rescript/Utility/E.res
@@ -572,11 +572,21 @@ module A = {
       |> (x => Ok(x))
     }
 
-  let getByOpen = (a, op, bin) =>
-    switch getBy(a, r => bin(op(r))) {
-    | Some(r) => Some(op(r))
-    | None => None
+  let getByWithFn = (a, fn, boolCondition) => {
+    let i = ref(0);
+    let finalFunctionValue = ref(None);
+    let length = Belt.Array.length(a);
+
+    while (i.contents < length) && (finalFunctionValue.contents == None) {
+      let itemWithFnApplied = Belt.Array.getUnsafe(a, i.contents) |> fn
+      if boolCondition(itemWithFnApplied) {
+        finalFunctionValue := Some(itemWithFnApplied)
+      }
+      i := i.contents + 1
     }
+
+    finalFunctionValue.contents
+  }
 
   let tail = Belt.Array.sliceToEnd(_, 1)
 
@@ -680,7 +690,7 @@ module A = {
     let firstSome = x => Belt.Array.getBy(x, O.isSome)
 
     let firstSomeFn = (r: array<unit => option<'a>>): option<'a> =>
-      O.flatten(getByOpen(r, l => l(), O.isSome))
+      O.flatten(getByWithFn(r, l => l(), O.isSome))
 
     let firstSomeFnWithDefault = (r, default) => firstSomeFn(r)->O2.default(default)
 

--- a/packages/squiggle-lang/src/rescript/Utility/E.res
+++ b/packages/squiggle-lang/src/rescript/Utility/E.res
@@ -572,7 +572,7 @@ module A = {
       |> (x => Ok(x))
     }
 
-  let getByWithFn = (a, fn, boolCondition) => {
+  let getByFmap = (a, fn, boolCondition) => {
     let i = ref(0)
     let finalFunctionValue = ref(None)
     let length = Belt.Array.length(a)
@@ -690,7 +690,7 @@ module A = {
     let firstSome = x => Belt.Array.getBy(x, O.isSome)
 
     let firstSomeFn = (r: array<unit => option<'a>>): option<'a> =>
-      O.flatten(getByWithFn(r, l => l(), O.isSome))
+      O.flatten(getByFmap(r, l => l(), O.isSome))
 
     let firstSomeFnWithDefault = (r, default) => firstSomeFn(r)->O2.default(default)
 

--- a/packages/squiggle-lang/src/rescript/Utility/E.res
+++ b/packages/squiggle-lang/src/rescript/Utility/E.res
@@ -573,11 +573,11 @@ module A = {
     }
 
   let getByWithFn = (a, fn, boolCondition) => {
-    let i = ref(0);
-    let finalFunctionValue = ref(None);
-    let length = Belt.Array.length(a);
+    let i = ref(0)
+    let finalFunctionValue = ref(None)
+    let length = Belt.Array.length(a)
 
-    while (i.contents < length) && (finalFunctionValue.contents == None) {
+    while i.contents < length && finalFunctionValue.contents == None {
       let itemWithFnApplied = Belt.Array.getUnsafe(a, i.contents) |> fn
       if boolCondition(itemWithFnApplied) {
         finalFunctionValue := Some(itemWithFnApplied)


### PR DESCRIPTION
Addresses https://github.com/quantified-uncertainty/squiggle/issues/1040

From a quick read, this seems to address the main discrepancy between typing
```
fn(1) + fn(1) + fn(1)...
```
and 
```
reduce(0, {|acc,b| acc + fn(b)})
```