### PR TITLE
Fix comments formatting in function definitions; `squiggle parse` CLI command

### DIFF
--- a/.changeset/large-mangos-tap.md
+++ b/.changeset/large-mangos-tap.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+"squiggle parse" CLI command

--- a/.changeset/tame-suns-push.md
+++ b/.changeset/tame-suns-push.md
@@ -1,0 +1,5 @@
+---
+"@quri/prettier-plugin-squiggle": patch
+---
+
+format comments in function definition body correctly

--- a/packages/prettier-plugin/src/shared.ts
+++ b/packages/prettier-plugin/src/shared.ts
@@ -134,7 +134,11 @@ export function createPlugin(util: PrettierUtil): Plugin<Node> {
           case "Program":
             return path.map(print, "statements");
           case "Block":
-            if (node.statements.length === 1) {
+            if (
+              node.statements.length === 1 &&
+              !("comments" in node) &&
+              !("comments" in node.statements[0])
+            ) {
               return typedPath(node).call(print, "statements", 0);
             }
             return group([
@@ -335,10 +339,14 @@ export function createPlugin(util: PrettierUtil): Plugin<Node> {
               return node.elements;
             case "LetStatement":
               return [node.variable, node.value];
+            case "DefunStatement":
+              return [node.value];
             case "Call":
               return [...node.args, node.fn];
             case "Record":
               return node.elements;
+            case "Lambda":
+              return [node.body];
             case "KeyValue":
               return [node.key, node.value];
             default:

--- a/packages/prettier-plugin/test/main.test.ts
+++ b/packages/prettier-plugin/test/main.test.ts
@@ -46,6 +46,50 @@ x = 5
 // second line
 123`);
   });
+
+  test("comment in block definition", async () => {
+    expect(
+      await format(`
+foo = {
+  // inner comment
+  x = 5
+  x*x
+}
+`)
+    ).toBe(`foo = {
+  // inner comment
+  x = 5
+  x * x
+}
+`);
+  });
+
+  test("comment in simple function definition", async () => {
+    expect(
+      await format(`
+foo() = { /* inner comment */ 5 }
+`)
+    ).toBe(`foo() = {
+  /* inner comment */
+  5
+}
+`);
+  });
+
+  test("comment in function definition", async () => {
+    expect(
+      await format(`
+foo(x) = {
+  // inner comment
+  x*x
+}
+`)
+    ).toBe(`foo(x) = {
+  // inner comment
+  x * x
+}
+`);
+  });
 });
 
 describe("expressions", () => {

--- a/packages/squiggle-lang/src/cli/makeProgram.ts
+++ b/packages/squiggle-lang/src/cli/makeProgram.ts
@@ -1,11 +1,34 @@
 import fs from "fs";
+import util from "util";
 import { OutputMode, run } from "./utils.js";
 
 import { Command } from "@commander-js/extra-typings";
 import open from "open";
+import { parse } from "../public/parse.js";
+import { red } from "./colors.js";
 
-export const makeProgram = () => {
+export function makeProgram() {
   const program = new Command();
+
+  const loadSrc = ({
+    filename,
+    inline,
+  }: {
+    filename: string | undefined;
+    inline: string | undefined;
+  }) => {
+    let src = "";
+    if (filename !== undefined && inline !== undefined) {
+      program.error("Only one of filename and eval string should be set.");
+    } else if (filename !== undefined) {
+      src = fs.readFileSync(filename, "utf-8");
+    } else if (inline !== undefined) {
+      src = inline;
+    } else {
+      program.error("One of filename and eval string should be set.");
+    }
+    return src;
+  };
 
   program
     .command("run")
@@ -21,8 +44,6 @@ export const makeProgram = () => {
       "show bindings even if the result is present"
     ) // incompatible with --quiet
     .action((filename, options) => {
-      let src = "";
-
       let output: OutputMode = "RESULT_OR_BINDINGS";
       if (options.quiet && options.showBindings) {
         program.error(
@@ -34,19 +55,31 @@ export const makeProgram = () => {
         output = "RESULT_AND_BINDINGS";
       }
 
-      if (filename && options.eval) {
-        program.error("Only one of filename and eval string should be set.");
-      } else if (filename) {
-        src = fs.readFileSync(filename, "utf-8");
-      } else if (options.eval) {
-        src = options.eval;
-      } else {
-        program.error("One of filename and eval string should be set.");
-      }
+      const src = loadSrc({ filename, inline: options.eval });
 
       const sampleCount = process.env.SAMPLE_COUNT;
 
       run({ src, filename, output, measure: options.time, sampleCount });
+    });
+
+  program
+    .command("parse")
+    .arguments("[filename]")
+    .option(
+      "-e, --eval <code>",
+      "parse a given squiggle code string instead of a file"
+    )
+    .action((filename, options) => {
+      const src = loadSrc({ filename, inline: options.eval });
+
+      const parseResult = parse(src);
+      if (parseResult.ok) {
+        console.log(
+          util.inspect(parseResult.value, { depth: Infinity, colors: true })
+        );
+      } else {
+        console.log(red(parseResult.value.toString()));
+      }
     });
 
   program.command("playground").action(() => {
@@ -54,4 +87,4 @@ export const makeProgram = () => {
   });
 
   return program;
-};
+}


### PR DESCRIPTION
Fixes #708. Fixes #1805.