### PR TITLE
Jest timeout for first prettier test

### DIFF
--- a/packages/prettier-plugin/test/main.test.ts
+++ b/packages/prettier-plugin/test/main.test.ts
@@ -14,7 +14,7 @@ describe("comments", () => {
 123`)
     ).toBe(`// line comment
 123`);
-  });
+  }, 20000); // first call to prettier is slow and occasionally causes timeouts in Github Actions
 
   test("comment indentation is ignored", async () => {
     expect(


### PR DESCRIPTION
Our tests are occasionally failing with `Exceeded timeout of 5000 ms for a test.` on prettier plugin.

Seems like it's a combination of: (1) slow prettier initialization on the first call; (2) CPU throttling in Github Actions.