### PR TITLE
fetch-depth for coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - name: Setup Node.js environment
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Codecov complains that it can't detect a SHA on PRs. This PR should fix that.