### PR TITLE
Added plots to documentation

### DIFF
--- a/packages/components/src/components/DistributionsChart/SummaryTable.tsx
+++ b/packages/components/src/components/DistributionsChart/SummaryTable.tsx
@@ -83,7 +83,7 @@ type SummaryTableProps = {
 export const SummaryTable: FC<SummaryTableProps> = ({ plot, environment }) => {
   const showNames = plot.distributions.some((d) => d.name);
   return (
-    <table className="border border-collapse border-slate-200 overflow-hidden rounded-lg">
+    <table className="border border-collapse border-slate-400">
       <thead className="bg-slate-50">
         <tr>
           {showNames && <TableHeadCell>Name</TableHeadCell>}

--- a/packages/components/src/components/DistributionsChart/SummaryTable.tsx
+++ b/packages/components/src/components/DistributionsChart/SummaryTable.tsx
@@ -83,7 +83,7 @@ type SummaryTableProps = {
 export const SummaryTable: FC<SummaryTableProps> = ({ plot, environment }) => {
   const showNames = plot.distributions.some((d) => d.name);
   return (
-    <table className="border border-collapse border-slate-400">
+    <table className="border border-collapse border-slate-200 overflow-hidden rounded-lg">
       <thead className="bg-slate-50">
         <tr>
           {showNames && <TableHeadCell>Name</TableHeadCell>}

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -332,7 +332,7 @@ export const DistributionsChart: FC<DistributionsChartProps> = ({
           height={height}
         />
       )}
-      <div className="flex justify-center">
+      <div className="flex justify-center pt-2">
         {plot.showSummary && (
           <SummaryTable plot={plot} environment={environment} />
         )}

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -164,8 +164,10 @@ const InnerDistributionsChart: FC<{
             .context(context)(shape.continuous);
           context.fill();
 
+          // The top line
           context.globalAlpha = 1;
           context.strokeStyle = context.fillStyle;
+          context.beginPath();
           d3
             .line<SqShape["continuous"][number]>()
             .x((d) => xScale(d.x))

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -4,7 +4,7 @@ import { Padding, Point } from "./types.js";
 
 const axisColor = "rgba(114, 125, 147, 0.1)";
 export const labelColor = "rgb(114, 125, 147)";
-export const cursorLineColor = "#aaa";
+export const cursorLineColor = "#888";
 export const primaryColor = "#4c78a8"; // for lines and areas
 const labelFont = "10px sans-serif";
 const xLabelOffset = 6;

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -4,7 +4,7 @@ import { Padding, Point } from "./types.js";
 
 const axisColor = "rgba(114, 125, 147, 0.1)";
 export const labelColor = "rgb(114, 125, 147)";
-export const cursorLineColor = "#aaa"; // tailwind red-400
+export const cursorLineColor = "#aaa";
 export const primaryColor = "#4c78a8"; // for lines and areas
 const labelFont = "10px sans-serif";
 const xLabelOffset = 6;
@@ -48,7 +48,7 @@ export function drawAxes({
   const xTickFormat = xScale.tickFormat(tickCount, xTickFormatSpecifier);
 
   const yTicks = yScale.ticks(tickCount);
-  const yTickFormat = xScale.tickFormat(tickCount, yTickFormatSpecifier);
+  const yTickFormat = yScale.tickFormat(tickCount, yTickFormatSpecifier);
 
   const tickSize = 2;
 

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -4,7 +4,7 @@ import { Padding, Point } from "./types.js";
 
 const axisColor = "rgba(114, 125, 147, 0.1)";
 export const labelColor = "rgb(114, 125, 147)";
-export const cursorLineColor = "#f87171"; // tailwind red-400
+export const cursorLineColor = "#aaa"; // tailwind red-400
 export const primaryColor = "#4c78a8"; // for lines and areas
 const labelFont = "10px sans-serif";
 const xLabelOffset = 6;
@@ -219,9 +219,11 @@ export function drawCursorLines({
     context.beginPath();
     context.strokeStyle = cursorLineColor;
     context.lineWidth = 1;
+    context.setLineDash([5, 5]); // setting the dashed line pattern
     context.moveTo(point.x, 0);
     context.lineTo(point.x, frame.height);
     context.stroke();
+    context.setLineDash([]); // resetting the dashed line pattern so it doesn't affect other lines
 
     context.textAlign = "left";
     context.textBaseline = "bottom";
@@ -267,9 +269,11 @@ export function drawCursorLines({
     context.beginPath();
     context.strokeStyle = cursorLineColor;
     context.lineWidth = 1;
+    context.setLineDash([5, 5]); // setting the dashed line pattern
     context.moveTo(0, point.y);
     context.lineTo(frame.width, point.y);
     context.stroke();
+    context.setLineDash([]); // resetting the dashed line pattern so it doesn't affect other lines
 
     context.textAlign = "left";
     context.textBaseline = "bottom";

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -28,7 +28,8 @@ Examples:
 />
 
 ### Plot.dist
-Like ``Plot.dists``, but plots a single distribution.
+
+Like `Plot.dists`, but plots a single distribution.
 
 ```js
 Plot.dist: ({dist: dist, xScale: scale, yScale: scale, title: string, showSummary: bool}) => plot
@@ -45,10 +46,9 @@ Examples:
 })`}
 />
 
-
 ### Plot.numericFn
 
-Plots a function that outputs numeric values. This works by sampling the function at a fixed number of points. The number of points is adjustable with the ``points`` parameter.
+Plots a function that outputs numeric values. This works by sampling the function at a fixed number of points. The number of points is adjustable with the `points` parameter.
 
 ```js
 Plot.numericFn: ({fn: (number => number), xScale: scale, yScale: scale, points: number}) => plot
@@ -78,7 +78,8 @@ Plot.distFn: ({fn: (number => dist), xScale: scale, distXScale: scale, points: n
   fn: {|t| normal(t,2)*normal(5,3)},
   xScale: Scale.log({ min: 3, max: 100 }),
   distXScale: Scale.linear({ tickFormat: '#x' }),
-})`}/>
+})`}
+/>
 
 ### Plot.scatter
 
@@ -92,7 +93,8 @@ Plot.scatter({
   xDist: xDist,
   yDist: yDist,
   xScale: Scale.log({min: 1.5}),
-})`}/>
+})`}
+/>
 
 <SquiggleEditor
   defaultCode={`xDist = SampleSet.fromDist(-2 to 5)
@@ -102,9 +104,11 @@ Plot.scatter({
   yDist: yDist,
   xScale: Scale.symlog(),
   yScale: Scale.symlog(),
-})`}/>
+})`}
+/>
 
-### Scales  
+### Scales
+
 Chart axes can be scaled using the following functions. Each scale function accepts optional min and max value. Power scale accepts an extra exponent parameter.
 
 We use D3 for the tick formats. You can read about custom tick formats [here](https://github.com/d3/d3-format).
@@ -116,12 +120,12 @@ Scale.symlog: ({min: number, max: number, tickFormat: string}) => scale
 Scale.power: ({min: number, max: number, tickFormat: string, exponent: number}) => scale
 ```
 
-** Scale.log **  
+** Scale.log **
 
-** Scale.linear **  
+** Scale.linear **
 
 ** Scale.symlog **  
 Symmetric log scale. Useful for plotting data that includes negative values.
 
 ** Scale.power **  
-Power scale. Accepts an extra ``exponent`` parameter, like, ``Scale.power({exponent: 2, min: 0, max: 100})``.
+Power scale. Accepts an extra `exponent` parameter, like, `Scale.power({exponent: 2, min: 0, max: 100})`.

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -84,7 +84,10 @@ Plot.distFn: ({fn: (number => dist), xScale: scale, distXScale: scale, points: n
 ### Plot.scatter
 
 Plots a scatterplot. Requires two sample set distributions.
+
+```js
 Plot.numericFn: ({yDist: sampleSetDist, xDist: sampleSetDist, xScale: Scale, yScale: Scale}) => plot
+```
 
 <SquiggleEditor
   defaultCode={`xDist = SampleSet.fromDist(2 to 5)

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -11,8 +11,8 @@ The Plot module provides functions to create plots of distributions and function
 
 Plots one or more labeled distributions on the same plot. Distributions can be either continuous, discrete, or a single number.
 
-```
-Plot.dists: ({dists: list<{name: string, value: distribution | number}>}) => plot
+```js
+Plot.dists: ({dists: list<{name: string, value: distribution | number}>, xScale: scale, yScale: scale, title: string, showSummary: bool}) => plot
 ```
 
 Examples:
@@ -22,26 +22,106 @@ Examples:
     dists: [
         { name: "First Dist", value: normal(0, 1) },
         { name: "Second Dist", value: uniform(2, 4) },
-    ]
+    ], 
+    xScale: Scale.symlog({ min: -2, max: 5})
 })`}
 />
 
-### Plot.fn
+### Plot.dist
+Like ``Plot.dists``, but plots a single distribution.
 
-Plots a function within a specified range of x-values.
-
-```
-Plot.fn: ({fn: (number => number), min: number, max: number}) => plot
+```js
+Plot.dist: ({dist: dist, xScale: scale, yScale: scale, title: string, showSummary: bool}) => plot
 ```
 
 Examples:
 
-<SquiggleEditor defaultCode={`Plot.fn({fn: {|x| x^5}, min: 3, max: 40})`} />
-
 <SquiggleEditor
-  defaultCode={`Plot.fn({
-    fn: {|x| Math.sin(x)},
-    min: 5,
-    max: 10
+  defaultCode={`Plot.dist({
+    dist: normal(5,2),
+    xScale: Scale.linear({ min: -2, max: 6}),
+    title: "A Simple Normal Distribution",
+    showSummary: true
 })`}
 />
+
+
+### Plot.numericFn
+
+Plots a function that outputs numeric values. This works by sampling the function at a fixed number of points. The number of points is adjustable with the ``points`` parameter.
+
+```js
+Plot.numericFn: ({fn: (number => number), xScale: scale, yScale: scale, points: number}) => plot
+```
+
+Examples:
+
+<SquiggleEditor
+  defaultCode={`Plot.numericFn({
+  fn: {|t| t^2},
+  xScale: Scale.log({
+    min: 1,
+    max: 100
+  }),
+  points: 10
+})`}
+/>
+
+### Plot.distFn
+
+```js
+Plot.distFn: ({fn: (number => dist), xScale: scale, distXScale: scale, points: number}) => plot
+```
+
+<SquiggleEditor
+  defaultCode={`Plot.distFn({
+  fn: {|t| normal(t,2)*normal(5,3)},
+  xScale: Scale.log({ min: 3, max: 100 }),
+  distXScale: Scale.linear({ tickFormat: '#x' }),
+})`}/>
+
+### Plot.scatter
+
+Plots a scatterplot. Requires two sample set distributions.
+Plot.numericFn: ({yDist: sampleSetDist, xDist: sampleSetDist, xScale: Scale, yScale: Scale}) => plot
+
+<SquiggleEditor
+  defaultCode={`xDist = SampleSet.fromDist(2 to 5)
+yDist = (-3 to 3) * 5 - xDist ^ 2
+Plot.scatter({
+  xDist: xDist,
+  yDist: yDist,
+  xScale: Scale.log({min: 1.5}),
+})`}/>
+
+<SquiggleEditor
+  defaultCode={`xDist = SampleSet.fromDist(-2 to 5)
+yDist = (-3 to 3) * 5 - xDist
+Plot.scatter({
+  xDist: xDist,
+  yDist: yDist,
+  xScale: Scale.symlog(),
+  yScale: Scale.symlog(),
+})`}/>
+
+### Scales  
+Chart axes can be scaled using the following functions. Each scale function accepts optional min and max value. Power scale accepts an extra exponent parameter.
+
+We use D3 for the tick formats. You can read about custom tick formats [here](https://github.com/d3/d3-format).
+
+```js
+Scale.log: ({min: number, max: number, tickFormat: string}) => scale
+Scale.linear: ({min: number, max: number, tickFormat: string}) => scale
+Scale.symlog: ({min: number, max: number, tickFormat: string}) => scale
+Scale.power: ({min: number, max: number, tickFormat: string, exponent: number}) => scale
+```
+
+** Scale.log **  
+
+** Scale.linear **  
+
+** Scale.symlog **  
+Symmetric log scale. Useful for plotting data that includes negative values.
+
+** Scale.power **  
+Power scale. Accepts an extra ``exponent`` parameter, like, ``Scale.power({exponent: 2, min: 0, max: 100})``.


### PR DESCRIPTION
This does some light UI changes:
- In MultiDist plot, only show line on top of dists, not on bottom.
- When hovering over plots, show the hover coordinates with light gray dashed lines.
- Fixes an issue where yTickFormat would actually use the xScale parameter.

Then, I added a lot of information about the recent plot additions to the documentation. I imagine this could be further improved, but think this is one decent step. 