### PR TITLE
Restore parse() in squiggle-lang; use it in VS Code extension

### DIFF
--- a/packages/squiggle-lang/src/js/index.ts
+++ b/packages/squiggle-lang/src/js/index.ts
@@ -15,6 +15,7 @@ export {
 } from "../rescript/ForTS/ForTS_Distribution/ForTS_Distribution.gen";
 export { SqError, SqFrame, SqLocation } from "./SqError";
 export { SqShape } from "./SqPointSetDist";
+export { parse } from "./parse";
 
 export { resultMap } from "./types";
 

--- a/packages/squiggle-lang/src/js/parse.ts
+++ b/packages/squiggle-lang/src/js/parse.ts
@@ -1,23 +1,27 @@
-// import {
-//   errorValue,
-//   parse as parseRescript,
-// } from "../rescript/TypescriptInterface.gen";
-// import { result } from "./types";
-// import { AnyPeggyNode } from "../rescript/Reducer/Reducer_Peggy/helpers";
+import * as RSParse from "../rescript/Reducer/Reducer_Peggy/Reducer_Peggy_Parse.gen";
+import { result, resultMap2 } from "./types";
+import { AnyPeggyNode } from "../rescript/Reducer/Reducer_Peggy/helpers";
+import { SqLocation } from "./SqError";
 
-// export function parse(
-//   squiggleString: string
-// ): result<AnyPeggyNode, Extract<errorValue, { tag: "RESyntaxError" }>> {
-//   const maybeExpression = parseRescript(squiggleString);
-//   if (maybeExpression.tag === "Ok") {
-//     return { tag: "Ok", value: maybeExpression.value as AnyPeggyNode };
-//   } else {
-//     if (
-//       typeof maybeExpression.value !== "object" ||
-//       maybeExpression.value.tag !== "RESyntaxError"
-//     ) {
-//       throw new Error("Expected syntax error");
-//     }
-//     return { tag: "Error", value: maybeExpression.value };
-//   }
-// }
+export class SqParseError {
+  constructor(private _value: RSParse.ParseError_t) {}
+
+  getMessage() {
+    return RSParse.ParseError_getMessage(this._value);
+  }
+
+  getLocation(): SqLocation {
+    return RSParse.ParseError_getLocation(this._value);
+  }
+}
+
+export function parse(
+  squiggleString: string
+): result<AnyPeggyNode, SqParseError> {
+  const parseResult = RSParse.parse(squiggleString, "main");
+  return resultMap2(
+    parseResult,
+    (ast) => ast as AnyPeggyNode,
+    (error: RSParse.ParseError_t) => new SqParseError(error)
+  );
+}

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_Parse.res
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_Parse.res
@@ -14,7 +14,18 @@ type location = {
 
 type node = {"type": string, "location": location}
 
-type parseError = SyntaxError(string, location)
+module ParseError = {
+  @genType.opaque
+  type t = SyntaxError(string, location)
+
+  @genType
+  let getMessage = (SyntaxError(message, _): t) => message
+
+  @genType
+  let getLocation = (SyntaxError(_, location): t) => location
+}
+
+type parseError = ParseError.t
 
 type parseResult = result<node, parseError>
 
@@ -26,6 +37,7 @@ external castWithLocation: Js.Exn.t => withLocation = "%identity"
 
 let syntaxErrorToLocation = (error: Js.Exn.t): location => castWithLocation(error)["location"]
 
+@genType
 let parse = (expr: string, source: string): parseResult =>
   try {
     Ok(parse__(expr, {"grammarSource": source}))
@@ -169,7 +181,7 @@ let rec pgToString = (ast: ast): string => {
 and toString = (node: node): string => node->nodeToAST->pgToString
 
 let toStringError = (error: parseError): string => {
-  let SyntaxError(message, _) = error
+  let ParseError.SyntaxError(message, _) = error
   `Syntax Error: ${message}}`
 }
 

--- a/packages/vscode-ext/.gitignore
+++ b/packages/vscode-ext/.gitignore
@@ -1,6 +1,5 @@
 /media/vendor
-/client/out
-/server/out
 /*.vsix
 /syntaxes/*.json
 dist
+/out

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -22,7 +22,7 @@
     "onCustomEditor:squiggle.wysiwyg",
     "onCommand:squiggle.preview"
   ],
-  "main": "./dist/src/client/extension.js",
+  "main": "./dist/client/extension.js",
   "contributes": {
     "languages": [
       {
@@ -139,7 +139,7 @@
     "vscode-languageclient": "^8.0.2",
     "vscode-languageserver": "^8.0.2",
     "vscode-languageserver-textdocument": "^1.0.7",
-    "@quri/squiggle-lang": "^0.2.11",
+    "@quri/squiggle-lang": "*",
     "@quri/squiggle-components": "*"
   }
 }

--- a/packages/vscode-ext/src/client/client.ts
+++ b/packages/vscode-ext/src/client/client.ts
@@ -13,7 +13,7 @@ let client: LanguageClient;
 export const startClient = (context: vscode.ExtensionContext) => {
   // The server is implemented in node
   let serverModule = context.asAbsolutePath(
-    path.join("dist", "src", "server", "server.js")
+    path.join("dist", "server", "server.js")
   );
   // The debug options for the server
   // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

--- a/packages/vscode-ext/src/client/highlight.ts
+++ b/packages/vscode-ext/src/client/highlight.ts
@@ -21,8 +21,9 @@ const populateTokensBuilder = (
   // bindings: { [key: string]: boolean }
 ) => {
   switch (node.type) {
-    case "Expression":
-      for (const child of node.nodes) {
+    case "Call":
+      populateTokensBuilder(tokensBuilder, node.fn);
+      for (const child of node.args) {
         populateTokensBuilder(tokensBuilder, child);
       }
       break;

--- a/packages/vscode-ext/src/server/server.ts
+++ b/packages/vscode-ext/src/server/server.ts
@@ -44,7 +44,6 @@ async function validateSquiggleDocument(
   const diagnostics: Diagnostic[] = [];
 
   const parseResult = parse(text);
-  console.log(parseResult);
   if (parseResult.tag === "Error") {
     const location = parseResult.value.getLocation();
     diagnostics.push({

--- a/packages/vscode-ext/src/server/server.ts
+++ b/packages/vscode-ext/src/server/server.ts
@@ -44,8 +44,9 @@ async function validateSquiggleDocument(
   const diagnostics: Diagnostic[] = [];
 
   const parseResult = parse(text);
+  console.log(parseResult);
   if (parseResult.tag === "Error") {
-    const location = parseResult.value.value[1];
+    const location = parseResult.value.getLocation();
     diagnostics.push({
       severity: DiagnosticSeverity.Error,
       range: {
@@ -58,7 +59,7 @@ async function validateSquiggleDocument(
           character: location.end.column - 1,
         },
       },
-      message: parseResult.value.value[0],
+      message: parseResult.value.getMessage(),
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,7 +1524,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.6", "@babel/runtime@^7.18.9", "@babel/runtime@^7.19.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.6", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
   integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
@@ -2998,18 +2998,6 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
   integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
-"@quri/squiggle-lang@^0.2.11":
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/@quri/squiggle-lang/-/squiggle-lang-0.2.12.tgz#e8fdb22a84aa75df71c071d1ed4ae5c55f15d447"
-  integrity sha512-fgv9DLvPlX/TqPSacKSW3GZ5S9H/YwqaMoRdFrn5SJjHnnMh/xJW/9iyzzgOxPCXov9xFeDvL159tkbStMm7vw==
-  dependencies:
-    "@rescript/std" "^9.1.4"
-    "@stdlib/stats" "^0.0.13"
-    jstat "^1.9.5"
-    lodash "^4.17.21"
-    mathjs "^11.0.1"
-    pdfast "^0.2.0"
-
 "@react-hook/latest@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"
@@ -3041,11 +3029,6 @@
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@rescript/std/-/std-10.0.0.tgz#11996296739d7f0d2949283c93b4d14e9ed4589d"
   integrity sha512-DFwX5vWASZtvjFdqar2VIadvmy2ZBPTnPI2A9EKEkvNR93OUoZygOfvhRaueIQtlS4f9X50E3v2awI9JJG+JsQ==
-
-"@rescript/std@^9.1.4":
-  version "9.1.4"
-  resolved "https://registry.yarnpkg.com/@rescript/std/-/std-9.1.4.tgz#94971cb504b10d36d470618fa1c6f0a2d03a6b9b"
-  integrity sha512-OHBORysVe6vmyllL24S2sXiwLGrpVRbZW5k2FverbjY3QF81VoyCRYL6kMOSNMEn9GseO/oDubK8+nvVzCSVMA==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -7400,11 +7383,6 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
-complex.js@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.1.1.tgz#0675dac8e464ec431fb2ab7d30f41d889fb25c31"
-  integrity sha512-8njCHOTtFFLtegk6zQo0kkVX1rngygb/KQI6z1qZxlFI3scluC+LVTCFbrkWjBv4vvLlbQ9t88IPMC6k95VTTg==
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -9033,11 +9011,6 @@ escape-html@^1.0.3, escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
-
-escape-latex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/escape-latex/-/escape-latex-1.2.0.tgz#07c03818cf7dac250cce517f4fda1b001ef2bca1"
-  integrity sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -11595,11 +11568,6 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
-javascript-natural-sort@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
-  integrity sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==
-
 jest-changed-files@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.5.1.tgz#a348aed00ec9bf671cc58a66fcbe7c3dfd6a68f5"
@@ -13121,21 +13089,6 @@ markdown-it@^12.3.2:
     linkify-it "^3.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
-
-mathjs@^11.0.1:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/mathjs/-/mathjs-11.3.0.tgz#17d7504ab27445b3c7e847f6de4cef26e16381e6"
-  integrity sha512-HAUFLxyH8WMSDisNljQFIKjp//d1iL0C36nhGEJFwzdMb46gACMG1E8Ze06sES4hJ5jHDv5ieq7r3mDDcU/d4g==
-  dependencies:
-    "@babel/runtime" "^7.19.4"
-    complex.js "^2.1.1"
-    decimal.js "^10.4.1"
-    escape-latex "^1.2.0"
-    fraction.js "^4.2.0"
-    javascript-natural-sort "^0.7.1"
-    seedrandom "^3.0.5"
-    tiny-emitter "^2.1.0"
-    typed-function "^4.1.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -16679,11 +16632,6 @@ section-matter@^1.0.0:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
 
-seedrandom@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
-  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
-
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -17893,11 +17841,6 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-emitter@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
-  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
-
 tiny-invariant@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
@@ -18273,11 +18216,6 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-typed-function@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/typed-function/-/typed-function-4.1.0.tgz#da4bdd8a6d19a89e22732f75e4a410860aaf9712"
-  integrity sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==
 
 typed-rest-client@^1.8.4:
   version "1.8.9"


### PR DESCRIPTION
For a few releases vscode extension depended on the old @quri/squiggle-lang for `parse()` (syntax errors and semantic highlighting).

This PR brings back the parse functionality and adapts the VS Code extension to use it.

It also fixes a few bugs with the VS Code extension build process.