### PR TITLE
Split distribution chart in 2. Fix colours

### DIFF
--- a/packages/components/src/components/DistributionChart.tsx
+++ b/packages/components/src/components/DistributionChart.tsx
@@ -1,41 +1,17 @@
 import * as React from "react";
-import * as yup from "yup";
+import { SqDistribution } from "@quri/squiggle-lang";
 import {
-  SqDistribution,
-  result,
-  SqDistributionError,
-  resultMap,
-  environment,
-  SqDistributionTag,
-} from "@quri/squiggle-lang";
-import { Vega } from "react-vega";
-import { ErrorAlert } from "./Alert";
-import { useMeasure } from "react-use";
+  MultiDistributionChart,
+  MultiDistributionChartProps,
+} from "./MultiDistributionChart";
 
-import {
-  buildVegaSpec,
-  distributionChartSpecSchema,
-} from "../lib/distributionSpecBuilder";
-import { NumberShower } from "./NumberShower";
-import { hasMassBelowZero } from "../lib/distributionUtils";
+export { DistributionChartSettings } from "./MultiDistributionChart";
 
-export const distributionSettingsSchema = yup
-  .object({})
-  .shape({
-    showSummary: yup.boolean().required().default(false),
-    vegaActions: yup.boolean().required().default(false),
-  })
-  .concat(distributionChartSpecSchema);
-
-export type DistributionChartSettings = yup.InferType<
-  typeof distributionSettingsSchema
->;
-
-export type DistributionChartProps = {
+export type DistributionChartProps = Omit<
+  MultiDistributionChartProps,
+  "plot"
+> & {
   distribution: SqDistribution;
-  environment: environment;
-  chartHeight?: number;
-  settings: DistributionChartSettings;
 };
 
 export const DistributionChart: React.FC<DistributionChartProps> = ({
@@ -44,145 +20,18 @@ export const DistributionChart: React.FC<DistributionChartProps> = ({
   chartHeight,
   settings,
 }) => {
-  const [containerRef, containerMeasure] = useMeasure<HTMLDivElement>();
-  const shape = resultMap(distribution.pointSet(environment), (pointSet) =>
-    pointSet.asShape()
-  );
-
-  if (shape.tag === "Error") {
-    return (
-      <ErrorAlert heading="Distribution Error">
-        {shape.value.toString()}
-      </ErrorAlert>
-    );
-  }
-
-  // if this is a sample set, include the samples
-  const samples: number[] = [];
-  if (distribution.tag === SqDistributionTag.SampleSet) {
-    samples.push(...distribution.value());
-  }
-
-  const domain = shape.value.discrete.concat(shape.value.continuous);
-
-  const spec = buildVegaSpec({
-    ...settings,
-    minX: Number.isFinite(settings.minX)
-      ? settings.minX
-      : Math.min(...domain.map((x) => x.x)),
-    maxX: Number.isFinite(settings.maxX)
-      ? settings.maxX
-      : Math.max(...domain.map((x) => x.x)),
-    maxY: Math.max(...domain.map((x) => x.y)),
-    multiplot: false,
-  });
-
-  const vegaData = { data: [shape.value], samples };
-
   return (
-    <div ref={containerRef}>
-      {
-        settings.logX && hasMassBelowZero(shape.value) ? (
-          <ErrorAlert heading="Log Domain Error">
-            Cannot graph distribution with negative values on logarithmic scale.
-          </ErrorAlert>
-        ) : containerMeasure.width ? (
-          <Vega
-            spec={spec}
-            data={vegaData}
-            width={containerMeasure.width - 22}
-            height={chartHeight}
-            actions={settings.vegaActions}
-          />
-        ) : null /* width can be 0 initially or when we're on the server side; that's fine, we don't want to pre-render charts with broken width */
-      }
-      <div className="flex justify-center">
-        {settings.showSummary && (
-          <SummaryTable distribution={distribution} environment={environment} />
-        )}
-      </div>
-    </div>
-  );
-};
-
-const TableHeadCell: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => (
-  <th className="border border-slate-200 bg-slate-50 py-1 px-2 text-slate-500 font-semibold">
-    {children}
-  </th>
-);
-
-const Cell: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <td className="border border-slate-200 py-1 px-2 text-slate-900">
-    {children}
-  </td>
-);
-
-type SummaryTableProps = {
-  distribution: SqDistribution;
-  environment: environment;
-};
-
-const SummaryTable: React.FC<SummaryTableProps> = ({
-  distribution,
-  environment,
-}) => {
-  const mean = distribution.mean(environment);
-  const stdev = distribution.stdev(environment);
-  const p5 = distribution.inv(environment, 0.05);
-  const p10 = distribution.inv(environment, 0.1);
-  const p25 = distribution.inv(environment, 0.25);
-  const p50 = distribution.inv(environment, 0.5);
-  const p75 = distribution.inv(environment, 0.75);
-  const p90 = distribution.inv(environment, 0.9);
-  const p95 = distribution.inv(environment, 0.95);
-
-  const hasResult = (x: result<number, SqDistributionError>): boolean =>
-    x.tag === "Ok";
-
-  const unwrapResult = (
-    x: result<number, SqDistributionError>
-  ): React.ReactNode => {
-    if (x.tag === "Ok") {
-      return <NumberShower number={x.value} />;
-    } else {
-      return (
-        <ErrorAlert heading="Distribution Error">
-          {x.value.toString()}
-        </ErrorAlert>
-      );
-    }
-  };
-
-  return (
-    <table className="border border-collapse border-slate-400">
-      <thead className="bg-slate-50">
-        <tr>
-          <TableHeadCell>{"Mean"}</TableHeadCell>
-          {hasResult(stdev) && <TableHeadCell>{"Stdev"}</TableHeadCell>}
-          <TableHeadCell>{"5%"}</TableHeadCell>
-          <TableHeadCell>{"10%"}</TableHeadCell>
-          <TableHeadCell>{"25%"}</TableHeadCell>
-          <TableHeadCell>{"50%"}</TableHeadCell>
-          <TableHeadCell>{"75%"}</TableHeadCell>
-          <TableHeadCell>{"90%"}</TableHeadCell>
-          <TableHeadCell>{"95%"}</TableHeadCell>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <Cell>{unwrapResult(mean)}</Cell>
-          {hasResult(stdev) && <Cell>{unwrapResult(stdev)}</Cell>}
-          <Cell>{unwrapResult(p5)}</Cell>
-          <Cell>{unwrapResult(p10)}</Cell>
-          <Cell>{unwrapResult(p25)}</Cell>
-          <Cell>{unwrapResult(p50)}</Cell>
-          <Cell>{unwrapResult(p75)}</Cell>
-          <Cell>{unwrapResult(p90)}</Cell>
-          <Cell>{unwrapResult(p95)}</Cell>
-        </tr>
-      </tbody>
-    </table>
+    <MultiDistributionChart
+      plot={{
+        distributions: [
+          { name: "default", distribution: distribution, opacity: 1 },
+        ],
+        showLegend: false,
+        colorScheme: "blues",
+      }}
+      environment={environment}
+      chartHeight={chartHeight}
+      settings={settings}
+    />
   );
 };

--- a/packages/components/src/components/FunctionChart1Dist.tsx
+++ b/packages/components/src/components/FunctionChart1Dist.tsx
@@ -15,7 +15,6 @@ import * as percentilesSpec from "../vega-specs/spec-percentiles.json";
 import {
   DistributionChart,
   DistributionChartSettings,
-  defaultPlot,
 } from "./DistributionChart";
 import { NumberShower } from "./NumberShower";
 import { ErrorAlert } from "./Alert";
@@ -179,7 +178,7 @@ export const FunctionChart1Dist: React.FC<FunctionChart1DistProps> = ({
     mouseItem.tag === "Ok" &&
     mouseItem.value.tag === SqValueTag.Distribution ? (
       <DistributionChart
-        plot={defaultPlot(mouseItem.value.value)}
+        distribution={mouseItem.value.value}
         environment={environment}
         chartHeight={50}
         settings={distributionChartSettings}

--- a/packages/components/src/components/MultiDistributionChart.tsx
+++ b/packages/components/src/components/MultiDistributionChart.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+import * as yup from "yup";
+import {
+  resultMap,
+  environment,
+  SqRecord,
+  SqDistributionTag,
+} from "@quri/squiggle-lang";
+import { Vega } from "react-vega";
+import { ErrorAlert } from "./Alert";
+import { useSize } from "react-use";
+
+import {
+  buildVegaSpec,
+  distributionChartSpecSchema,
+} from "../lib/distributionSpecBuilder";
+import { flattenResult } from "../lib/utility";
+import { hasMassBelowZero } from "../lib/distributionUtils";
+import { Plot, parsePlot, LabeledDistribution } from "../lib/plotParser";
+
+export const distributionSettingsSchema = yup
+  .object({})
+  .shape({
+    showSummary: yup.boolean().required().default(false),
+    vegaActions: yup.boolean().required().default(false),
+  })
+  .concat(distributionChartSpecSchema);
+
+export type DistributionChartSettings = yup.InferType<
+  typeof distributionSettingsSchema
+>;
+
+export function makePlot(record: SqRecord): Plot | void {
+  const plotResult = parsePlot(record);
+  if (plotResult.tag === "Ok") {
+    return plotResult.value;
+  }
+}
+
+export type MultiDistributionChartProps = {
+  environment: environment;
+  width?: number;
+  chartHeight?: number;
+  settings: DistributionChartSettings;
+  plot: Plot;
+};
+
+export const MultiDistributionChart: React.FC<MultiDistributionChartProps> = ({
+  plot,
+  environment,
+  width,
+  chartHeight,
+  settings,
+}) => {
+  const [sized] = useSize((size) => {
+    const distributions: LabeledDistribution[] = plot.distributions;
+    let shapes = flattenResult(
+      distributions.map((x) =>
+        resultMap(x.distribution.pointSet(environment), (pointSet) => ({
+          name: x.name,
+          // color: x.color, // not supported yet
+          ...pointSet.asShape(),
+        }))
+      )
+    );
+
+    if (shapes.tag === "Error") {
+      return (
+        <ErrorAlert heading="Distribution Error">
+          {shapes.value.toString()}
+        </ErrorAlert>
+      );
+    }
+
+    // if this is a sample set, include the samples
+    const samples: number[] = [];
+    for (const { distribution } of distributions) {
+      if (distribution.tag === SqDistributionTag.SampleSet) {
+        samples.push(...distribution.value());
+      }
+    }
+
+    const domain = shapes.value.flatMap((shape) =>
+      shape.discrete.concat(shape.continuous)
+    );
+
+    const spec = buildVegaSpec({
+      ...settings,
+      minX: Number.isFinite(settings.minX)
+        ? settings.minX
+        : Math.min(...domain.map((x) => x.x)),
+      maxX: Number.isFinite(settings.maxX)
+        ? settings.maxX
+        : Math.max(...domain.map((x) => x.x)),
+      maxY: Math.max(...domain.map((x) => x.y)),
+      multiplot: true,
+    });
+
+    let widthProp = width
+      ? width
+      : Number.isFinite(size.width)
+      ? size.width
+      : 400;
+
+    if (widthProp < 20) {
+      console.warn(
+        `Width of Distribution is set to ${widthProp}, which is too small`
+      );
+      widthProp = 20;
+    }
+
+    const vegaData = { data: shapes.value, samples };
+
+    return (
+      <div>
+        {settings.logX && shapes.value.some(hasMassBelowZero) ? (
+          <ErrorAlert heading="Log Domain Error">
+            Cannot graph distribution with negative values on logarithmic scale.
+          </ErrorAlert>
+        ) : (
+          <Vega
+            spec={spec}
+            data={vegaData}
+            width={widthProp - 10}
+            height={chartHeight}
+            actions={settings.vegaActions}
+          />
+        )}
+      </div>
+    );
+  });
+  return sized;
+};

--- a/packages/components/src/components/MultiDistributionChart.tsx
+++ b/packages/components/src/components/MultiDistributionChart.tsx
@@ -154,6 +154,7 @@ const SummaryTable: React.FC<SummaryTableProps> = ({ plot, environment }) => {
         <tr>
           {plot.showLegend && <TableHeadCell>Name</TableHeadCell>}
           <TableHeadCell>{"Mean"}</TableHeadCell>
+          <TableHeadCell>{"Stdev"}</TableHeadCell>
           <TableHeadCell>{"5%"}</TableHeadCell>
           <TableHeadCell>{"10%"}</TableHeadCell>
           <TableHeadCell>{"25%"}</TableHeadCell>
@@ -201,10 +202,6 @@ const SummaryTableRow: React.FC<SummaryTableRowProps> = ({
   const p90 = distribution.inv(environment, 0.9);
   const p95 = distribution.inv(environment, 0.95);
 
-  const hasResult = (
-    x: result<number, SqDistributionError>
-  ): x is { tag: "Ok"; value: number } => x.tag === "Ok";
-
   const unwrapResult = (
     x: result<number, SqDistributionError>
   ): React.ReactNode => {
@@ -222,15 +219,7 @@ const SummaryTableRow: React.FC<SummaryTableRowProps> = ({
     <tr>
       {showName && <Cell>{name}</Cell>}
       <Cell>{unwrapResult(mean)}</Cell>
-      {
-        <Cell>
-          {hasResult(stdev) ? (
-            <NumberShower number={stdev.value} />
-          ) : (
-            stdev.value.toString()
-          )}
-        </Cell>
-      }
+      <Cell>{unwrapResult(stdev)}</Cell>
       <Cell>{unwrapResult(p5)}</Cell>
       <Cell>{unwrapResult(p10)}</Cell>
       <Cell>{unwrapResult(p25)}</Cell>

--- a/packages/components/src/components/MultiDistributionChart.tsx
+++ b/packages/components/src/components/MultiDistributionChart.tsx
@@ -201,8 +201,9 @@ const SummaryTableRow: React.FC<SummaryTableRowProps> = ({
   const p90 = distribution.inv(environment, 0.9);
   const p95 = distribution.inv(environment, 0.95);
 
-  const hasResult = (x: result<number, SqDistributionError>): boolean =>
-    x.tag === "Ok";
+  const hasResult = (
+    x: result<number, SqDistributionError>
+  ): x is { tag: "Ok"; value: number } => x.tag === "Ok";
 
   const unwrapResult = (
     x: result<number, SqDistributionError>
@@ -221,7 +222,15 @@ const SummaryTableRow: React.FC<SummaryTableRowProps> = ({
     <tr>
       {showName && <Cell>{name}</Cell>}
       <Cell>{unwrapResult(mean)}</Cell>
-      {hasResult(stdev) && <Cell>{unwrapResult(stdev)}</Cell>}
+      {
+        <Cell>
+          {hasResult(stdev) ? (
+            <NumberShower number={stdev.value} />
+          ) : (
+            stdev.value.toString()
+          )}
+        </Cell>
+      }
       <Cell>{unwrapResult(p5)}</Cell>
       <Cell>{unwrapResult(p10)}</Cell>
       <Cell>{unwrapResult(p25)}</Cell>

--- a/packages/components/src/components/MultiDistributionChart.tsx
+++ b/packages/components/src/components/MultiDistributionChart.tsx
@@ -20,6 +20,8 @@ import { flattenResult } from "../lib/utility";
 import { hasMassBelowZero } from "../lib/distributionUtils";
 import { NumberShower } from "./NumberShower";
 import { Plot, parsePlot, LabeledDistribution } from "../lib/plotParser";
+import { XIcon } from "@heroicons/react/solid";
+import { Tooltip } from "./ui/Tooltip";
 
 export const distributionSettingsSchema = yup
   .object({})
@@ -209,9 +211,9 @@ const SummaryTableRow: React.FC<SummaryTableRowProps> = ({
       return <NumberShower number={x.value} />;
     } else {
       return (
-        <ErrorAlert heading="Distribution Error">
-          {x.value.toString()}
-        </ErrorAlert>
+        <Tooltip text={x.value.toString()}>
+          <XIcon className="w-5 h-5 text-gray-500" />
+        </Tooltip>
       );
     }
   };

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -10,32 +10,6 @@ import { ItemSettingsMenu } from "./ItemSettingsMenu";
 import { hasMassBelowZero } from "../../lib/distributionUtils";
 import { MergedItemSettings } from "./utils";
 
-/*
-// DISABLED FOR NOW
-function getRange<a>(x: declaration<a>) {
-  const first = x.args[0];
-  switch (first.tag) {
-    case "Float": {
-      return { floats: { min: first.value.min, max: first.value.max } };
-    }
-    case "Date": {
-      return { time: { min: first.value.min, max: first.value.max } };
-    }
-  }
-}
-
-function getChartSettings<a>(x: declaration<a>): FunctionChartSettings {
-  const range = getRange(x);
-  const min = range.floats ? range.floats.min : 0;
-  const max = range.floats ? range.floats.max : 10;
-  return {
-    start: min,
-    stop: max,
-    count: 20,
-  };
-}
-*/
-
 const VariableList: React.FC<{
   value: SqValue;
   heading: string;
@@ -61,7 +35,7 @@ export interface Props {
   width?: number;
 }
 
-export const ExpressionViewer: React.FC<Props> = ({ value, width }) => {
+export const ExpressionViewer: React.FC<Props> = ({ value }) => {
   const environment = value.location.project.getEnvironment();
 
   switch (value.tag) {

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { SqDistributionTag, SqValue, SqValueTag } from "@quri/squiggle-lang";
 import { NumberShower } from "../NumberShower";
-import { DistributionChart, defaultPlot, makePlot } from "../DistributionChart";
+import { DistributionChart } from "../DistributionChart";
+import { MultiDistributionChart, makePlot } from "../MultiDistributionChart";
 import { FunctionChart } from "../FunctionChart";
 import clsx from "clsx";
 import { VariableBox } from "./VariableBox";
@@ -103,7 +104,7 @@ export const ExpressionViewer: React.FC<Props> = ({ value, width }) => {
           {(settings) => {
             return (
               <DistributionChart
-                plot={defaultPlot(value.value)}
+                distribution={value.value}
                 environment={environment}
                 chartHeight={settings.chartHeight}
                 settings={settings.distributionChartSettings}
@@ -244,7 +245,7 @@ export const ExpressionViewer: React.FC<Props> = ({ value, width }) => {
           >
             {(settings) => {
               return (
-                <DistributionChart
+                <MultiDistributionChart
                   plot={plot}
                   environment={environment}
                   chartHeight={settings.chartHeight}

--- a/packages/components/src/components/ViewSettingsForm.tsx
+++ b/packages/components/src/components/ViewSettingsForm.tsx
@@ -5,7 +5,7 @@ import { InputItem } from "./ui/InputItem";
 import { Checkbox } from "./ui/Checkbox";
 import { HeadedSection } from "./ui/HeadedSection";
 import { Text } from "./ui/Text";
-import { distributionSettingsSchema } from "./DistributionChart";
+import { distributionSettingsSchema } from "./MultiDistributionChart";
 import { functionSettingsSchema } from "./FunctionChart";
 
 export const viewSettingsSchema = yup.object({}).shape({

--- a/packages/components/src/lib/distributionSpecBuilder.ts
+++ b/packages/components/src/lib/distributionSpecBuilder.ts
@@ -215,7 +215,7 @@ export function buildVegaSpec(
                       value: 0,
                     },
                     fillOpacity: {
-                      value: multiplot ? 0.5 : 1,
+                      value: multiplot ? 0.3 : 1,
                     },
                   },
                 },

--- a/packages/components/src/lib/distributionSpecBuilder.ts
+++ b/packages/components/src/lib/distributionSpecBuilder.ts
@@ -75,11 +75,21 @@ const width = 500;
 export function buildVegaSpec(
   specOptions: DistributionChartSpecOptions & {
     maxY: number;
-    multiplot: boolean;
+    showLegend: boolean;
+    colorScheme: string;
   }
 ): VisualizationSpec {
-  const { title, minX, maxX, logX, expY, xAxisType, maxY, multiplot } =
-    specOptions;
+  const {
+    title,
+    minX,
+    maxX,
+    logX,
+    expY,
+    xAxisType,
+    maxY,
+    showLegend,
+    colorScheme,
+  } = specOptions;
 
   const dateTime = xAxisType === "dateTime";
 
@@ -142,7 +152,7 @@ export function buildVegaSpec(
           data: "data",
           field: "name",
         },
-        range: { scheme: multiplot ? "category10" : "blues" },
+        range: { scheme: colorScheme },
       },
     ],
     axes: [
@@ -215,7 +225,7 @@ export function buildVegaSpec(
                       value: 0,
                     },
                     fillOpacity: {
-                      value: multiplot ? 0.3 : 1,
+                      field: { parent: "opacity" },
                     },
                   },
                 },
@@ -365,7 +375,7 @@ export function buildVegaSpec(
         },
       },
     ],
-    legends: multiplot
+    legends: showLegend
       ? [
           {
             fill: "color",

--- a/packages/components/src/lib/distributionSpecBuilder.ts
+++ b/packages/components/src/lib/distributionSpecBuilder.ts
@@ -73,9 +73,13 @@ export const timeTickFormat = "%b %d, %Y %H:%M";
 const width = 500;
 
 export function buildVegaSpec(
-  specOptions: DistributionChartSpecOptions & { maxY: number }
+  specOptions: DistributionChartSpecOptions & {
+    maxY: number;
+    multiplot: boolean;
+  }
 ): VisualizationSpec {
-  const { title, minX, maxX, logX, expY, xAxisType, maxY } = specOptions;
+  const { title, minX, maxX, logX, expY, xAxisType, maxY, multiplot } =
+    specOptions;
 
   const dateTime = xAxisType === "dateTime";
 
@@ -138,7 +142,7 @@ export function buildVegaSpec(
           data: "data",
           field: "name",
         },
-        range: { scheme: "blues" },
+        range: { scheme: multiplot ? "category10" : "blues" },
       },
     ],
     axes: [
@@ -198,6 +202,10 @@ export function buildVegaSpec(
                       scale: "yscale",
                       field: "y",
                     },
+                    stroke: {
+                      scale: "color",
+                      field: { parent: "name" },
+                    },
                     fill: {
                       scale: "color",
                       field: { parent: "name" },
@@ -207,7 +215,7 @@ export function buildVegaSpec(
                       value: 0,
                     },
                     fillOpacity: {
-                      value: 1,
+                      value: multiplot ? 0.5 : 1,
                     },
                   },
                 },
@@ -357,32 +365,28 @@ export function buildVegaSpec(
         },
       },
     ],
-    legends: [
-      {
-        fill: "color",
-        orient: "top",
-        labelFontSize: 12,
-        encode: {
-          symbols: {
-            update: {
-              fill: [
-                { test: "length(domain('color')) == 1", value: "transparent" },
-                { scale: "color", field: "value" },
-              ],
+    legends: multiplot
+      ? [
+          {
+            fill: "color",
+            orient: "top",
+            labelFontSize: 12,
+            encode: {
+              symbols: {
+                update: {
+                  fill: { scale: "color", field: "value" },
+                },
+              },
+              labels: {
+                interactive: true,
+                update: {
+                  fill: { value: "black" },
+                },
+              },
             },
           },
-          labels: {
-            interactive: true,
-            update: {
-              fill: [
-                { test: "length(domain('color')) == 1", value: "transparent" },
-                { value: "black" },
-              ],
-            },
-          },
-        },
-      },
-    ],
+        ]
+      : [],
     ...(title && {
       title: {
         text: title,

--- a/packages/components/src/lib/plotParser.ts
+++ b/packages/components/src/lib/plotParser.ts
@@ -10,11 +10,13 @@ import {
 export type LabeledDistribution = {
   name: string;
   distribution: SqDistribution;
-  color?: string;
+  opacity: number;
 };
 
 export type Plot = {
   distributions: LabeledDistribution[];
+  showLegend: boolean;
+  colorScheme: string;
 };
 
 function error<a, b>(err: b): result<a, b> {
@@ -28,17 +30,22 @@ function ok<a, b>(x: a): result<a, b> {
 const schema = yup
   .object()
   .noUnknown()
-  .strict()
   .shape({
     distributions: yup
       .array()
       .required()
       .of(
-        yup.object().required().shape({
-          name: yup.string().required(),
-          distribution: yup.mixed().required(),
-        })
+        yup
+          .object()
+          .required()
+          .shape({
+            name: yup.string().required(),
+            distribution: yup.mixed().required(),
+            opacity: yup.number().default(0.3),
+          })
       ),
+    showLegend: yup.boolean().default(true),
+    colorScheme: yup.string().default("category10"),
   });
 
 type JsonObject =
@@ -69,9 +76,16 @@ function toJsonRecord(val: SqRecord): JsonObject {
 
 export function parsePlot(record: SqRecord): result<Plot, string> {
   try {
-    const plotRecord = schema.validateSync(toJsonRecord(record));
+    const r = toJsonRecord(record);
+    console.log(r);
+    const plotRecord = schema.validateSync(r);
+    console.log(plotRecord);
     if (plotRecord.distributions) {
-      return ok({ distributions: plotRecord.distributions.map((x) => x) });
+      return ok({
+        distributions: plotRecord.distributions.map((x) => x),
+        showLegend: plotRecord.showLegend,
+        colorScheme: plotRecord.colorScheme,
+      });
     } else {
       // I have no idea why yup's typings thinks this is possible
       return error("no distributions field. Should never get here");

--- a/packages/components/src/lib/plotParser.ts
+++ b/packages/components/src/lib/plotParser.ts
@@ -77,9 +77,7 @@ function toJsonRecord(val: SqRecord): JsonObject {
 export function parsePlot(record: SqRecord): result<Plot, string> {
   try {
     const r = toJsonRecord(record);
-    console.log(r);
     const plotRecord = schema.validateSync(r);
-    console.log(plotRecord);
     if (plotRecord.distributions) {
       return ok({
         distributions: plotRecord.distributions.map((x) => x),


### PR DESCRIPTION
This PR creates a separate class for Multi charts and normal charts. This allows me to differentiate between plot objects with one element and simple distributions, which I think should be rendered differently. Particularly as it comes to colour schemes.

I also fix the colours up a bit for multiplots, they look like this currently: 
![image](https://user-images.githubusercontent.com/13807753/201828598-f9e0e124-d412-494b-a56a-dad6b83b2600.png)


This paves the way to having summary tables for multiplot distributions.

This currently has a lot of duplication, I'll look to remove as much duplication as possible before saying this is ready for review.