### PR TITLE
turbo lint depends on build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "pipeline": {
-    "lint": {
-      "outputs": []
-    },
-    "format": {},
     "build": {
       "dependsOn": ["^build"]
     },
@@ -24,6 +20,11 @@
         "src/rescript/**/*.gen.tsx",
         "dist/**"
       ]
+    },
+    "format": {},
+    "lint": {
+      "dependsOn": ["^build"],
+      "outputs": []
     },
     "test": {
       "dependsOn": ["build"],


### PR DESCRIPTION
We can optimize this later (only vscode-ext lint step depends on squiggle-lang build, and I'm still not even sure if `tsc` belongs in the `lint` step).