### PR TITLE
Symlog scale in UI

### DIFF
--- a/packages/components/src/components/ViewSettingsForm.tsx
+++ b/packages/components/src/components/ViewSettingsForm.tsx
@@ -9,6 +9,7 @@ import { Radio } from "./ui/Radio.js";
 import { Text } from "./ui/Text.js";
 import { functionChartDefaults } from "./FunctionChart/utils.js";
 import { defaultTickFormatSpecifier } from "../lib/draw/index.js";
+import { SqSymlogScale } from "@quri/squiggle-lang";
 
 export const functionSettingsSchema = yup.object({}).shape({
   start: yup
@@ -34,7 +35,7 @@ export const functionSettingsSchema = yup.object({}).shape({
     .min(2),
 });
 
-const scaleTypes = ["linear", "log", "exp"] as const;
+const scaleTypes = ["linear", "log", "symlog", "exp"] as const;
 type ScaleType = (typeof scaleTypes)[number];
 
 function scaleTypeToSqScale(
@@ -46,6 +47,8 @@ function scaleTypeToSqScale(
       return SqLinearScale.create(args);
     case "log":
       return SqLogScale.create(args);
+    case "symlog":
+      return SqSymlogScale.create(args);
     case "exp":
       return SqPowerScale.create({ exponent: 0.1, ...args });
     default:
@@ -179,6 +182,12 @@ export const DistributionViewSettingsForm: React.FC<{
                           "Your distribution has mass lower than or equal to 0. Log only works on strictly positive values.",
                       }
                     : null),
+                },
+                {
+                  id: "symlog",
+                  name: "Symlog",
+                  tooltip:
+                    "Almost logarithmic scale that supports negative values.",
                 },
                 {
                   id: "exp",

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -28,6 +28,7 @@ export {
   SqScale,
   SqLinearScale,
   SqLogScale,
+  SqSymlogScale,
   SqPowerScale,
 } from "./public/SqScale.js";
 export { SqParseError, parse } from "./public/parse.js";


### PR DESCRIPTION
Tiny follow-up to #1716.
Fixes #1666.
<img width="658" alt="Captura de pantalla 2023-04-24 a la(s) 12 02 28" src="https://user-images.githubusercontent.com/89368/234078940-f1290308-6e8d-4889-84b8-5c367de662b4.png">
