### PR TITLE
English language pedantry: Fix use of 'prefix' in docs

### DIFF
--- a/packages/website/docs/Guides/Language.mdx
+++ b/packages/website/docs/Guides/Language.mdx
@@ -86,11 +86,11 @@ c = 5 to 10 // namespace not required
 ""`}
 />
 
-## Number Prefixes
+## Number Suffixes
 
-Numbers support a few scientific notation prefixes.
+Numbers support a few scientific notation suffixes.
 
-| prefix | multiplier |
+| suffix | multiplier |
 | ------ | ---------- |
 | n      | 10^-9      |
 | m      | 10^-3      |


### PR DESCRIPTION
I was briefly confused by the use of the word 'prefix' for a postfix.

prefixes come before, postfixes come after, suffixes is a generic term

