### PR TITLE
Improve tooltip for errors in editor

### DIFF
--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useMaybeControlledValue } from "../lib/hooks/index.js";
 import { SquiggleArgs, useSquiggle } from "../lib/hooks/useSquiggle.js";
-import { getErrorLocations, getValueToRender } from "../lib/utility.js";
+import { getErrors, getValueToRender } from "../lib/utility.js";
 import { CodeEditor } from "./CodeEditor.js";
 import { SquiggleContainer } from "./SquiggleContainer.js";
 import { SquiggleViewer, SquiggleViewerProps } from "./SquiggleViewer/index.js";
@@ -22,7 +22,7 @@ export const SquiggleEditor: React.FC<SquiggleEditorProps> = (props) => {
 
   const resultAndBindings = useSquiggle({ ...props, code });
   const valueToRender = getValueToRender(resultAndBindings);
-  const errorLocations = getErrorLocations(resultAndBindings.result);
+  const errors = getErrors(resultAndBindings.result);
 
   return (
     <SquiggleContainer>
@@ -34,7 +34,7 @@ export const SquiggleEditor: React.FC<SquiggleEditorProps> = (props) => {
           value={code}
           onChange={setCode}
           showGutter={false}
-          errorLocations={errorLocations}
+          errors={errors}
           project={resultAndBindings.project}
         />
       </div>

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -21,7 +21,7 @@ import { useMaybeControlledValue, useSquiggle } from "../../lib/hooks/index.js";
 import { SquiggleArgs } from "../../lib/hooks/useSquiggle.js";
 
 import { JsImports } from "../../lib/jsImports.js";
-import { getErrorLocations, getValueToRender } from "../../lib/utility.js";
+import { getErrors, getValueToRender } from "../../lib/utility.js";
 import { CodeEditor } from "../CodeEditor.js";
 import { SquiggleContainer } from "../SquiggleContainer.js";
 import {
@@ -32,14 +32,14 @@ import { ViewSettingsForm, viewSettingsSchema } from "../ViewSettingsForm.js";
 import { StyledTab } from "../ui/StyledTab.js";
 
 import { ImportSettingsForm } from "./ImportSettingsForm.js";
+import { RunControls } from "./RunControls/index.js";
+import { useRunnerState } from "./RunControls/useRunnerState.js";
 import { ShareButton } from "./ShareButton.js";
 import {
   EnvironmentSettingsForm,
   playgroundSettingsSchema,
   type PlaygroundFormFields,
 } from "./playgroundSettings.js";
-import { RunControls } from "./RunControls/index.js";
-import { useRunnerState } from "./RunControls/useRunnerState.js";
 
 type PlaygroundProps = SquiggleArgs &
   Omit<SquiggleViewerProps, "result"> & {
@@ -138,12 +138,12 @@ export const SquigglePlayground: React.FC<PlaygroundProps> = (props) => {
       </div>
     );
 
-  const errorLocations = getErrorLocations(resultAndBindings.result);
+  const errors = getErrors(resultAndBindings.result);
 
   const firstTab = showEditor ? (
     <div className="border border-slate-200" data-testid="squiggle-editor">
       <CodeEditor
-        errorLocations={errorLocations}
+        errors={errors}
         value={code}
         onChange={setCode}
         onSubmit={runnerState.run}

--- a/packages/components/src/lib/utility.ts
+++ b/packages/components/src/lib/utility.ts
@@ -44,10 +44,9 @@ export function getValueToRender({
   );
 }
 
-export function getErrorLocations(result: ResultAndBindings["result"]) {
+export function getErrors(result: ResultAndBindings["result"]) {
   if (!result.ok) {
-    const location = result.value.location();
-    return location ? [location] : [];
+    return [result.value];
   } else {
     return [];
   }


### PR DESCRIPTION
The tooltip previously said "Syntax error!", now it shows the error text.