### PR TITLE
Small Distribution/Display Changes

### DIFF
--- a/.changeset/ten-eyes-sip.md
+++ b/.changeset/ten-eyes-sip.md
@@ -1,0 +1,7 @@
+---
+"@quri/squiggle-lang": patch
+"@quri/squiggle-components": patch
+"@quri/ui": patch
+---
+
+Distribution plot improvements - 1M sample fix, Not Normalized Warning, coloring.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "name": "squiggle",
   "scripts": {
-    "nodeclean": "rm -r node_modules && rm -r packages/*/node_modules"
+    "nodeclean": "rm -r node_modules && rm -r packages/*/node_modules",
+    "changeset": "changeset"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.1",

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -99,6 +99,7 @@ const InnerDistributionsChart: FC<{
         Math.max(...domain.map((p) => p.y)),
       ]);
 
+      const tickCount = Math.min(width / 100, 12);
       const { padding, frame } = drawAxes({
         context,
         width,
@@ -113,7 +114,6 @@ const InnerDistributionsChart: FC<{
         yScale,
         hideYAxis: true,
         drawTicks: true,
-        tickCount: 10,
         xTickFormat: plot.xScale.tickFormat,
       });
 

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -15,6 +15,7 @@ import { MouseTooltip, TextTooltip } from "@quri/ui";
 import { hasMassBelowZero } from "../../lib/distributionUtils.js";
 import {
   distance,
+  distributionColor,
   drawAxes,
   drawCircle,
   drawCursorLines,
@@ -82,7 +83,7 @@ const InnerDistributionsChart: FC<{
       context.clearRect(0, 0, width, height);
 
       const getColor = (i: number) =>
-        isMulti ? d3.schemeCategory10[i] : "#6d9bce";
+        isMulti ? d3.schemeCategory10[i] : distributionColor;
 
       const xScale = sqScaleToD3(plot.xScale);
       xScale.domain([

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -187,9 +187,20 @@ const InnerDistributionsChart: FC<{
           context.stroke();
 
           // discrete
-          const darkerColor = adjustColorBrightness(getColor(i), -40);
-          context.fillStyle = darkerColor;
-          context.strokeStyle = darkerColor;
+          const darkenAmountCircle = isMulti ? 10 : 50;
+          const darkenAmountLine = Math.floor(darkenAmountCircle / 2);
+
+          const discreteLineColor = adjustColorBrightness(
+            getColor(i),
+            -darkenAmountLine
+          );
+          const discreteCircleColor = adjustColorBrightness(
+            getColor(i),
+            -darkenAmountCircle
+          );
+
+          context.strokeStyle = discreteLineColor;
+          context.fillStyle = discreteCircleColor;
           for (const point of shape.discrete) {
             context.beginPath();
             context.lineWidth = 1;

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -82,7 +82,7 @@ const InnerDistributionsChart: FC<{
       context.clearRect(0, 0, width, height);
 
       const getColor = (i: number) =>
-        isMulti ? d3.schemeCategory10[i] : "#6cabd2";
+        isMulti ? d3.schemeCategory10[i] : "#6d9bce";
 
       const xScale = sqScaleToD3(plot.xScale);
       xScale.domain([

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -69,7 +69,8 @@ const InnerDistributionsChart: FC<{
   const showTitle = !!plot.title;
   const titleHeight = showTitle ? 20 : 4;
   const legendHeight = isMulti ? legendItemHeight * shapes.length : 0;
-  const samplesFooterHeight = samples.length ? 10 : 0;
+  const _showSamplesBar = showSamplesBar && samples.length;
+  const samplesFooterHeight = _showSamplesBar ? 10 : 0;
 
   const height =
     innerHeight + legendHeight + titleHeight + samplesFooterHeight + 30;
@@ -227,7 +228,7 @@ const InnerDistributionsChart: FC<{
       }
 
       // samples
-      if (showSamplesBar) {
+      if (_showSamplesBar) {
         context.save();
         context.strokeStyle = primaryColor;
         context.lineWidth = 0.1;
@@ -343,9 +344,7 @@ export const DistributionsChart: FC<DistributionsChartProps> = ({
   for (const { distribution } of distributions) {
     if (distribution.tag === SqDistributionTag.SampleSet) {
       const distSamples = distribution.getSamples();
-      for (let i = 0; i < distSamples.length; i++) {
-        samples.push(distSamples[i]);
-      }
+      samples.concat(distSamples);
     }
   }
 
@@ -373,12 +372,9 @@ export const DistributionsChart: FC<DistributionsChartProps> = ({
             .join(
               ", "
             )}] are not valid probability distributions, because their integrals do not add up to 1.`;
-    console.log(
-      distributions.map(({ name, distribution }) => distribution.integralSum())
-    );
     return (
       <div>
-        <TextTooltip text={message} placement="right">
+        <TextTooltip text={message} placement="top">
           <div className="font-semibold text-xs text-orange-900 bg-orange-100 rounded-md px-1.5 py-0.5 w-fit ml-2">
             Not Normalized
           </div>

--- a/packages/components/src/components/DistributionsChart/index.tsx
+++ b/packages/components/src/components/DistributionsChart/index.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/draw/index.js";
 import { useCanvas, useCanvasCursor } from "../../lib/hooks/index.js";
 import {
+  adjustColorBrightness,
   canvasClasses,
   flattenResult,
   sqScaleToD3,
@@ -80,7 +81,7 @@ const InnerDistributionsChart: FC<{
       context.clearRect(0, 0, width, height);
 
       const getColor = (i: number) =>
-        isMulti ? d3.schemeCategory10[i] : "#5ba3cf";
+        isMulti ? d3.schemeCategory10[i] : "#6cabd2";
 
       const xScale = sqScaleToD3(plot.xScale);
       xScale.domain([
@@ -99,7 +100,6 @@ const InnerDistributionsChart: FC<{
         Math.max(...domain.map((p) => p.y)),
       ]);
 
-      const tickCount = Math.min(width / 100, 12);
       const { padding, frame } = drawAxes({
         context,
         width,
@@ -187,6 +187,9 @@ const InnerDistributionsChart: FC<{
           context.stroke();
 
           // discrete
+          const darkerColor = adjustColorBrightness(getColor(i), -40);
+          context.fillStyle = darkerColor;
+          context.strokeStyle = darkerColor;
           for (const point of shape.discrete) {
             context.beginPath();
             context.lineWidth = 1;

--- a/packages/components/src/components/ScatterChart/index.tsx
+++ b/packages/components/src/components/ScatterChart/index.tsx
@@ -68,7 +68,6 @@ export const ScatterChart: FC<Props> = ({ plot, height, environment }) => {
         yScale,
         xTickFormat: plot.xScale?.tickFormat,
         yTickFormat: plot.yScale?.tickFormat,
-        tickCount: 20,
         drawTicks: true,
       });
 

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -289,7 +289,7 @@ export const SquigglePlayground: React.FC<PlaygroundProps> = (props) => {
       >
         {showEditor && playgroundWithEditor}
         {!showEditor && (
-          <div style={standardHeightStyle(rightSideHeaderHeight)}>
+          <div style={standardHeightStyle(height - rightSideHeaderHeight)}>
             {squiggleChart}
           </div>
         )}

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -18,7 +18,7 @@ import { NumericFunctionChart } from "../FunctionChart/NumericFunctionChart.js";
 import { ScatterChart } from "../ScatterChart/index.js";
 import { generateDistributionPlotSettings } from "../PlaygroundSettings.js";
 import { ItemSettingsMenu } from "./ItemSettingsMenu.js";
-import { SQTypeWithCount, VariableBox } from "./VariableBox.js";
+import { SqTypeWithCount, VariableBox } from "./VariableBox.js";
 import { MergedItemSettings } from "./utils.js";
 import { RelativeValuesGridChart } from "../RelativeValuesGridChart/index.js";
 
@@ -255,7 +255,7 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
         <VariableList
           value={value}
           heading={`Record(${entries.length})`}
-          preview={<SQTypeWithCount type="{}" count={entries.length} />}
+          preview={<SqTypeWithCount type="{}" count={entries.length} />}
         >
           {() => {
             if (!entries.length) {
@@ -273,7 +273,7 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
         <VariableList
           value={value}
           heading={`List(${values.length})`}
-          preview={<SQTypeWithCount type="[]" count={values.length} />}
+          preview={<SqTypeWithCount type="[]" count={values.length} />}
         >
           {(_) => values.map((r, i) => <ExpressionViewer key={i} value={r} />)}
         </VariableList>

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -18,16 +18,17 @@ import { NumericFunctionChart } from "../FunctionChart/NumericFunctionChart.js";
 import { ScatterChart } from "../ScatterChart/index.js";
 import { generateDistributionPlotSettings } from "../PlaygroundSettings.js";
 import { ItemSettingsMenu } from "./ItemSettingsMenu.js";
-import { VariableBox } from "./VariableBox.js";
+import { SQTypeWithCount, VariableBox } from "./VariableBox.js";
 import { MergedItemSettings } from "./utils.js";
 import { RelativeValuesGridChart } from "../RelativeValuesGridChart/index.js";
 
 const VariableList: React.FC<{
   value: SqValue;
   heading: string;
+  preview?: React.ReactNode;
   children: (settings: MergedItemSettings) => React.ReactNode;
-}> = ({ value, heading, children }) => (
-  <VariableBox value={value} heading={heading}>
+}> = ({ value, heading, children, preview }) => (
+  <VariableBox value={value} preview={preview} heading={heading}>
     {(settings) => (
       <div
         className={clsx(
@@ -249,10 +250,14 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
       );
     }
     case "Record":
+      const entries = value.value.entries();
       return (
-        <VariableList value={value} heading="Record">
+        <VariableList
+          value={value}
+          heading={`Record(${entries.length})`}
+          preview={<SQTypeWithCount type="{}" count={entries.length} />}
+        >
           {() => {
-            const entries = value.value.entries();
             if (!entries.length) {
               return <div className="text-neutral-400">Empty record</div>;
             }
@@ -263,13 +268,14 @@ export const ExpressionViewer: React.FC<Props> = ({ value }) => {
         </VariableList>
       );
     case "Array":
+      const values = value.value.getValues();
       return (
-        <VariableList value={value} heading="Array">
-          {(_) =>
-            value.value
-              .getValues()
-              .map((r, i) => <ExpressionViewer key={i} value={r} />)
-          }
+        <VariableList
+          value={value}
+          heading={`List(${values.length})`}
+          preview={<SQTypeWithCount type="[]" count={values.length} />}
+        >
+          {(_) => values.map((r, i) => <ExpressionViewer key={i} value={r} />)}
         </VariableList>
       );
     default: {

--- a/packages/components/src/components/SquiggleViewer/ItemSettingsMenu.tsx
+++ b/packages/components/src/components/SquiggleViewer/ItemSettingsMenu.tsx
@@ -110,7 +110,7 @@ export const ItemSettingsMenu: React.FC<Props> = (props) => {
   return (
     <div className="flex gap-2" ref={ref}>
       <CogIcon
-        className="h-5 w-5 cursor-pointer text-stone-200 hover:text-stone-500"
+        className="h-5 w-5 cursor-pointer text-stone-300 hover:text-stone-500"
         onClick={() => setIsOpen(!isOpen)}
       />
       {settings.distributionChartSettings ? (

--- a/packages/components/src/components/SquiggleViewer/VariableBox.tsx
+++ b/packages/components/src/components/SquiggleViewer/VariableBox.tsx
@@ -22,7 +22,7 @@ type VariableBoxProps = {
   children: (settings: MergedItemSettings) => React.ReactNode;
 };
 
-export const SQTypeWithCount = ({
+export const SqTypeWithCount = ({
   type,
   count,
 }: {

--- a/packages/components/src/components/SquiggleViewer/VariableBox.tsx
+++ b/packages/components/src/components/SquiggleViewer/VariableBox.tsx
@@ -17,13 +17,28 @@ type SettingsMenuParams = {
 type VariableBoxProps = {
   value: SqValue;
   heading: string;
+  preview?: React.ReactNode;
   renderSettingsMenu?: (params: SettingsMenuParams) => React.ReactNode;
   children: (settings: MergedItemSettings) => React.ReactNode;
 };
 
+export const SQTypeWithCount = ({
+  type,
+  count,
+}: {
+  type: string;
+  count: number;
+}) => (
+  <div className="text-sm text-stone-400 font-mono">
+    {type}
+    <span className="ml-0.5">{count}</span>
+  </div>
+);
+
 export const VariableBox: React.FC<VariableBoxProps> = ({
   value: { location },
   heading = "Error",
+  preview,
   renderSettingsMenu,
   children,
 }) => {
@@ -66,6 +81,7 @@ export const VariableBox: React.FC<VariableBoxProps> = ({
               />
             </span>
             <span className="text-stone-800 font-mono text-sm">{name}</span>
+            {preview && <div className="ml-2">{preview}</div>}
           </div>
           <div className="inline-flex space-x-1">
             {!settings.collapsed && (

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -18,6 +18,6 @@ export function locationToShortName(
 ): string | undefined {
   const isTopLevel = location.path.items.length === 0;
   return isTopLevel
-    ? { result: undefined, bindings: "Bindings" }[location.path.root]
+    ? { result: undefined, bindings: "Outputs" }[location.path.root]
     : String(location.path.items[location.path.items.length - 1]);
 }

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -18,6 +18,6 @@ export function locationToShortName(
 ): string | undefined {
   const isTopLevel = location.path.items.length === 0;
   return isTopLevel
-    ? { result: undefined, bindings: "Outputs" }[location.path.root]
+    ? { result: undefined, bindings: "Variables" }[location.path.root]
     : String(location.path.items[location.path.items.length - 1]);
 }

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -17,6 +17,21 @@ export function distance(point1: Point, point2: Point) {
 }
 
 export const defaultTickFormatSpecifier = ".9~s";
+interface DrawAxesParams {
+  context: CanvasRenderingContext2D;
+  xScale: AnyChartScale;
+  yScale: AnyChartScale;
+  suggestedPadding: Padding;
+  width: number;
+  height: number;
+  hideYAxis?: boolean;
+  drawTicks?: boolean;
+  xTickCount?: number;
+  yTickCount?: number;
+  tickFormat?: string;
+  xTickFormat?: string;
+  yTickFormat?: string;
+}
 
 export function drawAxes({
   context,
@@ -25,30 +40,18 @@ export function drawAxes({
   suggestedPadding,
   width,
   height,
-  hideYAxis,
-  drawTicks,
-  tickCount = 5,
+  hideYAxis = false,
+  drawTicks = true,
+  xTickCount = Math.max(Math.min(Math.floor(width / 100), 12), 3),
+  yTickCount = Math.max(Math.min(Math.floor(height / 100), 12), 3),
   xTickFormat: xTickFormatSpecifier = defaultTickFormatSpecifier,
   yTickFormat: yTickFormatSpecifier = defaultTickFormatSpecifier,
-}: {
-  context: CanvasRenderingContext2D;
-  xScale: AnyChartScale;
-  yScale: AnyChartScale;
-  suggestedPadding: Padding; // expanded according to label width
-  width: number;
-  height: number;
-  hideYAxis?: boolean;
-  drawTicks?: boolean;
-  tickCount?: number;
-  tickFormat?: string;
-  xTickFormat?: string;
-  yTickFormat?: string;
-}) {
-  const xTicks = xScale.ticks(tickCount);
-  const xTickFormat = xScale.tickFormat(tickCount, xTickFormatSpecifier);
+}: DrawAxesParams) {
+  const xTicks = xScale.ticks(xTickCount);
+  const xTickFormat = xScale.tickFormat(xTickCount, xTickFormatSpecifier);
 
-  const yTicks = yScale.ticks(tickCount);
-  const yTickFormat = yScale.tickFormat(tickCount, yTickFormatSpecifier);
+  const yTicks = yScale.ticks(yTickCount);
+  const yTickFormat = yScale.tickFormat(yTickCount, yTickFormatSpecifier);
 
   const tickSize = 2;
 

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -6,6 +6,7 @@ const axisColor = "rgba(114, 125, 147, 0.1)";
 export const labelColor = "rgb(114, 125, 147)";
 export const cursorLineColor = "#888";
 export const primaryColor = "#4c78a8"; // for lines and areas
+export const distributionColor = "#6d9bce"; // for distributions. Slightly lighter than primaryColor
 const labelFont = "10px sans-serif";
 const xLabelOffset = 6;
 const yLabelOffset = 6;

--- a/packages/components/src/lib/utility.ts
+++ b/packages/components/src/lib/utility.ts
@@ -95,3 +95,20 @@ export function isMac() {
 
 //This is important to make sure that canvas elements properly stretch
 export const canvasClasses = "w-full";
+
+// Function by supersan on Stack Overflow.
+// https://stackoverflow.com/questions/5560248/programmatically-lighten-or-darken-a-hex-color-or-rgb-and-blend-colors
+// Takes in a string like "#333999"
+export function adjustColorBrightness(color: string, amount: number) {
+  return (
+    "#" +
+    color
+      .replace(/^#/, "")
+      .replace(/../g, (color) =>
+        (
+          "0" +
+          Math.min(255, Math.max(0, parseInt(color, 16) + amount)).toString(16)
+        ).substr(-2)
+      )
+  );
+}

--- a/packages/components/src/stories/SquiggleChart/Distributions.stories.tsx
+++ b/packages/components/src/stories/SquiggleChart/Distributions.stories.tsx
@@ -33,6 +33,17 @@ export const ContinuousSampleSet: Story = {
   },
 };
 
+export const ContinuousSampleSet1MSamples: Story = {
+  name: "Continuous SampleSet, 1M Sample",
+  args: {
+    code: "SampleSet.fromDist(uniform(5,10))",
+    environment: {
+      sampleCount: 1000000,
+      xyPointLength: 1000,
+    },
+  },
+};
+
 export const Discrete: Story = {
   args: {
     code: "mx(0, 1, 3, 5, 8, 10, [0.1, 0.8, 0.5, 0.3, 0.2, 0.1])",

--- a/packages/components/src/stories/SquiggleChart/Distributions.stories.tsx
+++ b/packages/components/src/stories/SquiggleChart/Distributions.stories.tsx
@@ -26,6 +26,13 @@ export const ContinuousPointset: Story = {
   },
 };
 
+export const NonnormalizedContinousPointSet: Story = {
+  name: "Non-normalized Continuous Pointset",
+  args: {
+    code: "normal(5,2) .- uniform(3,8)",
+  },
+};
+
 export const ContinuousSampleSet: Story = {
   name: "Continuous SampleSet",
   args: {

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -22,11 +22,10 @@ export const Normal: Story = {
 export const Slow: Story = {
   name: "Slow Code",
   args: {
-    defaultCode:
-      "normal(5,2) + uniform(10, 120) + uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)+ uniform(30,2000)",
+    defaultCode: "List.upTo(1,5000000) -> reduce(0,add)",
     height: 800,
     renderingSettings: {
-      sampleCount: 500000,
+      sampleCount: 100000,
       xyPointLength: 1000,
     },
   },

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -24,10 +24,6 @@ export const Slow: Story = {
   args: {
     defaultCode: "List.upTo(1,5000000) -> reduce(0,add)",
     height: 800,
-    renderingSettings: {
-      sampleCount: 100000,
-      xyPointLength: 1000,
-    },
   },
 };
 

--- a/packages/hub/src/relative-values/components/views/PlotView/ValueAndUncertaintyPlot.tsx
+++ b/packages/hub/src/relative-values/components/views/PlotView/ValueAndUncertaintyPlot.tsx
@@ -88,7 +88,6 @@ export const ValueAndUncertaintyPlot: FC<{
         xScale,
         yScale,
         drawTicks: true,
-        tickCount: 10,
       });
 
       context.textAlign = "right";

--- a/packages/relative-values/src/components/View/PlotView/ValueAndUncertaintyPlot.tsx
+++ b/packages/relative-values/src/components/View/PlotView/ValueAndUncertaintyPlot.tsx
@@ -89,7 +89,6 @@ export const ValueAndUncertaintyPlot: FC<{
         xScale,
         yScale,
         drawTicks: true,
-        tickCount: 10,
       });
 
       context.textAlign = "right";

--- a/packages/squiggle-lang/src/public/SqDistribution.ts
+++ b/packages/squiggle-lang/src/public/SqDistribution.ts
@@ -61,6 +61,14 @@ export abstract class SqAbstractDistribution<T extends BaseDist> {
     return this._value.mean();
   }
 
+  integralSum(): number {
+    return this._value.integralSum();
+  }
+
+  isNormalized(): boolean {
+    return this._value.isNormalized();
+  }
+
   pdf(env: Env, n: number) {
     return Result.fmap2(
       this._value.pdf(n, { env }),

--- a/packages/ui/src/components/TextTooltip.tsx
+++ b/packages/ui/src/components/TextTooltip.tsx
@@ -62,7 +62,7 @@ export const TextTooltip: FC<Props> = ({
               },
             })}
           >
-            <div className="whitespace-pre text-white">{text}</div>
+            <div className="text-white max-w-sm">{text}</div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/packages/ui/src/stories/TextTooltip.stories.tsx
+++ b/packages/ui/src/stories/TextTooltip.stories.tsx
@@ -13,3 +13,11 @@ export const Primary: Story = {
     placement: "top",
   },
 };
+
+export const Long: Story = {
+  args: {
+    children: <div className="flex border p-1 w-24">Hover me</div>,
+    text: "Prow scuttle parrel provost Sail ho shrouds spirits boom mizzenmast yardarm. Pinnace holystone mizzenmast quarter crow's nest nipperkin grog yardarm hempen halter furl. Swab barque interloper chantey doubloon starboard grog black jack gangway rutters.",
+    placement: "top",
+  },
+};


### PR DESCRIPTION
- Simple fixes for 1M samples error. Closes https://github.com/quantified-uncertainty/squiggle/issues/1909
- Show "Not Normalized" warning for not normalized point sets.
- Adjust tick count based on width and height. This helps in cases of now-height charts, which used to have a lot of ticks.
- Change discrete points to be darker.
- In VariableBox, show types and length of records and arrays.

## Before:
<img width="2012" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/9b3086b6-6bb6-4b40-b41c-ac4c2b64c1c8">

## After:
<img width="1645" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/ab792597-7990-4651-8fc8-bd6d878718ee">

Note: All discrete/continuous mixtures are basically non-normalized, by small amounts. This seems good to fix soon. We could also only show the warning when the dist is like 1% close to being normalized, not sure. 