### PR TITLE
Algebraic operation improvements

### DIFF
--- a/packages/squiggle-lang/__tests__/library/dist_test.ts
+++ b/packages/squiggle-lang/__tests__/library/dist_test.ts
@@ -137,6 +137,8 @@ describe("eval on distribution functions", () => {
   });
   describe("multiply", () => {
     testEvalToBe("normal(10, 2) * 2", "Normal(20,4)");
+    testEvalToBe("normal(10, 2) * 0", "PointMass(0)");
+    testEvalToBe("0 * normal(10, 2)", "PointMass(0)");
     testEvalToBe("2 * normal(10, 2)", "Normal(20,4)");
     testEvalToBe(
       "lognormal(5,2) * lognormal(10,2)",

--- a/packages/squiggle-lang/package.json
+++ b/packages/squiggle-lang/package.json
@@ -20,7 +20,7 @@
     "format": "yarn format:prettier",
     "prepack": "yarn build && yarn test",
     "all": "yarn build && yarn test",
-    "cli": "node ./dist/src/cli/index.js"
+    "cli": "node --experimental-vm-modules ./dist/esm/src/cli/index.js"
   },
   "author": "Quantified Uncertainty Research Institute",
   "dependencies": {

--- a/packages/squiggle-lang/src/dist/DistOperations/AlgebraicCombination.ts
+++ b/packages/squiggle-lang/src/dist/DistOperations/AlgebraicCombination.ts
@@ -22,19 +22,19 @@ export enum AlgebraicCombinationStrategy {
   AsConvolution,
 }
 
-/* Given two random variables A and B, this returns the distribution
-   of a new variable that is the result of the operation on A and B.
-   For instance, normal(0, 1) + normal(1, 1) -> normal(1, 2).
-   In general, this is implemented via convolution.
-*/
-const InputValidator = {
+// Checks if operation is possible, returns undefined if everything is ok.
+const validateInputs = (
+  t1: BaseDist,
+  t2: BaseDist,
+  arithmeticOperation: AlgebraicOperation
+): DistError | undefined => {
   /*
      It would be good to also do a check to make sure that probability mass for the second
      operand, at value 1.0, is 0 (or approximately 0). However, we'd ideally want to check
      that both the probability mass and the probability density are greater than zero.
      Right now we don't yet have a way of getting probability mass, so I'll leave this for later.
  */
-  getLogarithmInputError(t1: BaseDist, t2: BaseDist): DistError | undefined {
+  const getLogarithmInputError = (): DistError | undefined => {
     const isDistNotGreaterThanZero = (t: BaseDist) =>
       t.cdf(magicNumbers.Epsilon.ten) > 0;
 
@@ -49,19 +49,13 @@ const InputValidator = {
       );
     }
     return undefined;
-  },
+  };
 
-  run(
-    t1: BaseDist,
-    t2: BaseDist,
-    arithmeticOperation: AlgebraicOperation
-  ): DistError | undefined {
-    if (arithmeticOperation == "Logarithm") {
-      return InputValidator.getLogarithmInputError(t1, t2);
-    } else {
-      return undefined;
-    }
-  },
+  if (arithmeticOperation == "Logarithm") {
+    return getLogarithmInputError();
+  } else {
+    return undefined;
+  }
 };
 
 const StrategyCallOnValidatedInputs = {
@@ -205,6 +199,11 @@ const runStrategyOnValidatedInputs = ({
   }
 };
 
+/* Given two random variables A and B, this returns the distribution
+   of a new variable that is the result of the operation on A and B.
+   For instance, normal(0, 1) + normal(1, 1) -> normal(1, 2).
+   In general, this is implemented via convolution.
+*/
 export const algebraicCombination = ({
   t1,
   t2,
@@ -216,7 +215,7 @@ export const algebraicCombination = ({
   env: Env;
   arithmeticOperation: AlgebraicOperation;
 }): result<BaseDist, DistError> => {
-  const invalidOperationError = InputValidator.run(t1, t2, arithmeticOperation);
+  const invalidOperationError = validateInputs(t1, t2, arithmeticOperation);
 
   if (invalidOperationError !== undefined) {
     return Result.Error(invalidOperationError);

--- a/packages/squiggle-lang/src/dist/DistOperations/index.ts
+++ b/packages/squiggle-lang/src/dist/DistOperations/index.ts
@@ -103,18 +103,17 @@ export const logScoreScalarAnswer = ({
 };
 
 //TODO: Add faster pointwiseCombine fn
-const pointwiseCombination = (
-  t1: BaseDist,
-  {
-    env,
-    algebraicCombination,
-    t2,
-  }: {
-    env: Env;
-    algebraicCombination: AlgebraicOperation;
-    t2: BaseDist;
-  }
-): result<BaseDist, DistError> => {
+const pointwiseCombination = ({
+  t1,
+  t2,
+  env,
+  algebraicOperation,
+}: {
+  t1: BaseDist;
+  t2: BaseDist;
+  env: Env;
+  algebraicOperation: AlgebraicOperation;
+}): result<BaseDist, DistError> => {
   const p1r = t1.toPointSetDist(env);
   const p2r = t2.toPointSetDist(env);
   if (!p1r.ok) {
@@ -129,7 +128,7 @@ const pointwiseCombination = (
   const result = PointSetDist.combinePointwise(
     p1,
     p2,
-    Operation.Algebraic.toFn(algebraicCombination)
+    Operation.Algebraic.toFn(algebraicOperation)
   );
   if (result.ok) {
     return result;
@@ -142,11 +141,11 @@ export const pointwiseCombinationFloat = (
   t: BaseDist,
   {
     env,
-    algebraicCombination,
+    algebraicOperation,
     f,
   }: {
     env: Env;
-    algebraicCombination: AlgebraicOperation;
+    algebraicOperation: AlgebraicOperation;
     f: number;
   }
 ): result<BaseDist, DistError> => {
@@ -170,24 +169,24 @@ export const pointwiseCombinationFloat = (
       );
     });
 
-  if (algebraicCombination === "Add" || algebraicCombination === "Subtract") {
+  if (algebraicOperation === "Add" || algebraicOperation === "Subtract") {
     return Result.Error(distributionVerticalShiftIsInvalid());
   } else if (
-    algebraicCombination === "Multiply" ||
-    algebraicCombination === "Divide" ||
-    algebraicCombination === "Power" ||
-    algebraicCombination === "Logarithm"
+    algebraicOperation === "Multiply" ||
+    algebraicOperation === "Divide" ||
+    algebraicOperation === "Power" ||
+    algebraicOperation === "Logarithm"
   ) {
-    return executeCombination(algebraicCombination);
-  } else if (algebraicCombination.NAME === "LogarithmWithThreshold") {
-    return executeCombination(algebraicCombination);
+    return executeCombination(algebraicOperation);
+  } else if (algebraicOperation.NAME === "LogarithmWithThreshold") {
+    return executeCombination(algebraicOperation);
   } else {
-    throw new Error(`Unknown AlgebraicOperation ${algebraicCombination}`);
+    throw new Error(`Unknown AlgebraicOperation ${algebraicOperation}`);
   }
 };
 
 export const scaleLog = (t: BaseDist, f: number, { env }: { env: Env }) =>
-  pointwiseCombinationFloat(t, { env, algebraicCombination: "Logarithm", f });
+  pointwiseCombinationFloat(t, { env, algebraicOperation: "Logarithm", f });
 
 //TODO: The result should always cumulatively sum to 1. This would be good to test.
 //TODO: If the inputs are not normalized, this will return poor results. The weights probably refer to the post-normalized forms. It would be good to apply a catch to this.
@@ -198,15 +197,16 @@ export const mixture = (
   const scaleMultiplyFn = (dist: BaseDist, weight: number) =>
     pointwiseCombinationFloat(dist, {
       env,
-      algebraicCombination: "Multiply",
+      algebraicOperation: "Multiply",
       f: weight,
     });
 
   const pointwiseAddFn = (dist1: BaseDist, dist2: BaseDist) =>
-    pointwiseCombination(dist1, {
-      env,
-      algebraicCombination: "Add",
+    pointwiseCombination({
+      t1: dist1,
       t2: dist2,
+      env,
+      algebraicOperation: "Add",
     });
 
   const allValuesAreSampleSet = (v: [BaseDist, number][]) =>
@@ -265,15 +265,16 @@ const algebraic = (
 ) => algebraicCombination({ t1, t2, arithmeticOperation: operation, env });
 
 const pointwise = (
-  dist1: BaseDist,
-  dist2: BaseDist,
+  t1: BaseDist,
+  t2: BaseDist,
   env: Env,
-  operation: AlgebraicOperation
+  algebraicOperation: AlgebraicOperation
 ) =>
-  pointwiseCombination(dist1, {
+  pointwiseCombination({
+    t1,
+    t2,
     env,
-    algebraicCombination: operation,
-    t2: dist2,
+    algebraicOperation,
   });
 
 export const BinaryOperations: { [k: string]: BinaryOperation } = {

--- a/packages/squiggle-lang/src/dist/DistOperations/index.ts
+++ b/packages/squiggle-lang/src/dist/DistOperations/index.ts
@@ -12,10 +12,7 @@ import {
   operationDistError,
   otherError,
 } from "../DistError.js";
-import {
-  algebraicCombination,
-  AsAlgebraicCombinationStrategy,
-} from "./AlgebraicCombination.js";
+import { algebraicCombination } from "./AlgebraicCombination.js";
 import { Env } from "../env.js";
 import * as SampleSetDist from "../SampleSetDist/SampleSetDist.js";
 import { OperationError } from "../../operationError.js";
@@ -261,17 +258,11 @@ export type BinaryOperation = (
 
 // private helpers
 const algebraic = (
-  dist1: BaseDist,
-  dist2: BaseDist,
+  t1: BaseDist,
+  t2: BaseDist,
   env: Env,
   operation: AlgebraicOperation
-) =>
-  algebraicCombination(dist1, {
-    strategy: AsAlgebraicCombinationStrategy.AsDefault,
-    arithmeticOperation: operation,
-    env,
-    t2: dist2,
-  });
+) => algebraicCombination({ t1, t2, arithmeticOperation: operation, env });
 
 const pointwise = (
   dist1: BaseDist,

--- a/packages/squiggle-lang/src/dist/SymbolicDist.ts
+++ b/packages/squiggle-lang/src/dist/SymbolicDist.ts
@@ -262,12 +262,15 @@ export class Normal extends SymbolicDist {
     operation: Operation.AlgebraicOperation,
     n1: number,
     n2: Normal
-  ): Normal | undefined {
+  ): SymbolicDist | undefined {
     if (operation === "Add") {
       return new Normal({ mean: n1 + n2._mean, stdev: n2._stdev });
     } else if (operation === "Subtract") {
       return new Normal({ mean: n1 - n2._mean, stdev: n2._stdev });
     } else if (operation === "Multiply") {
+      if (n1 === 0) {
+        return new PointMass(0);
+      }
       return new Normal({
         mean: n1 * n2._mean,
         stdev: Math.abs(n1) * n2._stdev,
@@ -280,12 +283,15 @@ export class Normal extends SymbolicDist {
     operation: Operation.AlgebraicOperation,
     n1: Normal,
     n2: number
-  ): Normal | undefined {
+  ): SymbolicDist | undefined {
     if (operation === "Add") {
       return new Normal({ mean: n1._mean + n2, stdev: n1._stdev });
     } else if (operation === "Subtract") {
       return new Normal({ mean: n1._mean - n2, stdev: n1._stdev });
     } else if (operation === "Multiply") {
+      if (n2 === 0) {
+        return new PointMass(0);
+      }
       return new Normal({
         mean: n1._mean * n2,
         stdev: n1._stdev * Math.abs(n2),
@@ -1039,11 +1045,11 @@ export function makeFromCredibleInterval({
   }
 }
 
-/* Calling e.g. "Normal.operate" returns an optional that wraps a result.
-       If the optional is None, there is no valid analytic solution. If it Some, it
-       can still return an error if there is a serious problem,
-       like in the case of a divide by 0.
-   */
+/* Calling e.g. "Normal.operate" returns an optional Result.
+   If the result is undefined, there is no valid analytic solution.
+   If it's a Result object, it can still return an error if there is a serious problem,
+   like in the case of a divide by 0.
+*/
 export const tryAnalyticalSimplification = (
   d1: SymbolicDist,
   d2: SymbolicDist,

--- a/packages/squiggle-lang/src/fr/genericDist.ts
+++ b/packages/squiggle-lang/src/fr/genericDist.ts
@@ -176,7 +176,7 @@ export const library: FRFunction[] = [
         toValueResult(
           pointwiseCombinationFloat(dist, {
             env: environment,
-            algebraicCombination: {
+            algebraicOperation: {
               NAME: "LogarithmWithThreshold",
               VAL: eps,
             },
@@ -191,7 +191,7 @@ export const library: FRFunction[] = [
       unpackDistResult(
         pointwiseCombinationFloat(dist, {
           env,
-          algebraicCombination: "Multiply",
+          algebraicOperation: "Multiply",
           f,
         })
       ),
@@ -202,7 +202,7 @@ export const library: FRFunction[] = [
       unpackDistResult(
         pointwiseCombinationFloat(dist, {
           env,
-          algebraicCombination: "Power",
+          algebraicOperation: "Power",
           f,
         })
       ),
@@ -213,7 +213,7 @@ export const library: FRFunction[] = [
       unpackDistResult(
         pointwiseCombinationFloat(dist, {
           env,
-          algebraicCombination: "Power",
+          algebraicOperation: "Power",
           f: Math.E,
         })
       ),


### PR DESCRIPTION
Partial fix for #1661: fixes the example given in the issue, but only for symbolic distributions.

- refactor AlgebraicCombination.ts (removed strategies enum, simplified the code, more idiomatic for Typescript)
- support for pointMass operations in `tryAnalyticalSimplification`

Unfortunately, I haven't fixed zero multiplication for pointsets yet, only for symbolics. That's because `combineShapesContinuousDiscrete` convolution currently returns `XYShape`; but to support multiplication by 0, it should be able to return a mixed pointset with a discrete `0` component. So it would require a more significant refactoring to fix.