### PR TITLE
The RV sidebar plots should use SymLog

### DIFF
--- a/packages/relative-values/src/components/View/ListView/sidebar.tsx
+++ b/packages/relative-values/src/components/View/ListView/sidebar.tsx
@@ -46,7 +46,7 @@ value_${numeratorItemName} = dists[0]
 value_${denominatorItemName} = dists[1]
 relativeValue = value_${numeratorItemName} / value_${denominatorItemName}
 median = abs(inv(dists[1], 0.5))
-tickFormat = '^10'
+tickFormat = '10'
 tickFormatObj = {tickFormat: tickFormat}
 
 [Plot.scatter({xDist:dists[1] / median, yDist: dists[0]/median, xScale: Scale.symlog(tickFormatObj), yScale: Scale.symlog(tickFormatObj)}), Plot.dist({

--- a/packages/relative-values/src/components/View/ListView/sidebar.tsx
+++ b/packages/relative-values/src/components/View/ListView/sidebar.tsx
@@ -6,6 +6,7 @@ import { getModelCode } from "@/model/utils";
 import { FC, Fragment } from "react";
 import { NumberShower } from "@quri/squiggle-components";
 import { SquiggleChart } from "@quri/squiggle-components";
+import { sq } from "@quri/squiggle-lang";
 
 function codeToPlaygroundUrl(code: string) {
   const text = JSON.stringify({ initialSquiggleString: code });
@@ -45,7 +46,15 @@ value_${numeratorItemName} = dists[0]
 value_${denominatorItemName} = dists[1]
 relativeValue = value_${numeratorItemName} / value_${denominatorItemName}
 median = abs(inv(dists[1], 0.5))
-[Plot.scatter({xDist:dists[1] / median, yDist: dists[0]/median}), relativeValue]`;
+tickFormat = '^10'
+tickFormatObj = {tickFormat: tickFormat}
+
+[Plot.scatter({xDist:dists[1] / median, yDist: dists[0]/median, xScale: Scale.symlog(tickFormatObj), yScale: Scale.symlog(tickFormatObj)}), Plot.dist({
+  dist: relativeValue,
+  xScale: Scale.symlog(tickFormatObj),
+  yScale: Scale.symlog(tickFormatObj),
+  showSummary: false,
+})]`;
 };
 
 type Props = {


### PR DESCRIPTION
This is pretty straightforward.

There are still some problems, probably for a future PR. (Might be Components changes).

Problems:
1. A better tick format would still be good.
2. The axes often get cut-off. (See right of the x-axis here, for instance)

<img width="547" alt="image" src="https://user-images.githubusercontent.com/377065/234101293-55245a39-5d80-4ca2-894e-aa16dba5a0a0.png">
