### PR TITLE
feature: List.length

### DIFF
--- a/packages/squiggle-lang/__tests__/SquiggleLibrary/SquiggleLibrary_FunctionRegistryLibrary_test.res
+++ b/packages/squiggle-lang/__tests__/SquiggleLibrary/SquiggleLibrary_FunctionRegistryLibrary_test.res
@@ -10,6 +10,8 @@ let examples = E.A.to_list(FunctionRegistry_Core.Registry.allExamples(registry))
 
 describe("FunctionRegistry Library", () => {
   describe("Regular tests", () => {
+    testEvalToBe("List.length([3,5,8])", "Ok(3)")
+    testEvalToBe("List.length([])", "Ok(0)")
     testEvalToBe("List.make(3, 'HI')", "Ok(['HI','HI','HI'])")
     testEvalToBe("make(3, 'HI')", "Error(make is not defined)")
     testEvalToBe("List.upTo(1,3)", "Ok([1,2,3])")

--- a/packages/squiggle-lang/src/rescript/FR/FR_List.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_List.res
@@ -5,6 +5,10 @@ let nameSpace = "List"
 let requiresNamespace = true
 
 module Internals = {
+  let length = (v: array<Reducer_T.value>): Reducer_T.value => IEvNumber(
+    Belt.Int.toFloat(Array.length(v)),
+  )
+
   let makeFromNumber = (n: float, value: Reducer_T.value): Reducer_T.value => IEvArray(
     Belt.Array.make(E.Float.toInt(n), value),
   )
@@ -75,6 +79,26 @@ module Internals = {
 }
 
 let library = [
+  Function.make(
+    ~name="length",
+    ~nameSpace,
+    ~output=EvtNumber,
+    ~requiresNamespace=false,
+    ~examples=[`List.length([1,4,5])`],
+    ~definitions=[
+      FnDefinition.make(
+        ~name="length",
+        ~inputs=[FRTypeArray(FRTypeAny)],
+        ~run=(inputs, _, _) =>
+          switch inputs {
+          | [IEvArray(array)] => Internals.length(array)->Ok
+          | _ => Error(impossibleError)
+          },
+        (),
+      ),
+    ],
+    (),
+  ),
   Function.make(
     ~name="make",
     ~nameSpace,

--- a/packages/squiggle-lang/src/rescript/FR/FR_List.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_List.res
@@ -83,7 +83,7 @@ let library = [
     ~name="length",
     ~nameSpace,
     ~output=EvtNumber,
-    ~requiresNamespace=false,
+    ~requiresNamespace=true,
     ~examples=[`List.length([1,4,5])`],
     ~definitions=[
       FnDefinition.make(


### PR DESCRIPTION
closes #1217

List length:
* `List.length([1, 2, 3])` = 3
* `List.length([])` = 0

The documentation already included this function, but it was not present in the library.