### PR TITLE
nix: remove bisect_ppx from build

### DIFF
--- a/nix/squiggle-lang.nix
+++ b/nix/squiggle-lang.nix
@@ -30,16 +30,6 @@ rec {
           patchelf --replace-needed libstdc++.so.6 $THE_SO linux/ninja.exe && echo "- replaced needed for linux/ninja.exe"
         '';
       };
-      bisect_ppx = {
-        buildInputs = common.which;
-        postInstall = ''
-          echo "PATCHELF'ING BISECT_PPX EXECUTABLE"
-          THE_LD=$(patchelf --print-interpreter $(which mkdir))
-          patchelf --set-interpreter $THE_LD bin/linux/ppx
-          patchelf --set-interpreter $THE_LD bin/linux/bisect-ppx-report
-          cp bin/linux/ppx ppx
-        '';
-      };
       gentype = {
         postInstall = ''
           mv gentype.exe ELFLESS-gentype.exe


### PR DESCRIPTION
Checked that the flake#lang still builds, at least on sandboxed x86_64-linux