### PR TITLE
Global prettier config

### DIFF
--- a/packages/cli/.prettierrc.json
+++ b/packages/cli/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/packages/components/.prettierrc.json
+++ b/packages/components/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/packages/hub/.prettierrc.json
+++ b/packages/hub/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/packages/relative-values/.prettierrc.json
+++ b/packages/relative-values/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/packages/squiggle-lang/.prettierrc.json
+++ b/packages/squiggle-lang/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/packages/vscode-ext/.prettierrc.json
+++ b/packages/vscode-ext/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/packages/website/.prettierrc.json
+++ b/packages/website/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "trailingComma": "es5"
-}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  trailingComma: "es5",
+};


### PR DESCRIPTION
I also wanted to install https://github.com/tailwindlabs/prettier-plugin-tailwindcss (which was the main point), but it didn't work with our prettier setup ("TypeError: hI.default.resolveConfigFile.sync is not a function").

Still, it's a straightforward simplification.