### PR TITLE
Monthly dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "⬆️"
     open-pull-requests-limit: 100
@@ -17,7 +17,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "⬆️"
     labels:


### PR DESCRIPTION
Quoting myself from Slack:

> Today's dependabot day again.
>
> In my opinion, we should switch to monthly schedule, or even disable it entirely.
> * My impression is that we don't really check that everything still works, except for smoke tests from our CI, don't read changelogs of dependencies carefully, etc. There's always a chance to break something and not notice (e.g. [#1131](https://github.com/quantified-uncertainty/squiggle/issues/1131))
> * It spams our repo with PRs.
> * Quick upgrades to minor versions are of low value. Upgrades for security reasons are rarely necessary, security issues come from indirect dependencies, and we're not careful about those anyway (https://github.com/quantified-uncertainty/squiggle/security/dependabot).
> * Also, in some cases bleeding edge dependencies can cause bad user experience to those who depend on Squiggle. E.g., if someone uses Squiggle components in a larger React app and Squiggle required the latest React then Squiggle we'd force them to upgrade too. (This is partially theoretical, Squiggle depends on React through peerDependencies, but we depend on 18.1 in devDependencies, so it's possible that we could use some bleeding edge React feature by accident and break other people's projects.)
> * Also, it locks down deployments for an hour or two (not a big problem, though, and can be fixed by reconfiguring it to run at a different time)
>
> In my experience, it's better to upgrade less often, but to be more deliberate about it: read through changelogs and apply discretion.
> Running `yarn outdated` manually from time to time is also not difficult.