### PR TITLE
Ordered records and bindings (fixes #1072)

### DIFF
--- a/packages/squiggle-lang/src/reducer/bindings.ts
+++ b/packages/squiggle-lang/src/reducer/bindings.ts
@@ -4,7 +4,7 @@
   { localX: ..., localY: ... } <- { globalZ: ..., ... } <- { importedT: ..., ... } <- { stdlibFunction: ..., ... }
 */
 
-import { Map as ImmutableMap } from "immutable";
+import { ImmutableMap } from "../utility/immutableMap.js";
 
 import { Value } from "../value/index.js";
 

--- a/packages/squiggle-lang/src/utility/immutableMap.ts
+++ b/packages/squiggle-lang/src/utility/immutableMap.ts
@@ -1,3 +1,3 @@
-import { Map } from "immutable";
+import { OrderedMap } from "immutable";
 
-export { Map as ImmutableMap };
+export { OrderedMap as ImmutableMap };


### PR DESCRIPTION
This causes ~20% performance hit on GUCEM benchmark, but still worth it.

There's no test because it would be annoying to write (the order issues happen only when there are many keys), and there's not much that could go wrong here if we trust the underlying immutable-js implementation.

I checked that [macrovariables model](https://quri-hub-git-ui-enhancements-mid-june-quantified-uncertainty.vercel.app/users/berekuk/models/macrovariables) now renders on order.

There's a chance the performance could be improved by storing data in mutable native objects, since native JS objects are ordered, but there are various tradeoffs involved (do we need a debugger? mutable objects would make the debugger harder/impossible to implement).