### PR TITLE
Remove oneLine feature

### DIFF
--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 
-import { SqLocation } from "@quri/squiggle-lang";
-
+import { useMaybeControlledValue } from "../lib/hooks/index.js";
+import { SquiggleArgs, useSquiggle } from "../lib/hooks/useSquiggle.js";
+import { getErrorLocations, getValueToRender } from "../lib/utility.js";
 import { CodeEditor } from "./CodeEditor.js";
 import { SquiggleContainer } from "./SquiggleContainer.js";
-import { useMaybeControlledValue } from "../lib/hooks/index.js";
-import { useSquiggle, SquiggleArgs } from "../lib/hooks/useSquiggle.js";
 import { SquiggleViewer, SquiggleViewerProps } from "./SquiggleViewer/index.js";
-import { getErrorLocations, getValueToRender } from "../lib/utility.js";
 
 export type SquiggleEditorProps = SquiggleArgs & {
   defaultCode?: string;
@@ -35,7 +33,6 @@ export const SquiggleEditor: React.FC<SquiggleEditorProps> = (props) => {
         <CodeEditor
           value={code}
           onChange={setCode}
-          oneLine={true}
           showGutter={false}
           errorLocations={errorLocations}
           project={resultAndBindings.project}

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -247,7 +247,6 @@ export const SquigglePlayground: React.FC<PlaygroundProps> = (props) => {
         value={code}
         onChange={setCode}
         onSubmit={run}
-        oneLine={false}
         showGutter={true}
         height={height}
         project={resultAndBindings.project}

--- a/packages/components/src/languageSupport/squiggle.ts
+++ b/packages/components/src/languageSupport/squiggle.ts
@@ -11,130 +11,127 @@ import { snippetCompletion, CompletionContext } from "@codemirror/autocomplete";
 import { SqProject } from "@quri/squiggle-lang";
 import { parser } from "./generated/squiggle.js";
 
-function squiggle(project: SqProject) {
-  return () =>
-    new LanguageSupport(
-      LRLanguage.define({
-        name: "squiggle",
-        parser: parser.configure({
-          props: [
-            styleTags({
-              if: t.keyword,
-              then: t.keyword,
-              else: t.keyword,
+export function squiggleLanguageSupport(project: SqProject) {
+  return new LanguageSupport(
+    LRLanguage.define({
+      name: "squiggle",
+      parser: parser.configure({
+        props: [
+          styleTags({
+            if: t.keyword,
+            then: t.keyword,
+            else: t.keyword,
 
-              Equals: t.definitionOperator,
+            Equals: t.definitionOperator,
 
-              ArithOp: t.arithmeticOperator,
-              LogicOp: t.logicOperator,
-              ControlOp: t.controlOperator,
+            ArithOp: t.arithmeticOperator,
+            LogicOp: t.logicOperator,
+            ControlOp: t.controlOperator,
 
-              "{ }": t.brace,
-              "[ ]": t.squareBracket,
-              "( )": t.paren,
-              "|": t.squareBracket,
-              ",": t.separator,
+            "{ }": t.brace,
+            "[ ]": t.squareBracket,
+            "( )": t.paren,
+            "|": t.squareBracket,
+            ",": t.separator,
 
-              Syntax: t.annotation,
-              Boolean: t.bool,
-              Number: t.integer,
-              String: t.string,
-              Comment: t.comment,
-              Void: t.escape,
+            Syntax: t.annotation,
+            Boolean: t.bool,
+            Number: t.integer,
+            String: t.string,
+            Comment: t.comment,
+            Void: t.escape,
 
-              FunctionName: t.function(t.variableName),
+            FunctionName: t.function(t.variableName),
 
-              LambdaSyntax: t.blockComment,
+            LambdaSyntax: t.blockComment,
 
-              VariableName: t.constant(t.variableName),
-              Field: t.variableName,
-              LambdaParameter: t.variableName,
+            VariableName: t.constant(t.variableName),
+            Field: t.variableName,
+            LambdaParameter: t.variableName,
+          }),
+          foldNodeProp.add({
+            LambdaExpr: (context) => ({
+              from: context.getChild("NonEmptyProgram")?.from || 0,
+              to: context.getChild("NonEmptyProgram")?.to || 0,
             }),
-            foldNodeProp.add({
-              LambdaExpr: (context) => ({
-                from: context.getChild("NonEmptyProgram")?.from || 0,
-                to: context.getChild("NonEmptyProgram")?.to || 0,
-              }),
-              BlockExpr: foldInside,
-              RecordExpr: foldInside,
-              ArrayExpr: foldInside,
-            }),
-            indentNodeProp.add({
-              RecordExpr: (context) =>
-                context.baseIndent +
-                (context.textAfter === "}" ? 0 : context.unit),
-              BlockExpr: (context) =>
-                context.baseIndent +
-                (context.textAfter === "}" ? 0 : context.unit),
-              LambdaExpr: (context) =>
-                context.baseIndent +
-                (context.textAfter === "}" ? 0 : context.unit),
-              ArrayExpr: (context) =>
-                context.baseIndent +
-                (context.textAfter === "]" ? 0 : context.unit),
-            }),
-          ],
-        }),
-        languageData: {
-          commentTokens: {
-            line: "//",
-          },
-          autocomplete: (cmpl: CompletionContext) => {
-            const tree = syntaxTree(cmpl.state);
-            {
-              const lambda = cmpl.tokenBefore(["ArgsOpen"]);
-              if (lambda) {
-                return {
-                  from: lambda.from,
-                  options: [
-                    /*eslint no-template-curly-in-string: "off"*/
-                    snippetCompletion("|${args}| ${body}", {
-                      label: "|",
-                      detail: "lambda function",
-                      type: "syntax",
-                    }),
-                  ],
-                };
-              }
-            }
-            const field = cmpl.tokenBefore(["AccessIdentifier"]);
-            if (field === null) {
-              return undefined;
-            }
-            const from = field.from;
-
-            const cursor = tree.cursor();
-            let names: String[] = [];
-            while (cursor.next()) {
-              if (cursor.type.is("VariableName")) {
-                names.push(cmpl.state.doc.sliceString(cursor.from, cursor.to));
-              }
-            }
-            return {
-              from: from,
-              options: [
-                ...names.map((name) => ({
-                  label: name,
-                  type: "constant",
-                })),
-                ...project
-                  .getStdLib()
-                  .keySeq()
-                  .toArray()
-                  .map((name) => ({
-                    label: name,
-                    type: "function",
-                  })),
-              ],
-            };
-          },
-          closeBrackets: {
-            brackets: ['"', "'", "(", "{"],
-          },
-        },
+            BlockExpr: foldInside,
+            RecordExpr: foldInside,
+            ArrayExpr: foldInside,
+          }),
+          indentNodeProp.add({
+            RecordExpr: (context) =>
+              context.baseIndent +
+              (context.textAfter === "}" ? 0 : context.unit),
+            BlockExpr: (context) =>
+              context.baseIndent +
+              (context.textAfter === "}" ? 0 : context.unit),
+            LambdaExpr: (context) =>
+              context.baseIndent +
+              (context.textAfter === "}" ? 0 : context.unit),
+            ArrayExpr: (context) =>
+              context.baseIndent +
+              (context.textAfter === "]" ? 0 : context.unit),
+          }),
+        ],
       }),
-      []
-    );
-}
+      languageData: {
+        commentTokens: {
+          line: "//",
+        },
+        autocomplete: (cmpl: CompletionContext) => {
+          const tree = syntaxTree(cmpl.state);
+          {
+            const lambda = cmpl.tokenBefore(["ArgsOpen"]);
+            if (lambda) {
+              return {
+                from: lambda.from,
+                options: [
+                  /*eslint no-template-curly-in-string: "off"*/
+                  snippetCompletion("|${args}| ${body}", {
+                    label: "|",
+                    detail: "lambda function",
+                    type: "syntax",
+                  }),
+                ],
+              };
+            }
+          }
+          const field = cmpl.tokenBefore(["AccessIdentifier"]);
+          if (field === null) {
+            return undefined;
+          }
+          const from = field.from;
 
-export default squiggle;
+          const cursor = tree.cursor();
+          let names: String[] = [];
+          while (cursor.next()) {
+            if (cursor.type.is("VariableName")) {
+              names.push(cmpl.state.doc.sliceString(cursor.from, cursor.to));
+            }
+          }
+          return {
+            from: from,
+            options: [
+              ...names.map((name) => ({
+                label: name,
+                type: "constant",
+              })),
+              ...project
+                .getStdLib()
+                .keySeq()
+                .toArray()
+                .map((name) => ({
+                  label: name,
+                  type: "function",
+                })),
+            ],
+          };
+        },
+        closeBrackets: {
+          brackets: ['"', "'", "(", "{"],
+        },
+      },
+    }),
+    []
+  );
+}


### PR DESCRIPTION
It was unused and not needed, since the editor already defaults to one line mode if you don't set height, and somewhat broken.
(previously, with oneLine=true, it caused hidden code on line breaks, and also the single line didn't fix in the box)

This fix is straightforward and I'm going to merge it without the review, since I want to do 0.7.0 release soon.