### PR TITLE
Fix api-server builds when cache is hit

### DIFF
--- a/packages/api-server/vercel.json
+++ b/packages/api-server/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "npx turbo build",
+  "buildCommand": "npx turbo build && yarn db:generate",
   "framework": "nextjs",
   "ignoreCommand": "npx turbo-ignore"
 }


### PR DESCRIPTION
In line with https://turbo.build/repo/docs/handbook/tools/prisma#7-caching-the-results-of-prisma-generate