### PR TITLE
fix sampleset -> pointset sorting sideeffects

### DIFF
--- a/packages/squiggle-lang/src/rescript/Distributions/SampleSetDist/SampleSetDist_ToPointSet.res
+++ b/packages/squiggle-lang/src/rescript/Distributions/SampleSetDist/SampleSetDist_ToPointSet.res
@@ -62,6 +62,7 @@ let toPointSetDist = (
   ~samplingInputs: SamplingInputs.samplingInputs,
   (),
 ): Internals.Types.outputs => {
+  let samples = Js.Array2.copy(samples)
   Array.fast_sort(compare, samples)
   let minDiscreteToKeep = MagicNumbers.ToPointSet.minDiscreteToKeep(samples)
   let (continuousPart, discretePart) = E.A.Floats.Sorted.splitContinuousAndDiscreteForMinWeight(


### PR DESCRIPTION
Converting samplesets to pointsets makes the original sampleset sorted. Even as a side-effect from calling some function on a sampleset.

[https://develop--squiggle-documentation.netlify.app/playground/#code=eNp9jL0OgjAURl%2FlphMkKLiS6KSbW0dgK[…]WTAyr3w2cYQKKiY3uw%2Fin2KlqHMTrDfnyS2k%3D](https://develop--squiggle-documentation.netlify.app/playground/#code=eNp9jL0OgjAURl%2FlphMkKLiS6KSbW0dgKPTHm9BWey9Ro767jYlxcz3f%2Bc5D0Cle5eK9SnfRclpM9UEHjRzTl2BARjXLy4LOzUZywuBEKwi2EGLyai6aalPCcwdS%2BXM2DK9tin6PxH1QWftxjsdMCyq7ZujDLW%2BTtgVVkAN1DYTagLHWTAyr3w2cYQKKiY3uw%2Fin2KlqHMTrDfnyS2k%3D)

This PR fixes it (with slight performance costs).