### PR TITLE
Plot.fn()

### DIFF
--- a/packages/components/src/components/MultiDistributionChart.tsx
+++ b/packages/components/src/components/MultiDistributionChart.tsx
@@ -21,6 +21,7 @@ import { hasMassBelowZero } from "../lib/distributionUtils";
 import { NumberShower } from "./NumberShower";
 import { XIcon } from "@heroicons/react/solid";
 import { Tooltip } from "./ui/Tooltip";
+import { SqDistributionsPlot } from "@quri/squiggle-lang/src/public/SqPlot";
 
 export const distributionSettingsSchema = yup
   .object({})
@@ -46,7 +47,7 @@ interface Plot {
   colorScheme: string;
 }
 
-export function sqPlotToPlot(sqPlot: SqPlot): Plot {
+export function sqPlotToPlot(sqPlot: SqDistributionsPlot): Plot {
   return {
     distributions: sqPlot.distributions.map((x) => ({ ...x, opacity: 0.3 })),
     colorScheme: "category10",

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -12,6 +12,7 @@ import { VariableBox } from "./VariableBox";
 import { ItemSettingsMenu } from "./ItemSettingsMenu";
 import { hasMassBelowZero } from "../../lib/distributionUtils";
 import { MergedItemSettings } from "./utils";
+import { PartialViewSettings } from "../ViewSettingsForm";
 
 const VariableList: React.FC<{
   value: SqValue;
@@ -70,8 +71,14 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
               <ItemSettingsMenu
                 value={value}
                 onChange={onChange}
-                disableLogX={
+                fixed={
                   shape.ok && hasMassBelowZero(shape.value.asShape())
+                    ? {
+                        distributionChartSettings: {
+                          logX: false,
+                        },
+                      }
+                    : undefined
                 }
                 withFunctionSettings={false}
               />
@@ -202,6 +209,7 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
           value={value}
           heading="Plot"
           renderSettingsMenu={({ onChange }) => {
+            const fixed: PartialViewSettings = {};
             const disableLogX =
               plot.tag === "distributions"
                 ? plot.distributions.some((x) => {
@@ -210,13 +218,24 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
                       pointSet.ok && hasMassBelowZero(pointSet.value.asShape())
                     );
                   })
-                : true;
+                : false;
+            if (disableLogX) {
+              fixed.distributionChartSettings = {
+                logX: false,
+              };
+            }
+            fixed.functionChartSettings = {};
+            if (plot.tag === "fn") {
+              fixed.functionChartSettings.start = plot.min;
+              fixed.functionChartSettings.stop = plot.max;
+            }
+
             return (
               <ItemSettingsMenu
                 value={value}
                 onChange={onChange}
-                disableLogX={disableLogX}
-                withFunctionSettings={false}
+                fixed={fixed}
+                withFunctionSettings={plot.tag === "fn"}
               />
             );
           }}

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -210,7 +210,7 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
                       pointSet.ok && hasMassBelowZero(pointSet.value.asShape())
                     );
                   })
-                : true; // TODO - check min/max values for fn plots and support log scale in FunctionChart
+                : true;
             return (
               <ItemSettingsMenu
                 value={value}

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -202,10 +202,15 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
           value={value}
           heading="Plot"
           renderSettingsMenu={({ onChange }) => {
-            let disableLogX = plot.distributions.some((x) => {
-              let pointSet = x.distribution.pointSet(environment);
-              return pointSet.ok && hasMassBelowZero(pointSet.value.asShape());
-            });
+            const disableLogX =
+              plot.tag === "distributions"
+                ? plot.distributions.some((x) => {
+                    let pointSet = x.distribution.pointSet(environment);
+                    return (
+                      pointSet.ok && hasMassBelowZero(pointSet.value.asShape())
+                    );
+                  })
+                : true; // TODO - check min/max values for fn plots and support log scale in FunctionChart
             return (
               <ItemSettingsMenu
                 value={value}
@@ -217,14 +222,36 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
           }}
         >
           {(settings) => {
-            return (
-              <MultiDistributionChart
-                plot={sqPlotToPlot(plot)}
-                environment={environment}
-                chartHeight={settings.chartHeight}
-                settings={settings.distributionChartSettings}
-              />
-            );
+            switch (plot.tag) {
+              case "distributions":
+                return (
+                  <MultiDistributionChart
+                    plot={sqPlotToPlot(plot)}
+                    environment={environment}
+                    chartHeight={settings.chartHeight}
+                    settings={settings.distributionChartSettings}
+                  />
+                );
+              case "fn":
+                return (
+                  <FunctionChart
+                    fn={plot.fn}
+                    settings={{
+                      ...settings.functionChartSettings,
+                      start: plot.min,
+                      stop: plot.max,
+                    }}
+                    distributionChartSettings={
+                      settings.distributionChartSettings
+                    }
+                    height={settings.chartHeight}
+                    environment={{
+                      sampleCount: environment.sampleCount / 10,
+                      xyPointLength: environment.xyPointLength / 10,
+                    }}
+                  />
+                );
+            }
           }}
         </VariableBox>
       );

--- a/packages/components/src/components/SquiggleViewer/ItemSettingsMenu.tsx
+++ b/packages/components/src/components/SquiggleViewer/ItemSettingsMenu.tsx
@@ -3,7 +3,11 @@ import React, { useContext, useRef, useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { Modal } from "../ui/Modal";
-import { ViewSettingsForm, viewSettingsSchema } from "../ViewSettingsForm";
+import {
+  PartialViewSettings,
+  ViewSettingsForm,
+  viewSettingsSchema,
+} from "../ViewSettingsForm";
 import { ViewerContext } from "./ViewerContext";
 import { PlaygroundContext } from "../SquigglePlayground";
 import { SqValue } from "@quri/squiggle-lang";
@@ -13,24 +17,17 @@ import _ from "lodash";
 type Props = {
   value: SqValue;
   onChange: () => void;
-  disableLogX?: boolean;
+  fixed?: PartialViewSettings;
   withFunctionSettings: boolean;
 };
 
 const ItemSettingsModal: React.FC<
   Props & { close: () => void; resetScroll: () => void }
-> = ({
-  value,
-  onChange,
-  disableLogX,
-  withFunctionSettings,
-  close,
-  resetScroll,
-}) => {
+> = ({ value, onChange, fixed, withFunctionSettings, close, resetScroll }) => {
   const { setSettings, getSettings, getMergedSettings } =
     useContext(ViewerContext);
 
-  const mergedSettings = getMergedSettings(value.location);
+  const mergedSettings = _.merge(getMergedSettings(value.location), fixed);
 
   const { register, watch } = useForm({
     resolver: yupResolver(viewSettingsSchema),
@@ -70,7 +67,7 @@ const ItemSettingsModal: React.FC<
         <ViewSettingsForm
           register={register}
           withFunctionSettings={withFunctionSettings}
-          disableLogXSetting={disableLogX}
+          fixed={fixed}
         />
       </Modal.Body>
     </Modal>

--- a/packages/components/src/components/ViewSettingsForm.tsx
+++ b/packages/components/src/components/ViewSettingsForm.tsx
@@ -26,9 +26,9 @@ export type PartialViewSettings = DeepPartial<ViewSettings>;
 
 export const ViewSettingsForm: React.FC<{
   withFunctionSettings?: boolean;
-  disableLogXSetting?: boolean;
+  fixed?: PartialViewSettings;
   register: UseFormRegister<ViewSettings>;
-}> = ({ withFunctionSettings = true, disableLogXSetting, register }) => {
+}> = ({ withFunctionSettings = true, fixed, register }) => {
   return (
     <div className="space-y-6 p-3 divide-y divide-gray-200 max-w-xl">
       <HeadedSection title="General Display Settings">
@@ -42,22 +42,19 @@ export const ViewSettingsForm: React.FC<{
         </div>
       </HeadedSection>
 
-      <DistributionViewSettingsForm
-        disableLogXSetting={disableLogXSetting}
-        register={register}
-      />
+      <DistributionViewSettingsForm fixed={fixed} register={register} />
 
       {withFunctionSettings ? (
-        <FunctionViewSettingsForm register={register} />
+        <FunctionViewSettingsForm fixed={fixed} register={register} />
       ) : null}
     </div>
   );
 };
 
 export const DistributionViewSettingsForm: React.FC<{
-  disableLogXSetting?: boolean;
   register: UseFormRegister<ViewSettings>;
-}> = ({ disableLogXSetting, register }) => {
+  fixed?: PartialViewSettings;
+}> = ({ register, fixed }) => {
   return (
     <div className="pt-8">
       <HeadedSection title="Distribution Display Settings">
@@ -66,9 +63,9 @@ export const DistributionViewSettingsForm: React.FC<{
             register={register}
             name="distributionChartSettings.logX"
             label="Show x scale logarithmically"
-            disabled={disableLogXSetting}
+            fixed={fixed?.distributionChartSettings?.logX}
             tooltip={
-              disableLogXSetting
+              fixed?.distributionChartSettings?.logX !== undefined
                 ? "Your distribution has mass lower than or equal to 0. Log only works on strictly positive values."
                 : undefined
             }
@@ -120,7 +117,8 @@ export const DistributionViewSettingsForm: React.FC<{
 
 export const FunctionViewSettingsForm: React.FC<{
   register: UseFormRegister<ViewSettings>;
-}> = ({ register }) => (
+  fixed?: PartialViewSettings;
+}> = ({ register, fixed }) => (
   <div className="pt-8">
     <HeadedSection title="Function Display Settings">
       <div className="space-y-6">
@@ -135,12 +133,14 @@ export const FunctionViewSettingsForm: React.FC<{
             type="number"
             name="functionChartSettings.start"
             register={register}
+            fixed={fixed?.functionChartSettings?.start}
             label="Min X Value"
           />
           <InputItem
             type="number"
             name="functionChartSettings.stop"
             register={register}
+            fixed={fixed?.functionChartSettings?.stop}
             label="Max X Value"
           />
           <InputItem

--- a/packages/components/src/components/ui/Checkbox.tsx
+++ b/packages/components/src/components/ui/Checkbox.tsx
@@ -7,19 +7,24 @@ export function Checkbox<T extends FieldValues>({
   label,
   register,
   disabled,
+  fixed,
   tooltip,
 }: {
   name: Path<T>;
   label: string;
   register: UseFormRegister<T>;
   disabled?: boolean;
+  fixed?: boolean;
   tooltip?: string;
 }) {
+  disabled ??= fixed !== undefined;
+
   return (
     <label className="flex items-center" title={tooltip}>
       <input
         type="checkbox"
         disabled={disabled}
+        defaultChecked={fixed}
         {...register(name)}
         className="form-checkbox focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded"
       />

--- a/packages/components/src/components/ui/InputItem.tsx
+++ b/packages/components/src/components/ui/InputItem.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import React from "react";
 import { Path, UseFormRegister, FieldValues } from "react-hook-form";
 
@@ -6,17 +7,32 @@ export function InputItem<T extends FieldValues>({
   label,
   type,
   register,
+  disabled,
+  fixed,
 }: {
   name: Path<T>;
   label: string;
   type: "number" | "text" | "color";
   register: UseFormRegister<T>;
+  disabled?: boolean;
+  fixed?: string | number;
 }) {
+  disabled ??= fixed !== undefined;
+
   return (
     <label className="block">
-      <div className="text-sm font-medium text-gray-600 mb-1">{label}</div>
+      <div
+        className={clsx(
+          "text-sm font-medium mb-1",
+          disabled ? "text-gray-400" : "text-gray-600"
+        )}
+      >
+        {label}
+      </div>
       <input
         type={type}
+        disabled={disabled}
+        defaultValue={fixed}
         {...register(name, { valueAsNumber: type === "number" })}
         className="form-input max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
       />

--- a/packages/components/src/components/ui/InputItem.tsx
+++ b/packages/components/src/components/ui/InputItem.tsx
@@ -34,7 +34,10 @@ export function InputItem<T extends FieldValues>({
         disabled={disabled}
         defaultValue={fixed}
         {...register(name, { valueAsNumber: type === "number" })}
-        className="form-input max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
+        className={clsx(
+          "form-input max-w-lg block w-full shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md",
+          disabled && "text-gray-400"
+        )}
       />
     </label>
   );

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -4,11 +4,13 @@ import {
   frString,
   frRecord,
   frDistOrNumber,
+  frLambda,
+  frNumber,
 } from "../library/registry/frTypes";
 import { PointMass } from "../dist/SymbolicDist";
 import { FnFactory } from "../library/registry/helpers";
 import * as Result from "../utility/result";
-import { vPlot, LabeledDistribution } from "../value";
+import { vPlot, LabeledDistribution, vLambda } from "../value";
 import { REOther } from "../reducer/ErrorMessage";
 
 const maker = new FnFactory({
@@ -46,7 +48,29 @@ export const library = [
           });
           return Result.Ok(
             vPlot({
+              type: "distributions",
               distributions,
+            })
+          );
+        }
+      ),
+    ],
+  }),
+  maker.make({
+    name: "fn",
+    output: "Plot",
+    examples: [`Plot.fn({fn: fn, min: 3, max: 5})`],
+    definitions: [
+      makeDefinition(
+        "fn",
+        [frRecord(["fn", frLambda], ["min", frNumber], ["max", frNumber])],
+        ([{ fn, min, max }]) => {
+          return Result.Ok(
+            vPlot({
+              type: "fn",
+              fn,
+              min,
+              max,
             })
           );
         }

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -59,7 +59,7 @@ export const library = [
   maker.make({
     name: "fn",
     output: "Plot",
-    examples: [`Plot.fn({fn: fn, min: 3, max: 5})`],
+    examples: [`Plot.fn({fn: {|x|x*x}, min: 3, max: 5})`],
     definitions: [
       makeDefinition(
         "fn",

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -1,17 +1,17 @@
+import { PointMass } from "../dist/SymbolicDist";
 import { makeDefinition } from "../library/registry/fnDefinition";
 import {
   frArray,
-  frString,
-  frRecord,
   frDistOrNumber,
   frLambda,
   frNumber,
+  frRecord,
+  frString,
 } from "../library/registry/frTypes";
-import { PointMass } from "../dist/SymbolicDist";
 import { FnFactory } from "../library/registry/helpers";
-import * as Result from "../utility/result";
-import { vPlot, LabeledDistribution, vLambda } from "../value";
 import { REOther } from "../reducer/ErrorMessage";
+import * as Result from "../utility/result";
+import { LabeledDistribution, vPlot } from "../value";
 
 const maker = new FnFactory({
   nameSpace: "Plot",

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -18,38 +18,19 @@ const makeStdLib = (): Namespace => {
   res = res.merge(makeMathConstants());
   res = res.merge(makeVersionConstant());
 
-  // array and record lookups
+  // field lookups
   res = res.set(
     "$_atIndex_$",
     vLambda(
       new BuiltinLambda("$_atIndex_$", (inputs) => {
-        if (
-          inputs.length === 2 &&
-          inputs[0].type === "Array" &&
-          inputs[1].type === "Number"
-        ) {
-          const arr = inputs[0].value;
-          const index = inputs[1].value | 0; // TODO - fail on non-integer indices?
-          if (index >= 0 && index < arr.length) {
-            return arr[index];
-          } else {
-            return ErrorMessage.throw(
-              REArrayIndexNotFound("Array index not found", index)
-            );
-          }
-        } else if (
-          inputs.length === 2 &&
-          inputs[0].type === "Record" &&
-          inputs[1].type === "String"
-        ) {
-          const dict = inputs[0].value;
-          const index = inputs[1].value;
-          return (
-            dict.get(index) ??
-            ErrorMessage.throw(
-              RERecordPropertyNotFound("Record property not found", index)
-            )
-          );
+        if (inputs.length !== 2) {
+          // should never happen
+          return ErrorMessage.throw(REOther("$_atIndex_$ internal error"));
+        }
+
+        const [obj, key] = inputs;
+        if ("get" in obj) {
+          return obj.get(key);
         } else {
           return ErrorMessage.throw(
             REOther("Trying to access key on wrong value")

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -1,15 +1,10 @@
+import { Namespace, NamespaceMap } from "../reducer/bindings";
+import { ErrorMessage, REOther } from "../reducer/ErrorMessage";
+import { BuiltinLambda } from "../reducer/lambda";
 import { Value, vLambda } from "../value";
 import { makeMathConstants } from "./math";
-import { makeVersionConstant } from "./version";
 import * as registry from "./registry";
-import { Namespace, NamespaceMap } from "../reducer/bindings";
-import { BuiltinLambda } from "../reducer/lambda";
-import {
-  ErrorMessage,
-  REArrayIndexNotFound,
-  REOther,
-  RERecordPropertyNotFound,
-} from "../reducer/ErrorMessage";
+import { makeVersionConstant } from "./version";
 
 const makeStdLib = (): Namespace => {
   let res = NamespaceMap<string, Value>();

--- a/packages/squiggle-lang/src/public/SqLambdaDeclaration.ts
+++ b/packages/squiggle-lang/src/public/SqLambdaDeclaration.ts
@@ -1,5 +1,24 @@
 import { LambdaDeclaration } from "../reducer/declaration";
+import { SqLambda } from "./SqLambda";
+import { SqValueLocation } from "./SqValueLocation";
 
 export class SqLambdaDeclaration {
-  constructor(private _value: LambdaDeclaration) {}
+  constructor(
+    private _value: LambdaDeclaration,
+    public location: SqValueLocation
+  ) {}
+
+  get fn() {
+    return new SqLambda(
+      this._value.fn,
+      new SqValueLocation(this.location.project, this.location.sourceId, {
+        ...this.location.path,
+        items: [...this.location.path.items, "fn"],
+      })
+    );
+  }
+
+  get inputs() {
+    return this._value.args;
+  }
 }

--- a/packages/squiggle-lang/src/public/SqPlot.ts
+++ b/packages/squiggle-lang/src/public/SqPlot.ts
@@ -1,17 +1,25 @@
 import { Plot, vPlot } from "../value";
 import { wrapDistribution } from "./SqDistribution";
+import { SqLambda } from "./SqLambda";
 import { SqPlotValue } from "./SqValue";
 import { SqValueLocation } from "./SqValueLocation";
 
-export class SqPlot {
-  constructor(private _value: Plot, public location: SqValueLocation) {}
-
-  get distributions() {
-    return this._value.distributions.map(({ name, distribution }) => ({
-      name,
-      distribution: wrapDistribution(distribution),
-    }));
+export const wrapPlot = (value: Plot, location: SqValueLocation): SqPlot => {
+  if (value.type === "distributions") {
+    return new SqDistributionsPlot(value, location);
+  } else if (value.type === "fn") {
+    return new SqFnPlot(value, location);
   }
+  throw new Error(`Unknown value ${value}`);
+};
+
+abstract class SqAbstractPlot<T extends Plot["type"]> {
+  abstract tag: T;
+
+  constructor(
+    protected _value: Extract<Plot, { type: T }>,
+    public location: SqValueLocation
+  ) {}
 
   toString() {
     return vPlot(this._value).toString();
@@ -21,3 +29,36 @@ export class SqPlot {
     return new SqPlotValue(vPlot(this._value), this.location);
   }
 }
+
+export class SqDistributionsPlot extends SqAbstractPlot<"distributions"> {
+  tag = "distributions" as const;
+
+  get distributions() {
+    return this._value.distributions.map(({ name, distribution }) => ({
+      name,
+      distribution: wrapDistribution(distribution),
+    }));
+  }
+}
+
+export class SqFnPlot extends SqAbstractPlot<"fn"> {
+  tag = "fn" as const;
+
+  get fn() {
+    return new SqLambda(
+      this._value.fn,
+      new SqValueLocation(this.location.project, this.location.sourceId, {
+        ...this.location.path,
+        items: [...this.location.path.items, "fn"],
+      })
+    );
+  }
+  get min() {
+    return this._value.min;
+  }
+  get max() {
+    return this._value.max;
+  }
+}
+
+export type SqPlot = SqDistributionsPlot | SqFnPlot;

--- a/packages/squiggle-lang/src/public/SqValue.ts
+++ b/packages/squiggle-lang/src/public/SqValue.ts
@@ -3,7 +3,7 @@ import { SqDistribution, wrapDistribution } from "./SqDistribution";
 import { SqLambda } from "./SqLambda";
 import { SqLambdaDeclaration } from "./SqLambdaDeclaration";
 import { SqRecord } from "./SqRecord";
-import { SqPlot } from "./SqPlot";
+import { SqPlot, wrapPlot } from "./SqPlot";
 import { SqArray } from "./SqArray";
 import { SqValueLocation } from "./SqValueLocation";
 import { SqError } from "./SqError";
@@ -194,7 +194,7 @@ export class SqPlotValue extends SqAbstractValue<"Plot", SqPlot> {
   tag = "Plot" as const;
 
   get value() {
-    return new SqPlot(this._value.value, this.location);
+    return wrapPlot(this._value.value, this.location);
   }
 
   asJS() {

--- a/packages/squiggle-lang/src/public/SqValue.ts
+++ b/packages/squiggle-lang/src/public/SqValue.ts
@@ -101,7 +101,7 @@ export class SqDeclarationValue extends SqAbstractValue<
   tag = "Declaration" as const;
 
   get value() {
-    return new SqLambdaDeclaration(this._value.value);
+    return new SqLambdaDeclaration(this._value.value, this.location);
   }
 
   asJS() {

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -81,11 +81,18 @@ class VDate {
 }
 export const vDate = (v: Date) => new VDate(v);
 
-class VDeclaration {
+class VDeclaration implements Indexable {
   readonly type = "Declaration" as const;
   constructor(public value: LambdaDeclaration) {}
   toString() {
     return declarationToString(this.value, (f) => vLambda(f).toString());
+  }
+  get(key: Value) {
+    if (key.type === "String" && key.value === "fn") {
+      return vLambda(this.value.fn);
+    }
+
+    return ErrorMessage.throw(REOther("Trying to access key on wrong value"));
   }
 }
 export const vLambdaDeclaration = (v: LambdaDeclaration) => new VDeclaration(v);

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -194,7 +194,7 @@ class VPlot implements Indexable {
   readonly type = "Plot" as const;
   constructor(public value: Plot) {}
 
-  toString() {
+  toString(): string {
     switch (this.value.type) {
       case "distributions":
         return `Plot containing ${this.value.distributions
@@ -202,9 +202,6 @@ class VPlot implements Indexable {
           .join(", ")}`;
       case "fn":
         return `Plot for function ${this.value.fn}`;
-      default:
-        // never happens
-        return "Unknown plot";
     }
   }
 

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -20,6 +20,11 @@ export type ReducerFn = (
 
 export type ValueMap = Namespace;
 
+// Mixin for values that allow field lookups; just for type safety.
+type Indexable = {
+  get(key: Value): Value;
+};
+
 /*
 Value classes are shaped in a similar way and can work as discriminated unions thank to the `type` property.
 
@@ -32,7 +37,7 @@ If you add a new value class, don't forget to add it to the "Value" union type b
 "vBlah" functions are just for the sake of brevity, so that we don't have to prefix any value creation with "new".
 */
 
-class VArray {
+class VArray implements Indexable {
   readonly type = "Array" as const;
   constructor(public value: Value[]) {}
   toString(): string {
@@ -121,7 +126,7 @@ class VString {
 }
 export const vString = (v: string) => new VString(v);
 
-class VRecord {
+class VRecord implements Indexable {
   readonly type = "Record" as const;
   constructor(public value: ValueMap) {}
   toString(): string {
@@ -185,7 +190,7 @@ export type Plot =
       max: number;
     };
 
-class VPlot {
+class VPlot implements Indexable {
   readonly type = "Plot" as const;
   constructor(public value: Plot) {}
 

--- a/packages/website/docs/Api/Danger.md
+++ b/packages/website/docs/Api/Danger.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 title: Danger
 ---
 

--- a/packages/website/docs/Api/Date.md
+++ b/packages/website/docs/Api/Date.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 6
 title: Date
 ---
 

--- a/packages/website/docs/Api/Dictionary.md
+++ b/packages/website/docs/Api/Dictionary.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 9
 title: Dictionary
 ---
 

--- a/packages/website/docs/Api/Dist.mdx
+++ b/packages/website/docs/Api/Dist.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 title: Distribution
 ---
 

--- a/packages/website/docs/Api/DistPointSet.md
+++ b/packages/website/docs/Api/DistPointSet.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 3
 title: Point Set Distribution
 ---
 

--- a/packages/website/docs/Api/DistSampleSet.mdx
+++ b/packages/website/docs/Api/DistSampleSet.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 2
 title: Sample Set Distribution
 ---
 

--- a/packages/website/docs/Api/Duration.mdx
+++ b/packages/website/docs/Api/Duration.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 title: Duration
 ---
 

--- a/packages/website/docs/Api/List.md
+++ b/packages/website/docs/Api/List.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 title: List
 ---
 

--- a/packages/website/docs/Api/Math.md
+++ b/packages/website/docs/Api/Math.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 5
 title: Math
 ---
 

--- a/packages/website/docs/Api/Number.mdx
+++ b/packages/website/docs/Api/Number.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 4
 title: Number
 ---
 

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -1,0 +1,53 @@
+---
+sidebar_position: 10
+title: Plot
+---
+
+The Plot module provides functions to create plots of distributions and functions. The two primary functions are `Plot.dists` and `Plot.fn`, which allow you to plot multiple labeled distributions and plot functions respectively.
+
+### Plot.dists
+
+Plots one or more labeled distributions on the same plot. Distributions can be either continuous, discrete, or a single number.
+
+```
+Plot.dists: ({dists: list<{name: string, value: distribution | number}>}) => plot
+```
+
+Examples:
+
+```
+Plot.dists({
+    dists: [{name: "dist", value: normal(0, 1)}]
+});
+```
+
+```
+plot = Plot.dists({
+    dists: [
+        { name: "Normal(0,1)", value: normal(0, 1) },
+        { name: "Normal(2,1)", value: normal(2, 1) },
+    ]
+})
+```
+
+### Plot.fn
+
+Plots a function within a specified range of x-values.
+
+```
+Plot.fn: ({fn: (number => number), min: number, max: number}) => plot
+```
+
+Examples:
+
+```
+Plot.fn({fn: {|x| x * x}, min: 3, max: 5})
+```
+
+```
+const plot = Plot.fn({
+    fn: {|x| Math.sin(x)},
+    min: 0,
+    max: 2 * Math.pi,
+})
+```


### PR DESCRIPTION
Also, accidental discovery: methods on Squiggle objects are easy to implement, won't even need a parser change.

We can have `arr.length` and `dist.inv(0.5)` and so on. (see the refactoring from `$_atIndex_$` to `get` method on Value objects).

TODO:
- [x] disable minX/maxX fields in UI settings for function plots, or make them override the defaults
- [x] fix tests
- [x] documentation
- [x] support log X scale?