### PR TITLE
Split turbo config and clean up .prisma

### DIFF
--- a/packages/components/turbo.json
+++ b/packages/components/turbo.json
@@ -1,0 +1,12 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "outputs": [
+        "dist/**",
+        "storybook-static/**",
+        "src/languageSupport/generated/**"
+      ]
+    }
+  }
+}

--- a/packages/squiggle-lang/turbo.json
+++ b/packages/squiggle-lang/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "outputs": ["src/**/*.js", "dist/**"]
+    }
+  }
+}

--- a/packages/vscode-ext/turbo.json
+++ b/packages/vscode-ext/turbo.json
@@ -1,0 +1,13 @@
+{
+  "extends": ["//"],
+  "pipeline": {
+    "build": {
+      "dependsOn": [
+        "^build",
+        "@quri/squiggle-components#bundle",
+        "@quri/prettier-plugin-squiggle#build" // TODO - why is this necessary?
+      ],
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -3,35 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", "build/**"]
-    },
-    "vscode-squiggle#build": {
-      "dependsOn": [
-        "^build",
-        "@quri/squiggle-components#bundle",
-        "@quri/prettier-plugin-squiggle#build"
-      ],
-      "outputs": ["dist/**"]
-    },
-    "@quri/squiggle-components#build": {
-      "dependsOn": ["^build"],
-      "outputs": [
-        "dist/**",
-        "storybook-static/**",
-        "src/languageSupport/generated/**"
-      ]
-    },
-    "@quri/squiggle-lang#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["src/**/*.js", "dist/**"]
-    },
-    "@quri/relative-values#build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "./models/cache/**"]
-    },
-    "@quri/hub#build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "../../node_modules/.prisma"]
+      "outputs": ["dist/**", "build/**", ".next/**", "!.next/cache/**"]
     },
     "format": {},
     "lint": {


### PR DESCRIPTION
1. Modular turbo configuration, more manageable in the long run (https://turbo.build/blog/turbo-1-8-0#workspace-configurations)
2. Attempt to fix build issues when turbo cache is hit (e.g. https://vercel.com/quantified-uncertainty/quri-hub/6WNY8HMXWkEAg1fAFpGxMyuxWmzX)