### PR TITLE
explicit and minimal dependabot labels config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,13 @@ updates:
     commit-message:
       prefix: "⬆️"
     open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "⬆️"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Recently dependabot started to tag its PRs with `javascript` and `github_actions` labels. This PR disables both and leaves only `dependencies` label.

(otherwise we might accidentally start using these labels in our issues, and they don't add any value, only visual noise)