### PR TITLE
More CI percentiles

### DIFF
--- a/packages/squiggle-lang/__tests__/library/dist_test.ts
+++ b/packages/squiggle-lang/__tests__/library/dist_test.ts
@@ -1,3 +1,4 @@
+import { testRun } from "../helpers/helpers";
 import {
   MySkip,
   testEvalToBe,
@@ -5,34 +6,93 @@ import {
 } from "../helpers/reducerHelpers";
 
 describe("Symbolic constructors", () => {
-  testEvalToBe("Dist.normal(5,2)", "Normal(5,2)");
-  testEvalToBe("normal(5,2)", "Normal(5,2)");
-  testEvalToBe("normal({mean:5,stdev:2})", "Normal(5,2)");
-  testEvalToBe("-2 to 4", "Normal(1,1.8238704957353074)");
-  testEvalToBe("pointMass(5)", "PointMass(5)");
-});
-
-describe("eval on distribution functions", () => {
-  describe("normal distribution", () => {
+  describe("normal constructor", () => {
+    testEvalToBe("Dist.normal(5,2)", "Normal(5,2)");
     testEvalToBe("normal(5,2)", "Normal(5,2)");
-  });
-  describe("lognormal distribution", () => {
-    testEvalToBe("lognormal(5,2)", "Lognormal(5,2)");
-  });
-  describe("unaryMinus", () => {
-    testEvalToBe("mean(-normal(5,2))", "-5");
-    testEvalToBe("-normal(5,2)", "Normal(-5,2)");
-  });
-  describe("to", () => {
+
+    testEvalToBe("normal({mean:5,stdev:2})", "Normal(5,2)");
+
+    testEvalToBe("-2 to 4", "Normal(1,1.8238704957353071)");
+    testEvalToBe("to(-2,2)", "Normal(0,1.2159136638235382)");
     testEvalToBe(
-      "5 to 2",
-      "Error(Error: Low value must be less than high value.)"
+      "4 to -2",
+      "Error(Error: Low value must be less than high value)"
     );
+
+    testEvalToBe("normal({p5: -2, p95: 4})", "Normal(1,1.8238704957353071)");
+    expect(testRun("normal({p5: -2, p95: 4}) -> inv(0.05)").value).toBeCloseTo(
+      -2
+    );
+    expect(testRun("normal({p5: -2, p95: 4}) -> inv(0.95)").value).toBeCloseTo(
+      4
+    );
+
+    testEvalToBe("normal({p10: -2, p90: 4})", "Normal(1,2.3409124382171367)");
+    expect(testRun("normal({p10: -2, p90: 4}) -> inv(0.1)").value).toBeCloseTo(
+      -2
+    );
+    expect(testRun("normal({p10: -2, p90: 4}) -> inv(0.9)").value).toBeCloseTo(
+      4
+    );
+
+    testEvalToBe("normal({p25: -2, p75: 4})", "Normal(1,4.447806655516805)");
+    expect(testRun("normal({p25: -2, p75: 4}) -> inv(0.25)").value).toBeCloseTo(
+      -2
+    );
+    expect(testRun("normal({p25: -2, p75: 4}) -> inv(0.75)").value).toBeCloseTo(
+      4
+    );
+  });
+
+  describe("lognormal constructor", () => {
+    testEvalToBe("lognormal(5,2)", "Lognormal(5,2)");
+
     testEvalToBe(
       "to(2,5)",
       "Lognormal(1.1512925464970227,0.27853260523016377)"
     );
-    testEvalToBe("to(-2,2)", "Normal(0,1.2159136638235384)");
+
+    testEvalToBe(
+      "lognormal({p5: 2, p95: 5})",
+      "Lognormal(1.1512925464970227,0.27853260523016377)"
+    );
+    expect(
+      testRun("lognormal({p5: 2, p95: 5}) -> inv(0.05)").value
+    ).toBeCloseTo(2);
+    expect(
+      testRun("lognormal({p5: 2, p95: 5}) -> inv(0.95)").value
+    ).toBeCloseTo(5);
+
+    testEvalToBe(
+      "lognormal({p10: 2, p90: 5})",
+      "Lognormal(1.1512925464970227,0.3574927285445488)"
+    );
+    expect(
+      testRun("lognormal({p10: 2, p90: 5}) -> inv(0.1)").value
+    ).toBeCloseTo(2);
+    expect(
+      testRun("lognormal({p10: 2, p90: 5}) -> inv(0.9)").value
+    ).toBeCloseTo(5);
+
+    testEvalToBe(
+      "lognormal({p25: 2, p75: 5})",
+      "Lognormal(1.1512925464970227,0.6792473359363719)"
+    );
+    expect(
+      testRun("lognormal({p25: 2, p75: 5}) -> inv(0.25)").value
+    ).toBeCloseTo(2);
+    expect(
+      testRun("lognormal({p25: 2, p75: 5}) -> inv(0.75)").value
+    ).toBeCloseTo(5);
+  });
+
+  testEvalToBe("pointMass(5)", "PointMass(5)");
+});
+
+describe("eval on distribution functions", () => {
+  describe("unaryMinus", () => {
+    testEvalToBe("mean(-normal(5,2))", "-5");
+    testEvalToBe("-normal(5,2)", "Normal(-5,2)");
   });
   describe("mean", () => {
     testEvalToBe("mean(normal(5,2))", "5");

--- a/packages/squiggle-lang/src/dist/SymbolicDist.ts
+++ b/packages/squiggle-lang/src/dist/SymbolicDist.ts
@@ -207,6 +207,9 @@ export class Normal extends SymbolicDist {
   }
 
   static from90PercentCI(low: number, high: number): result<Normal, string> {
+    if (low >= high) {
+      return Result.Error("Low value must be less than high value.");
+    }
     const mean = E_A_Floats.mean([low, high]);
     const stdev = (high - low) / (2 * normal95confidencePoint);
     return Normal.make({ mean, stdev });
@@ -576,7 +579,10 @@ export class Lognormal extends SymbolicDist {
     );
   }
 
-  static from90PercentCI(low: number, high: number) {
+  static from90PercentCI(low: number, high: number): result<Lognormal, string> {
+    if (low >= high) {
+      return Result.Error("Low value must be less than high value.");
+    }
     const logLow = Math.log(low);
     const logHigh = Math.log(high);
     const mu = E_A_Floats.mean([logLow, logHigh]);
@@ -990,13 +996,11 @@ export class PointMass extends SymbolicDist {
 
 export const From90thPercentile = {
   make(low: number, high: number): result<SymbolicDist, string> {
-    if (low <= 0 && low < high) {
+    if (low <= 0) {
       return Normal.from90PercentCI(low, high);
-    }
-    if (low < high) {
+    } else {
       return Lognormal.from90PercentCI(low, high);
     }
-    return Result.Error("Low value must be less than high value.");
   },
 };
 

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -21,6 +21,12 @@ import {
   REOther,
 } from "../reducer/ErrorMessage";
 
+const CI_CONFIG = [
+  { lowKey: "p5", highKey: "p95", probability: 0.9 },
+  { lowKey: "p10", highKey: "p90", probability: 0.8 },
+  { lowKey: "p25", highKey: "p75", probability: 0.5 },
+] as const;
+
 const maker = new FnFactory({
   nameSpace: "Dist",
   requiresNamespace: false,
@@ -89,17 +95,20 @@ const makeTwoArgsDist = (
   );
 };
 
-const makeP5P95Dist = (
+const makeCIDist = <K1 extends string, K2 extends string>(
   name: string,
+  lowKey: K1,
+  highKey: K2,
   fn: (
-    p5: number,
-    p95: number
+    low: number,
+    high: number
   ) => Result.result<SymbolicDist.SymbolicDist, string>
 ) => {
   return makeDefinition(
     name,
-    [frRecord(["p5", frNumber], ["p95", frNumber])],
-    ([{ p5, p95 }], { environment }) => twoVarSample(p5, p95, environment, fn)
+    [frRecord([lowKey, frNumber], [highKey, frNumber])],
+    ([record], { environment }) =>
+      twoVarSample(record[lowKey], record[highKey], environment, fn)
   );
 };
 
@@ -155,8 +164,14 @@ export const library: FRFunction[] = [
       makeTwoArgsDist("normal", (mean, stdev) =>
         SymbolicDist.Normal.make({ mean, stdev })
       ),
-      makeP5P95Dist("normal", (p5, p95) =>
-        SymbolicDist.Normal.from90PercentCI(p5, p95)
+      ...CI_CONFIG.map((entry) =>
+        makeCIDist("normal", entry.lowKey, entry.highKey, (low, high) =>
+          SymbolicDist.Normal.fromCredibleInterval({
+            low,
+            high,
+            probability: entry.probability,
+          })
+        )
       ),
       makeMeanStdevDist("normal", (mean, stdev) =>
         SymbolicDist.Normal.make({ mean, stdev })
@@ -174,8 +189,14 @@ export const library: FRFunction[] = [
       makeTwoArgsDist("lognormal", (mu, sigma) =>
         SymbolicDist.Lognormal.make({ mu, sigma })
       ),
-      makeP5P95Dist("lognormal", (p5, p95) =>
-        SymbolicDist.Lognormal.from90PercentCI(p5, p95)
+      ...CI_CONFIG.map((entry) =>
+        makeCIDist("lognormal", entry.lowKey, entry.highKey, (low, high) =>
+          SymbolicDist.Lognormal.fromCredibleInterval({
+            low,
+            high,
+            probability: entry.probability,
+          })
+        )
       ),
       makeMeanStdevDist("lognormal", (mean, stdev) =>
         SymbolicDist.Lognormal.fromMeanAndStdev({ mean, stdev })
@@ -232,15 +253,12 @@ export const library: FRFunction[] = [
   }),
   maker.make({
     name: "to (distribution)",
-    examples: [`5 to 10`, `to(5,10)`, `-5 to 5`],
-    definitions: [
-      makeTwoArgsDist("to", (low, high) =>
-        SymbolicDist.From90thPercentile.make(low, high)
-      ),
-      makeTwoArgsDist("credibleIntervalToDistribution", (low, high) =>
-        SymbolicDist.From90thPercentile.make(low, high)
-      ),
-    ],
+    examples: ["5 to 10", "to(5,10)", "-5 to 5"],
+    definitions: ["to", "credibleIntervalToDistribution"].map((functionName) =>
+      makeTwoArgsDist(functionName, (low, high) =>
+        SymbolicDist.makeFromCredibleInterval({ low, high, probability: 0.9 })
+      )
+    ),
   }),
   maker.make({
     name: "exponential",

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -185,6 +185,8 @@ export const library: FRFunction[] = [
     examples: [
       "lognormal(0.5, 0.8)",
       "lognormal({p5: 4, p95: 10})",
+      "lognormal({p10: 4, p90: 10})",
+      "lognormal({p25: 4, p75: 10})",
       "lognormal({mean: 5, stdev: 2})",
     ],
     definitions: [

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -158,6 +158,8 @@ export const library: FRFunction[] = [
     examples: [
       "normal(5,1)",
       "normal({p5: 4, p95: 10})",
+      "normal({p10: 4, p90: 10})",
+      "normal({p25: 4, p75: 10})",
       "normal({mean: 5, stdev: 2})",
     ],
     definitions: [


### PR DESCRIPTION
Support for `{ p10: ..., p90: ... }` and `{ p25: ..., p75: ... }` in `normal()` and `lognormal()`.