### PR TITLE
Add ecmascript build to @quri/squiggle-components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,14 +77,15 @@
   "scripts": {
     "start": "cross-env REACT_APP_FAST_REFRESH=false && start-storybook -p 6006 -s public",
     "build:cjs": "rm -rf dist/src && rm -f dist/tsconfig.tsbuildinfo && tsc -b",
+    "build:esm": "tsc --project ./tsconfig.esm.json",
     "build:css": "postcss ./src/styles/main.css -o ./dist/main.css",
     "build:storybook": "build-storybook -s public",
-    "build": "yarn run build:cjs && yarn run build:css && yarn run build:storybook",
+    "build": "yarn run build:cjs && yarn build:esm && yarn run build:css && yarn run build:storybook",
     "bundle": "webpack",
     "all": "yarn bundle && yarn build",
     "lint": "prettier --check . && eslint --ignore-path .gitignore .",
     "format": "prettier --write .",
-    "prepack": "yarn run build:cjs && yarn run bundle",
+    "prepack": "yarn run build:cjs && yarn build:esm",
     "test": "jest",
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "test:profile": "node --cpu-prof node_modules/.bin/jest --runInBand"
@@ -126,5 +127,6 @@
   },
   "source": "./src/index.ts",
   "main": "./dist/src/index.js",
+  "module": "./dist/esm/src/index.js",
   "types": "./dist/src/index.d.ts"
 }

--- a/packages/components/tsconfig.esm.json
+++ b/packages/components/tsconfig.esm.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@quri/squiggle-lang": ["../squiggle-lang/src"]
+    },
+    "module": "esnext",
+    "jsx": "react",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "removeComments": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "preserveConstEnums": true,
+    "composite": true,
+    "outDir": "./dist/esm",
+    "declarationDir": "./dist",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "files": [
+    "src/vega-specs/spec-distributions.json",
+    "src/vega-specs/spec-percentiles.json",
+    "src/vega-specs/spec-line-chart.json"
+  ],
+  "target": "es5",
+  "include": ["src/**/*", "src/*"],
+  "exclude": ["node_modules", "**/*.spec.ts", "webpack.config.js"],
+  "references": [
+    {
+      "path": "../squiggle-lang"
+    }
+  ]
+}


### PR DESCRIPTION
This should fix #1234. Create-react-app uses a config with ecmascript by default, and then fails when importing .cjs files from `@headlessui/react`. This gives an ecmascript build to `@quri/squiggle-components`. Which makes CRA's webpack config resolve `@headlessui/react` to the ecmascript version, fixing the problem.