### PR TITLE
Fix CodeEditor bug

### DIFF
--- a/packages/components/src/languageSupport/squiggle.ts
+++ b/packages/components/src/languageSupport/squiggle.ts
@@ -1,19 +1,20 @@
+import { CompletionContext, snippetCompletion } from "@codemirror/autocomplete";
 import {
   LRLanguage,
   LanguageSupport,
-  indentNodeProp,
-  foldNodeProp,
   foldInside,
+  foldNodeProp,
+  indentNodeProp,
   syntaxTree,
 } from "@codemirror/language";
 import { styleTags, tags as t } from "@lezer/highlight";
-import { snippetCompletion, CompletionContext } from "@codemirror/autocomplete";
+import { RefObject } from "react";
 
 import { SqProject } from "@quri/squiggle-lang";
 
 import { parser } from "./generated/squiggle.js";
 
-export function squiggleLanguageSupport(project: SqProject) {
+export function squiggleLanguageSupport(projectRef: RefObject<SqProject>) {
   return new LanguageSupport(
     LRLanguage.define({
       name: "squiggle",
@@ -119,14 +120,14 @@ export function squiggleLanguageSupport(project: SqProject) {
                 label: name,
                 type: "constant",
               })),
-              ...project
-                .getStdLib()
+              ...(projectRef.current
+                ?.getStdLib()
                 .keySeq()
                 .toArray()
                 .map((name) => ({
                   label: name,
                   type: "function",
-                })),
+                })) ?? []),
             ],
           };
         },


### PR DESCRIPTION
Fixes #1939.

Note: I replaced `useMemo` with callback-based `useState`.

Usually this would be as bad as ignoring deps with `eslint-disable-next-line` (finding a way to exclude `defaultValue` from deps with a ref would be better, because it would catch other missing deps); but in this specific case, we really want to create `EditorState` only once, so `useState` is appropriate.