### PR TITLE
fixes #655 Anonymous functions can't be passed to the right of ->

### DIFF
--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
@@ -75,7 +75,7 @@ describe("eval", () => {
    })
    describe("to block", () => {
     testEvalToBe("1->{|x| x}", "Ok(1)")
-    testEvalToBe("1->{|x,y| x+y}(2)", "Ok(3)")
+    testEvalToBe("6->{|x,y| x/y}(2)", "Ok(3)")
    })
    describe("to expression", () => {
     testEvalToBe("1->{f:{|x|x+2}}.f", "Ok(3)")

--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
@@ -77,6 +77,10 @@ describe("eval", () => {
     testEvalToBe("1->{|x| x}", "Ok(1)")
     testEvalToBe("1->{|x,y| x+y}(2)", "Ok(3)")
    })
+   describe("to expression", () => {
+    testEvalToBe("1->{f:{|x|x+2}}.f", "Ok(3)")
+    testEvalToBe("1->{f:{|x|x+2}}['f']", "Ok(3)")
+   })
   })
 })
 

--- a/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
+++ b/packages/squiggle-lang/__tests__/Reducer/Reducer_test.res
@@ -67,6 +67,17 @@ describe("eval", () => {
   describe("blocks", () => {
     testEvalToBe("x = { y = { z = 5; z * 2 }; y + 3 }; x", "Ok(13)")
   })
+
+  describe("chain call", () => {
+   describe("to function", () => {
+    testEvalToBe("f(x)=x; 1->f", "Ok(1)")
+    testEvalToBe("f(x,y)=x+y; 1->f(2)", "Ok(3)")
+   })
+   describe("to block", () => {
+    testEvalToBe("1->{|x| x}", "Ok(1)")
+    testEvalToBe("1->{|x,y| x+y}(2)", "Ok(3)")
+   })
+  })
 })
 
 describe("test exceptions", () => {

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_GeneratedParser.peggy
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_GeneratedParser.peggy
@@ -139,16 +139,18 @@ power
 chainFunctionCall
   = head:unary tail:(_ ('->'/'|>') _nl chained:chainedFunction {return chained})* 
   { return tail.reduce(function(result, element) {
-      return h.makeFunctionCall(element.fnName, [result, ...element.args], location())
+      return h.makeFunctionCall(h.postOperatorToFunction['()'], [element.callable, result, ...element.args], location())
     }, head)}
 
   chainedFunction
-    = fn:variable '(' _nl args:array_functionArguments _nl ')' 
-      { return {fnName: fn.value, args: args}}
-      / fn:variable '(' _nl ')' 
-      { return {fnName: fn.value, args: []}}
-      / fn:variable
-      { return {fnName: fn.value, args: []}}
+    = fn:callableBasicValue '(' _nl args:array_functionArguments _nl ')' 
+      { return {callable: fn, args: args}}
+    / fn:callableBasicValue '(' _nl ')' 
+      { return {callable: fn, args: []}}
+    / fn:callableBasicValue
+      { return {callable: fn, args: []}}
+      
+  callableBasicValue = valueConstructor / variable   
 
 // end of binary operators
 

--- a/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_GeneratedParser.peggy
+++ b/packages/squiggle-lang/src/rescript/Reducer/Reducer_Peggy/Reducer_Peggy_GeneratedParser.peggy
@@ -150,7 +150,10 @@ chainFunctionCall
     / fn:callableBasicValue
       { return {callable: fn, args: []}}
       
-  callableBasicValue = valueConstructor / variable   
+  callableBasicValue = staticCollectionElement / valueConstructor / variable   
+
+// type: 'Call', fn: { type: 'Lambda', ... }, args:
+// type: 'Call', fn: { type: 'Identifier', value:  }, args:
 
 // end of binary operators
 
@@ -166,11 +169,21 @@ postOperator
   = collectionElement
   / atom
 
+staticCollectionElement
+  = head:atom &('['/'.')
+    tail:(
+      _ '[' _nl arg:expression  _nl ']' {return {fn: h.postOperatorToFunction['[]'], args: [arg]}}
+    / '.' arg:$dollarIdentifier {return {fn: h.postOperatorToFunction['[]'], args: [h.nodeString(arg, location())]}}
+    )* 
+  { return tail.reduce(function(result, element) {
+      return h.makeFunctionCall(element.fn, [result, ...element.args], location())
+    }, head)}
+
 collectionElement
   = head:atom &('['/'('/'.')
     tail:(
-      _ '[' _nl arg:expression  _nl ']' {return {fn: h.postOperatorToFunction['[]'], args: [arg]}}
-    / _ '(' _nl args:array_functionArguments  _nl ')' {return {fn: h.postOperatorToFunction['()'], args: args}}
+      _ '(' _nl args:array_functionArguments  _nl ')' {return {fn: h.postOperatorToFunction['()'], args: args}}
+    / _ '[' _nl arg:expression  _nl ']' {return {fn: h.postOperatorToFunction['[]'], args: [arg]}}
     / '.' arg:$dollarIdentifier {return {fn: h.postOperatorToFunction['[]'], args: [h.nodeString(arg, location())]}}
     )* 
   { return tail.reduce(function(result, element) {


### PR DESCRIPTION
anonymous functions can be at the right of ->
```
    testEvalToBe("1->{|x| x}", "Ok(1)")
    testEvalToBe("1->{|x,y| x+y}(2)", "Ok(3)")
```