### PR TITLE
Refactor: change the name env/environment to context in FR where appropriate

### DIFF
--- a/packages/squiggle-lang/__tests__/SquiggleLibrary/SquiggleLibrary_FunctionRegistryLibrary_test.res
+++ b/packages/squiggle-lang/__tests__/SquiggleLibrary/SquiggleLibrary_FunctionRegistryLibrary_test.res
@@ -88,7 +88,7 @@ describe("FunctionRegistry Library", () => {
     )
 
     testEvalToBe("Dict.set({a: 1, b: 2}, 'c', 3)", "Ok({a: 1,b: 2,c: 3})")
-    testEvalToBe("d={a: 1, b: 2}; _=Dict.set(d, 'c', 3); d", "Ok({a: 1,b: 2})")
+    testEvalToBe("d={a: 1, b: 2}; _=Dict.set(d, 'c', 3); d", "Ok({a: 1,b: 2})") // Immutable
     testEvalToBe("Dict.merge({a: 1, b: 2}, {b: 3, c: 4, d: 5})", "Ok({a: 1,b: 3,c: 4,d: 5})")
     testEvalToBe(
       "Dict.mergeMany([{a: 1, b: 2}, {c: 3, d: 4}, {c: 5, e: 6}])",

--- a/packages/squiggle-lang/src/rescript/FR/FR_Danger.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_Danger.res
@@ -61,16 +61,16 @@ module Integration = {
       min: float,
       max: float,
       numIntegrationPoints: float, // cast as int?
-      environment,
+      context,
       reducer,
     ) => {
       let applyFunctionAtFloatToFloatOption = (point: float) => {
-        // Defined here so that it has access to environment, reducer
+        // Defined here so that it has access to context, reducer
         let pointAsInternalExpression = FunctionRegistry_Helpers.Wrappers.evNumber(point)
         let resultAsInternalExpression = Reducer_Lambda.doLambdaCall(
           aLambda,
           [pointAsInternalExpression],
-          environment,
+          context,
           reducer,
         )
         let result = switch resultAsInternalExpression {
@@ -167,7 +167,7 @@ module Integration = {
         FnDefinition.make(
           ~name="integrateFunctionBetweenWithNumIntegrationPoints",
           ~inputs=[FRTypeLambda, FRTypeNumber, FRTypeNumber, FRTypeNumber],
-          ~run=(inputs, env, reducer) => {
+          ~run=(inputs, context, reducer) => {
             let result = switch inputs {
             | [_, _, _, IEvNumber(0.0)] =>
               "Integration error 4 in Danger.integrate: Increment can't be 0."
@@ -184,7 +184,7 @@ module Integration = {
                 min,
                 max,
                 numIntegrationPoints,
-                env,
+                context,
                 reducer,
               )
             | _ =>
@@ -211,7 +211,7 @@ module Integration = {
         FnDefinition.make(
           ~name="integrateFunctionBetweenWithEpsilon",
           ~inputs=[FRTypeLambda, FRTypeNumber, FRTypeNumber, FRTypeNumber],
-          ~run=(inputs, env, reducer) => {
+          ~run=(inputs, context, reducer) => {
             let result = switch inputs {
             | [_, _, _, IEvNumber(0.0)] =>
               "Integration error in Danger.integrate: Increment can't be 0."
@@ -223,7 +223,7 @@ module Integration = {
                 min,
                 max,
                 (max -. min) /. epsilon,
-                env,
+                context,
                 reducer,
               )->E.R.errMap(b =>
                 ("Integration error 7 in Danger.integrate. Something went wrong along the way: " ++
@@ -258,7 +258,7 @@ module DiminishingReturns = {
         }
       })
     type diminishingReturnsAccumulator = result<diminishingReturnsAccumulatorInner, errorMessage>
-    // TODO: This is so complicated, it probably should be its own file. It might also make sense to have it work in Rescript directly, taking in a function rather than a reducer; then something else can wrap that function in the reducer/lambdas/environment.
+    // TODO: This is so complicated, it probably should be its own file. It might also make sense to have it work in Rescript directly, taking in a function rather than a reducer; then something else can wrap that function in the reducer/lambdas/context.
     /*
     The key idea for this function is that 
     1. we keep track of past spending and current marginal returns for each function
@@ -281,7 +281,7 @@ module DiminishingReturns = {
       lambdas,
       funds,
       approximateIncrement,
-      environment,
+      context,
       reducer,
     ) => {
       switch (
@@ -308,12 +308,12 @@ module DiminishingReturns = {
         )
       | (true, true, true, true) => {
           let applyFunctionAtPoint = (lambda, point: float) => {
-            // Defined here so that it has access to environment, reducer
+            // Defined here so that it has access to context, reducer
             let pointAsInternalExpression = FunctionRegistry_Helpers.Wrappers.evNumber(point)
             let resultAsInternalExpression = Reducer_Lambda.doLambdaCall(
               lambda,
               [pointAsInternalExpression],
-              environment,
+              context,
               reducer,
             )
             switch resultAsInternalExpression {
@@ -407,7 +407,7 @@ module DiminishingReturns = {
         FnDefinition.make(
           ~name="optimalAllocationGivenDiminishingMarginalReturnsForManyFunctions",
           ~inputs=[FRTypeArray(FRTypeLambda), FRTypeNumber, FRTypeNumber],
-          ~run=(inputs, environment, reducer) =>
+          ~run=(inputs, context, reducer) =>
             switch inputs {
             | [IEvArray(innerlambdas), IEvNumber(funds), IEvNumber(approximateIncrement)] => {
                 let individuallyWrappedLambdas = innerlambdas->E.A.fmap(innerLambda => {
@@ -426,7 +426,7 @@ module DiminishingReturns = {
                       lambdas,
                       funds,
                       approximateIncrement,
-                      environment,
+                      context,
                       reducer,
                     )
                     result

--- a/packages/squiggle-lang/src/rescript/FR/FR_Dict.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_Dict.res
@@ -214,9 +214,10 @@ let library = [
       FnDefinition.make(
         ~name="map",
         ~inputs=[FRTypeDict(FRTypeAny), FRTypeLambda],
-        ~run=(inputs, env, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
-          | [IEvRecord(dict), IEvLambda(lambda)] => Ok(Internals.map(dict, lambda, env, reducer))
+          | [IEvRecord(dict), IEvLambda(lambda)] =>
+            Ok(Internals.map(dict, lambda, context, reducer))
           | _ => Error(impossibleError)
           },
         (),

--- a/packages/squiggle-lang/src/rescript/FR/FR_List.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_List.res
@@ -209,9 +209,10 @@ let library = [
       FnDefinition.make(
         ~name="map",
         ~inputs=[FRTypeArray(FRTypeAny), FRTypeLambda],
-        ~run=(inputs, env, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
-          | [IEvArray(array), IEvLambda(lambda)] => Ok(Internals.map(array, lambda, env, reducer))
+          | [IEvArray(array), IEvLambda(lambda)] =>
+            Ok(Internals.map(array, lambda, context, reducer))
           | _ => Error(impossibleError)
           },
         (),
@@ -228,10 +229,10 @@ let library = [
       FnDefinition.make(
         ~name="reduce",
         ~inputs=[FRTypeArray(FRTypeAny), FRTypeAny, FRTypeLambda],
-        ~run=(inputs, env, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [IEvArray(array), initialValue, IEvLambda(lambda)] =>
-            Ok(Internals.reduce(array, initialValue, lambda, env, reducer))
+            Ok(Internals.reduce(array, initialValue, lambda, context, reducer))
           | _ => Error(impossibleError)
           },
         (),
@@ -248,10 +249,10 @@ let library = [
       FnDefinition.make(
         ~name="reduceReverse",
         ~inputs=[FRTypeArray(FRTypeAny), FRTypeAny, FRTypeLambda],
-        ~run=(inputs, env, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [IEvArray(array), initialValue, IEvLambda(lambda)] =>
-            Ok(Internals.reduceReverse(array, initialValue, lambda, env, reducer))
+            Ok(Internals.reduceReverse(array, initialValue, lambda, context, reducer))
           | _ => Error(impossibleError)
           },
         (),
@@ -268,10 +269,10 @@ let library = [
       FnDefinition.make(
         ~name="filter",
         ~inputs=[FRTypeArray(FRTypeAny), FRTypeLambda],
-        ~run=(inputs, env, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [IEvArray(array), IEvLambda(lambda)] =>
-            Ok(Internals.filter(array, lambda, env, reducer))
+            Ok(Internals.filter(array, lambda, context, reducer))
           | _ => Error(impossibleError)
           },
         (),

--- a/packages/squiggle-lang/src/rescript/FR/FR_Pointset.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_Pointset.res
@@ -39,14 +39,14 @@ module Internal = {
     | Error(err) => Error(REOperationError(err))
     }
 
-  let doLambdaCall = (aLambdaValue, list, env, reducer) =>
-    switch Reducer_Lambda.doLambdaCall(aLambdaValue, list, env, reducer) {
+  let doLambdaCall = (aLambdaValue, list, context, reducer) =>
+    switch Reducer_Lambda.doLambdaCall(aLambdaValue, list, context, reducer) {
     | Reducer_T.IEvNumber(f) => Ok(f)
     | _ => Error(Operation.SampleMapNeedsNtoNFunction)
     }
 
-  let mapY = (pointSetDist: t, aLambdaValue, env, reducer) => {
-    let fn = r => doLambdaCall(aLambdaValue, [IEvNumber(r)], env, reducer)
+  let mapY = (pointSetDist: t, aLambdaValue, context, reducer) => {
+    let fn = r => doLambdaCall(aLambdaValue, [IEvNumber(r)], context, reducer)
     pointSetDist->PointSetDist.T.mapYResult(fn)->toType
   }
 }
@@ -91,10 +91,10 @@ let library = [
       FnDefinition.make(
         ~name="mapY",
         ~inputs=[FRTypeDist, FRTypeLambda],
-        ~run=(inputs, env, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [IEvDistribution(PointSet(dist)), IEvLambda(lambda)] =>
-            Internal.mapY(dist, lambda, env, reducer)
+            Internal.mapY(dist, lambda, context, reducer)
           | _ => Error(impossibleError)
           },
         (),

--- a/packages/squiggle-lang/src/rescript/FR/FR_Sampleset.res
+++ b/packages/squiggle-lang/src/rescript/FR/FR_Sampleset.res
@@ -158,10 +158,10 @@ let libaryBase = [
       FnDefinition.make(
         ~name="fromFn",
         ~inputs=[FRTypeLambda],
-        ~run=(inputs, environment, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [IEvLambda(lambda)] =>
-            switch Internal.fromFn(lambda, environment, reducer) {
+            switch Internal.fromFn(lambda, context, reducer) {
             | Ok(r) => Ok(r->Wrappers.sampleSet->Wrappers.evDistribution)
             | Error(e) => e->SqError.Message.REOperationError->Error
             }
@@ -182,10 +182,10 @@ let libaryBase = [
       FnDefinition.make(
         ~name="map",
         ~inputs=[FRTypeDist, FRTypeLambda],
-        ~run=(inputs, environment, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [IEvDistribution(SampleSet(dist)), IEvLambda(lambda)] =>
-            Internal.map1(dist, lambda, environment, reducer)
+            Internal.map1(dist, lambda, context, reducer)
           | _ => Error(impossibleError)
           },
         (),
@@ -205,14 +205,14 @@ let libaryBase = [
       FnDefinition.make(
         ~name="map2",
         ~inputs=[FRTypeDist, FRTypeDist, FRTypeLambda],
-        ~run=(inputs, environment, reducer) => {
+        ~run=(inputs, context, reducer) => {
           switch inputs {
           | [
               IEvDistribution(SampleSet(dist1)),
               IEvDistribution(SampleSet(dist2)),
               IEvLambda(lambda),
             ] =>
-            Internal.map2(dist1, dist2, lambda, environment, reducer)
+            Internal.map2(dist1, dist2, lambda, context, reducer)
           | _ => Error(impossibleError)
           }
         },
@@ -233,7 +233,7 @@ let libaryBase = [
       FnDefinition.make(
         ~name="map3",
         ~inputs=[FRTypeDist, FRTypeDist, FRTypeDist, FRTypeLambda],
-        ~run=(inputs, environment, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
           | [
               IEvDistribution(SampleSet(dist1)),
@@ -241,7 +241,7 @@ let libaryBase = [
               IEvDistribution(SampleSet(dist3)),
               IEvLambda(lambda),
             ] =>
-            Internal.map3(dist1, dist2, dist3, lambda, environment, reducer)
+            Internal.map3(dist1, dist2, dist3, lambda, context, reducer)
           | _ => Error(impossibleError)
           },
         (),
@@ -261,10 +261,9 @@ let libaryBase = [
       FnDefinition.make(
         ~name="mapN",
         ~inputs=[FRTypeArray(FRTypeDist), FRTypeLambda],
-        ~run=(inputs, environment, reducer) =>
+        ~run=(inputs, context, reducer) =>
           switch inputs {
-          | [IEvArray(dists), IEvLambda(lambda)] =>
-            Internal.mapN(dists, lambda, environment, reducer)
+          | [IEvArray(dists), IEvLambda(lambda)] => Internal.mapN(dists, lambda, context, reducer)
           | _ => Error(impossibleError)
           },
         (),


### PR DESCRIPTION
See [this comment](https://github.com/quantified-uncertainty/squiggle/pull/1324#discussion_r1006071013). I've checked that the type is `Reducer_T.context` in these places by inspection, possible I missed something though.