### PR TITLE
VS Code grammar improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,10 @@ Squiggle is a **monorepo** with several **packages**.
 - **website** is the site [squiggle-language.com](https://www.squiggle-language.com)
 - **vscode-ext** is the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=qURI.vscode-squiggle)
 
+# VS Code
+
+If you want to use [VS Code Jest extension](https://github.com/jest-community/vscode-jest), or share other useful workspace settings, such as multi-root mode, move `.vscode/squiggle.code-workspace.default` file to `.vscode/squiggle.code-workspace`.
+
 # Deployment ops
 
 We use Vercel, and it should only concern Slava, Sam, and Ozzie.

--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -12,16 +12,11 @@
   },
   "icon": "media/vendor/icon.png",
   "engines": {
-    "vscode": "^1.70.0"
+    "vscode": "^1.75.0"
   },
   "categories": [
     "Programming Languages",
     "Visualization"
-  ],
-  "activationEvents": [
-    "onLanguage:squiggle",
-    "onCustomEditor:squiggle.wysiwyg",
-    "onCommand:squiggle.preview"
   ],
   "main": "./dist/client/extension.js",
   "contributes": {

--- a/packages/vscode-ext/syntaxes/squiggle.tmLanguage.yaml
+++ b/packages/vscode-ext/syntaxes/squiggle.tmLanguage.yaml
@@ -89,5 +89,12 @@ repository:
     match: \b(\d+\.\d*|\.?\d+)([eE]-?\d+)?([_a-zA-Z]+[_a-zA-Z0-9]*)?
     name: constant.numeric.float.squiggle
   string:
+    patterns:
+      - include: "#single-quoted-string"
+      - include: "#double-quoted-string"
+  single-quoted-string:
+    match: "'.*?'"
+    name: string.quoted.single.squiggle
+  double-quoted-string:
     match: \".*?\"
     name: string.quoted.double.squiggle

--- a/packages/vscode-ext/syntaxes/squiggle.tmLanguage.yaml
+++ b/packages/vscode-ext/syntaxes/squiggle.tmLanguage.yaml
@@ -8,7 +8,6 @@ repository:
   statement:
     patterns:
       - include: "#let"
-      - include: "#defun"
   expression:
     patterns:
       - include: "#integer"
@@ -17,30 +16,12 @@ repository:
       - include: "#block"
       - include: "#function-call"
       - include: "#keywords"
+      - include: "#variable"
   let:
     match: ^\s*(\w+)\s*=
     captures:
       "1":
         name: variable.other.squiggle
-  defun:
-    begin: ^\s*(\w+)\s*(\()
-    end: (\))\s*=
-    beginCaptures:
-      "1":
-        name: entity.name.function.squiggle
-      "2":
-        name: punctuation.definition.arguments.begin.squiggle
-    endCaptures:
-      "1":
-        name: punctuation.definition.arguments.end.squiggle
-    patterns:
-      - include: "#array-parameters"
-  array-parameters:
-    begin: \b([\$_a-z]+[\$_a-zA-Z0-9]*)
-    end: \s*(?:(,)|(?=\)))
-    beginCaptures:
-      "1":
-        name: variable.parameter.function.squiggle
   function-call:
     begin: (\w+)\s*(\()
     end: (\))
@@ -48,12 +29,18 @@ repository:
       "1":
         name: entity.name.function.squiggle
       "2":
-        name: punctuation.definition.arguments.begin.squiggle
+        name: meta.brace.round.squiggle
     endCaptures:
       "1":
-        name: punctuation.definition.arguments.end.squiggle
+        name: meta.brace.round.squiggle
     patterns:
-      - include: "$self"
+      - include: "#expression"
+      - include: "#comma"
+  comma:
+    match: ","
+    captures:
+      "1":
+        name: punctuation.separator.comma.squiggle
   comment-block:
     begin: /\*
     end: \*/
@@ -92,6 +79,9 @@ repository:
     patterns:
       - include: "#single-quoted-string"
       - include: "#double-quoted-string"
+  variable:
+    match: \b([_a-zA-Z]+[_a-zA-Z0-9]*)
+    name: variable.other.squiggle
   single-quoted-string:
     match: "'.*?'"
     name: string.quoted.single.squiggle


### PR DESCRIPTION
- Fixes #891; turns out we have a pretty bad ambiguity between `f(x) = ...` and `f(x)` as an expression, so I had to remove the `defun` rule completely, which makes the grammar less semantic (we'll have to highlight function calls and function definitions in the same way), but there's no other easy way to fix this
- Adds support for single-quoted strings
- Highlights all variables

Before:
<img width="537" alt="Captura de pantalla 2023-04-22 a la(s) 16 33 59" src="https://user-images.githubusercontent.com/89368/233810486-c34e3dbd-907f-4d17-8111-aa5da785f87e.png">

After:
<img width="567" alt="Captura de pantalla 2023-04-22 a la(s) 16 34 04" src="https://user-images.githubusercontent.com/89368/233810489-508c88f9-383f-456d-88ab-b74466260632.png">
