### PR TITLE
Squiggle environment access

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_environment_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_environment_test.res
@@ -1,0 +1,17 @@
+open Jest
+open Reducer_Peggy_TestHelpers
+
+describe("Environment Accesss", () => {
+  testToExpression(
+    "environment",
+    "{(:$_endOfOuterBlock_$ () (:$$_environment_$$))}",
+    ~v=`{sampleCount: ${ReducerInterface_InternalExpressionValue.defaultEnvironment.sampleCount->Js.Int.toString},xyPointLength: ${ReducerInterface_InternalExpressionValue.defaultEnvironment.xyPointLength->Js.Int.toString}}`,
+    (),
+  )
+  testToExpression(
+    "withEnvironmentSampleCount(100, environment.sampleCount)",
+    "{(:$_endOfOuterBlock_$ () (:$$_withEnvironmentSampleCount_$$ 100 (:$_atIndex_$ (:$$_environment_$$) 'sampleCount')))}",
+    ~v="100",
+    (),
+  )
+})

--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_environment_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_environment_test.res
@@ -3,15 +3,35 @@ open Reducer_Peggy_TestHelpers
 
 describe("Environment Accesss", () => {
   testToExpression(
-    "environment",
-    "{(:$_endOfOuterBlock_$ () (:$$_environment_$$))}",
-    ~v=`{sampleCount: ${ReducerInterface_InternalExpressionValue.defaultEnvironment.sampleCount->Js.Int.toString},xyPointLength: ${ReducerInterface_InternalExpressionValue.defaultEnvironment.xyPointLength->Js.Int.toString}}`,
+    "Environment.sampleCount",
+    "{(:$_endOfOuterBlock_$ () (:$_atIndex_$ (:$$_environment_$$) 'sampleCount'))}",
+    ~v=ReducerInterface_InternalExpressionValue.defaultEnvironment.sampleCount->Js.Int.toString,
     (),
   )
   testToExpression(
-    "withEnvironmentSampleCount(100, environment.sampleCount)",
+    "Environment.withSampleCount(100, Environment.sampleCount)",
     "{(:$_endOfOuterBlock_$ () (:$$_withEnvironmentSampleCount_$$ 100 (:$_atIndex_$ (:$$_environment_$$) 'sampleCount')))}",
     ~v="100",
+    (),
+  )
+  testToExpression(
+    "Environment.withSampleCount(100, 99)",
+    "{(:$_endOfOuterBlock_$ () (:$$_withEnvironmentSampleCount_$$ 100 99))}",
+    ~v="99",
+    (),
+  )
+
+  testToExpression(
+    "f(x) = Environment.withSampleCount(999, Environment.sampleCount+1); f(1)",
+    "{(:$_let_$ :f (:$$_lambda_$$ [x] {(:$$_withEnvironmentSampleCount_$$ 999 (:add (:$_atIndex_$ (:$$_environment_$$) 'sampleCount') 1))})); (:$_endOfOuterBlock_$ () (:f 1))}",
+    ~v="1000",
+    (),
+  )
+
+  testToExpression(
+    "f(x) = Environment.sampleCount+1; Environment.withSampleCount(999, f(1))",
+    "{(:$_let_$ :f (:$$_lambda_$$ [x] {(:add (:$_atIndex_$ (:$$_environment_$$) 'sampleCount') 1)})); (:$_endOfOuterBlock_$ () (:$$_withEnvironmentSampleCount_$$ 999 (:f 1)))}",
+    ~v="1000",
     (),
   )
 })

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltInMacros.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Dispatch/Reducer_Dispatch_BuiltInMacros.res
@@ -169,13 +169,15 @@ let dispatchMacroCall = (
     | InternalExpressionValue.IEvNumber(sampleCount) => {
         let newEnvironment = {...accessors.environment, sampleCount: Js.Math.floor(sampleCount)}
         let newAccessors = {...accessors, environment: newEnvironment}
-        reduceExpression(expr, bindings, newAccessors)
+        let exprBlock = eBlock(list{expr})
+        reduceExpression(exprBlock, bindings, newAccessors)
         ->ExpressionT.EValue
         ->ExpressionWithContext.noContext
       }
     | _ => REExpectedType("Number", "")->Reducer_ErrorValue.toException
     }
   }
+
   let expandExpressionList = (
     aList,
     bindings: ExpressionT.bindings,
@@ -213,8 +215,8 @@ let dispatchMacroCall = (
     | list{ExpressionT.EValue(IEvCall("$$_environment_$$"))} => doEnvironment(accessors)
     | list{
         ExpressionT.EValue(IEvCall("$$_withEnvironmentSampleCount_$$")),
-        expr,
         sampleCountExpr,
+        expr,
       } =>
       doWithEnvironmentSampleCount(sampleCountExpr, expr, bindings, accessors)
     | _ => ExpressionWithContext.noContext(ExpressionT.EList(aList))

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Expression/Reducer_Expression.res
@@ -22,7 +22,7 @@ let rec reduceExpressionInProject = (
   continuation: T.bindings,
   accessors: ProjectAccessorsT.t,
 ): result<InternalExpressionValue.t, 'e> => {
-  // Js.log(`reduce: ${T.toString(expression)} bindings: ${bindings->Bindings.toString}`)
+  // `reduce: ${T.toString(expression)}`->Js.log
   switch expression {
   | T.EValue(value) => value->Ok
   | T.EList(list) =>

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression.res
@@ -17,14 +17,35 @@ let rec fromNode = (node: Parse.node): expression => {
     ExpressionBuilder.eFunction("$$_lambda_$$", list{args, body})
   }
 
+  // Convert function calls to macro calls
+  let caseCallIdentifier = (nodeCallIdentifier: Parse.nodeCallIdentifier): expression => {
+    let callIdentifier = nodeCallIdentifier["value"]
+    // `callIdentifier ${callIdentifier}`->Js.log
+    let callValue = switch callIdentifier {
+    | "withEnvironmentSampleCount" => "$$_withEnvironmentSampleCount_$$"
+    | callName => callName
+    }
+    ExpressionBuilder.eCall(callValue)
+  }
+
+  // Convert identifiers to macro calls
+  let caseIdentifier = (nodeIdentifier: Parse.nodeIdentifier): expression => {
+    let identifier = nodeIdentifier["value"]
+    // `caseIdentifier ${identifier}`->Js.log
+    switch identifier {
+    | "environment" => "$$_environment_$$"->ExpressionBuilder.eFunction(list{})
+    | symbol => symbol->ExpressionBuilder.eSymbol
+    }
+  }
+
   switch Parse.castNodeType(node) {
   | PgNodeBlock(nodeBlock) => caseBlock(nodeBlock)
   | PgNodeBoolean(nodeBoolean) => ExpressionBuilder.eBool(nodeBoolean["value"])
-  | PgNodeCallIdentifier(nodeCallIdentifier) => ExpressionBuilder.eCall(nodeCallIdentifier["value"])
+  | PgNodeCallIdentifier(nodeCallIdentifier) => caseCallIdentifier(nodeCallIdentifier)
   | PgNodeExpression(nodeExpression) =>
     ExpressionT.EList(nodeExpression["nodes"]->Js.Array2.map(fromNode)->Belt.List.fromArray)
   | PgNodeFloat(nodeFloat) => ExpressionBuilder.eNumber(nodeFloat["value"])
-  | PgNodeIdentifier(nodeIdentifier) => ExpressionBuilder.eSymbol(nodeIdentifier["value"])
+  | PgNodeIdentifier(nodeIdentifier) => caseIdentifier(nodeIdentifier)
   | PgNodeInteger(nodeInteger) => ExpressionBuilder.eNumber(Belt.Int.toFloat(nodeInteger["value"]))
   | PgNodeKeyValue(nodeKeyValue) =>
     ExpressionT.EList(list{fromNode(nodeKeyValue["key"]), fromNode(nodeKeyValue["value"])})

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression.res
@@ -33,7 +33,11 @@ let rec fromNode = (node: Parse.node): expression => {
     let identifier = nodeIdentifier["value"]
     // `caseIdentifier ${identifier}`->Js.log
     switch identifier {
-    | "System.environment" => "$$_environment_$$"->ExpressionBuilder.eFunction(list{})
+    | "Environment.sampleCount" =>
+      "$_atIndex_$"->ExpressionBuilder.eFunction(list{
+        "$$_environment_$$"->ExpressionBuilder.eFunction(list{}),
+        ExpressionBuilder.eString("sampleCount"),
+      })
     | symbol => symbol->ExpressionBuilder.eSymbol
     }
   }

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_ToExpression.res
@@ -22,7 +22,7 @@ let rec fromNode = (node: Parse.node): expression => {
     let callIdentifier = nodeCallIdentifier["value"]
     // `callIdentifier ${callIdentifier}`->Js.log
     let callValue = switch callIdentifier {
-    | "withEnvironmentSampleCount" => "$$_withEnvironmentSampleCount_$$"
+    | "Environment.withSampleCount" => "$$_withEnvironmentSampleCount_$$"
     | callName => callName
     }
     ExpressionBuilder.eCall(callValue)
@@ -33,7 +33,7 @@ let rec fromNode = (node: Parse.node): expression => {
     let identifier = nodeIdentifier["value"]
     // `caseIdentifier ${identifier}`->Js.log
     switch identifier {
-    | "environment" => "$$_environment_$$"->ExpressionBuilder.eFunction(list{})
+    | "System.environment" => "$$_environment_$$"->ExpressionBuilder.eFunction(list{})
     | symbol => symbol->ExpressionBuilder.eSymbol
     }
   }


### PR DESCRIPTION
- environment is accessible from Squiggle
- expressions can run in a modified environment

**Examples**
`Environment.withSampleCount(100, Environment.sampleCount) == 100`
`f(x) = Environment.withSampleCount(999, Environment.sampleCount+1); f(1) == 1000`
`f(x) = Environment.sampleCount+1; Environment.withSampleCount(999, f(1)) == 1000`