### PR TITLE
Documentation fixes

### DIFF
--- a/packages/website/docs/Guides/DistributionCreation.mdx
+++ b/packages/website/docs/Guides/DistributionCreation.mdx
@@ -70,8 +70,8 @@ If both values are above zero, a `lognormal` distribution is used. If not, a `no
 
 `mixture(...distributions: Distribution[], weights?: number[])`  
 `mx(...distributions: Distribution[], weights?: number[])`  
-`mixture(distributions: Distributions[], weights?: number[])`  
-`mx(distributions: Distributions[], weights?: number[])`
+`mixture(distributions: Distribution[], weights?: number[])`  
+`mx(distributions: Distribution[], weights?: number[])`
 
 The `mixture` mixes combines multiple distributions to create a mixture. You can optionally pass in a list of proportional weights.
 

--- a/packages/website/docs/Guides/Functions.mdx
+++ b/packages/website/docs/Guides/Functions.mdx
@@ -23,9 +23,9 @@ dist1 + dist2`}
 
 ### Subtraction
 
-A horizontal left shift. A horizontal right shift. The substraction operation represents
-the distribution of the value of one random sample chosen from the first distribution minus
-the value of one random sample chosen from the second distribution.
+A horizontal left shift. The subtraction operation represents the distribution of the value of
+one random sample chosen from the first distribution minus the value of one random sample chosen
+from the second distribution.
 
 <SquiggleEditor
   defaultCode={`dist1 = 1 to 10
@@ -35,7 +35,7 @@ dist1 - dist2`}
 
 ### Multiplication
 
-A proportional scaling. The addition operation represents the distribution of the multiplication of
+A proportional scaling. The multiplication operation represents the distribution of the multiplication of
 the value of one random sample chosen from the first distribution times the value one random sample
 chosen from the second distribution.
 
@@ -52,7 +52,7 @@ We also provide concatenation of two distributions as a syntax sugar for `*`
 ### Division
 
 A proportional scaling (normally a shrinking if the second distribution has values higher than 1).
-The addition operation represents the distribution of the division of
+The division operation represents the distribution of the division of
 the value of one random sample chosen from the first distribution over the value one random sample
 chosen from the second distribution. If the second distribution has some values near zero, it
 tends to be particularly unstable.


### PR DESCRIPTION
Obvious fixes for arithmetic, and changing type from `Distributions[]` to `Distribution[]` for mixture type signatures. I'm not sure the last one is the right fix, I just know it doesn't make sense for it to be plural *and* an array.