### PR TITLE
components v0.4.3 - fix build

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quri/squiggle-components",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "license": "MIT",
   "dependencies": {
     "@floating-ui/react-dom": "^1.0.0",
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "start": "cross-env REACT_APP_FAST_REFRESH=false && start-storybook -p 6006 -s public",
-    "build:cjs": "rm -rf dist/src && tsc -b",
+    "build:cjs": "rm -rf dist/src && rm -f dist/tsconfig.tsbuildinfo && tsc -b",
     "build:css": "postcss ./src/styles/main.css -o ./dist/main.css",
     "build:storybook": "build-storybook -s public",
     "build": "yarn run build:cjs && yarn run build:css && yarn run build:storybook",


### PR DESCRIPTION
In #1068 I added `rm -rf dist/src/` to fix stale files from previous builds.

This backfired and lead to invalid 0.4.2 release. Looks like `dist/tsconfig.tsbuildinfo` tracks the info about which files are already built, so rebuilds didn't generate .js files at all.

There's probably a better way to solve this, but this PR should be enough to fix the build for now.