### PR TITLE
Case-insensitive slugs and usernames

### DIFF
--- a/packages/hub/prisma/migrations/20230628225944_citext/migration.sql
+++ b/packages/hub/prisma/migrations/20230628225944_citext/migration.sql
@@ -1,0 +1,11 @@
+-- CreateExtension
+CREATE EXTENSION IF NOT EXISTS "citext";
+
+-- AlterTable
+ALTER TABLE "Model" ALTER COLUMN "slug" SET DATA TYPE CITEXT;
+
+-- AlterTable
+ALTER TABLE "RelativeValuesDefinition" ALTER COLUMN "slug" SET DATA TYPE CITEXT;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "username" SET DATA TYPE CITEXT;

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 generator pothos {
@@ -10,8 +11,9 @@ generator pothos {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [citext]
 }
 
 model SquiggleCache {
@@ -54,7 +56,7 @@ model User {
   id                        String                     @id @default(cuid())
   name                      String?
   email                     String?                    @unique
-  username                  String?                    @unique
+  username                  String?                    @unique @db.Citext
   emailVerified             DateTime?
   image                     String?
   accounts                  Account[]
@@ -80,7 +82,7 @@ enum ModelType {
 model Model {
   id String @id @default(cuid())
 
-  slug String
+  slug String @db.Citext
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -130,7 +132,7 @@ model SquiggleSnippet {
 model RelativeValuesDefinition {
   id String @id @default(cuid())
 
-  slug String
+  slug String @db.Citext
 
   createdAt DateTime @default(now())
 

--- a/packages/hub/src/app/users/[username]/models/[slug]/FixModelUrlCasing.ts
+++ b/packages/hub/src/app/users/[username]/models/[slug]/FixModelUrlCasing.ts
@@ -1,0 +1,31 @@
+import { usePathname, useRouter } from "next/navigation";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import { patchModelRoute } from "@/routes";
+import { FixModelUrlCasing$key } from "@/__generated__/FixModelUrlCasing.graphql";
+
+export const FixModelUrlCasingFragment = graphql`
+  fragment FixModelUrlCasing on Model {
+    id
+    slug
+    owner {
+      username
+    }
+  }
+`;
+
+export function useFixModelUrlCasing(modelRef: FixModelUrlCasing$key) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const model = useFragment(FixModelUrlCasingFragment, modelRef);
+
+  const patchedPathname = patchModelRoute({
+    pathname,
+    slug: model.slug,
+    username: model.owner.username,
+  });
+  if (patchedPathname && patchedPathname !== pathname) {
+    router.replace(patchedPathname);
+  }
+}

--- a/packages/hub/src/app/users/[username]/models/[slug]/ModelPage.tsx
+++ b/packages/hub/src/app/users/[username]/models/[slug]/ModelPage.tsx
@@ -1,21 +1,21 @@
-import { FC, PropsWithChildren } from "react";
-import { graphql } from "relay-runtime";
 import { useSession } from "next-auth/react";
+import { FC, PropsWithChildren } from "react";
 import { useLazyLoadQuery } from "react-relay";
+import { graphql } from "relay-runtime";
 
 import { DropdownMenu } from "@quri/ui";
 
-import { DotsDropdownButton } from "@/components/ui/DotsDropdownButton";
-import { StyledTabLink } from "@/components/ui/StyledTabLink";
-import { modelRevisionsRoute, modelRoute } from "@/routes";
-import { DeleteModelAction } from "./DeleteModelAction";
-import { UpdateModelSlugAction } from "./UpdateModelSlugAction";
 import {
   ModelRevisionForRelativeValuesInput,
   QueryModelInput,
 } from "@/__generated__/ModelPageQuery.graphql";
-import { ModelPageQuery as ModelPageQueryType } from "@gen/ModelPageQuery.graphql";
 import { EntityLayout } from "@/components/EntityLayout";
+import { DotsDropdownButton } from "@/components/ui/DotsDropdownButton";
+import { StyledTabLink } from "@/components/ui/StyledTabLink";
+import { modelRevisionsRoute, modelRoute } from "@/routes";
+import { ModelPageQuery as ModelPageQueryType } from "@gen/ModelPageQuery.graphql";
+import { DeleteModelAction } from "./DeleteModelAction";
+import { UpdateModelSlugAction } from "./UpdateModelSlugAction";
 
 export const ModelPageFragment = graphql`
   fragment ModelPage on Model
@@ -43,6 +43,7 @@ const ModelPageQuery = graphql`
   ) {
     model(input: $input) {
       ...ModelPage @arguments(forRelativeValues: $forRelativeValues)
+      ...FixModelUrlCasing
     }
   }
 `;

--- a/packages/hub/src/app/users/[username]/models/[slug]/page.tsx
+++ b/packages/hub/src/app/users/[username]/models/[slug]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useModelPageQuery } from "./ModelPage";
 import { EditModelPageBody } from "./EditModelPageBody";
+import { useFixModelUrlCasing } from "./FixModelUrlCasing";
 
 export default function Page({
   params,
@@ -12,6 +13,8 @@ export default function Page({
     ownerUsername: params.username,
     slug: params.slug,
   });
+
+  useFixModelUrlCasing(modelRef);
 
   return <EditModelPageBody modelRef={modelRef} />;
 }

--- a/packages/hub/src/app/users/[username]/models/[slug]/relative-values/[variableName]/layout.tsx
+++ b/packages/hub/src/app/users/[username]/models/[slug]/relative-values/[variableName]/layout.tsx
@@ -17,6 +17,7 @@ import { ModelPageFragment, useModelPageQuery } from "../../ModelPage";
 import { ModelRevisionFragment } from "../../ModelRevision";
 import { ViewModelRevision } from "../../ViewModelRevision";
 import { CacheMenu } from "./CacheMenu";
+import { useFixModelUrlCasing } from "../../FixModelUrlCasing";
 
 export default function RelativeValuesModelLayout({
   params,
@@ -34,6 +35,7 @@ export default function RelativeValuesModelLayout({
       variableName: params.variableName,
     }
   );
+  useFixModelUrlCasing(modelRef);
 
   const model = useFragment<ModelPage$key>(ModelPageFragment, modelRef);
   const revision = useFragment<ModelRevision$key>(

--- a/packages/hub/src/app/users/[username]/models/[slug]/revisions/ModelRevisionsList.tsx
+++ b/packages/hub/src/app/users/[username]/models/[slug]/revisions/ModelRevisionsList.tsx
@@ -9,6 +9,7 @@ import { modelRevisionRoute } from "@/routes";
 import { ModelRevisionsListQuery } from "@gen/ModelRevisionsListQuery.graphql";
 import { Button } from "@quri/ui";
 import { format } from "date-fns";
+import { useFixModelUrlCasing } from "../FixModelUrlCasing";
 
 const RevisionsFragment = graphql`
   fragment ModelRevisionsList on Model
@@ -36,6 +37,7 @@ const ModelRevisionsListQuery = graphql`
   query ModelRevisionsListQuery($input: QueryModelInput!) {
     model(input: $input) {
       id
+      ...FixModelUrlCasing
       ...ModelRevisionsList
     }
   }
@@ -54,6 +56,8 @@ export const ModelRevisionsList: FC<Props> = ({ username, slug }) => {
     },
     { fetchPolicy: "store-and-network" }
   );
+
+  useFixModelUrlCasing(modelRef);
 
   const { data: model, loadNext } = usePaginationFragment<
     ModelRevisionsListQuery,

--- a/packages/hub/src/app/users/[username]/models/[slug]/revisions/[revisionId]/ModelRevisionView.tsx
+++ b/packages/hub/src/app/users/[username]/models/[slug]/revisions/[revisionId]/ModelRevisionView.tsx
@@ -8,11 +8,13 @@ import { modelRoute } from "@/routes";
 import { ModelRevisionViewQuery } from "@gen/ModelRevisionViewQuery.graphql";
 import { SquigglePlayground } from "@quri/squiggle-components";
 import { format } from "date-fns";
+import { useFixModelUrlCasing } from "../../FixModelUrlCasing";
 
 const ModelRevisionViewQuery = graphql`
   query ModelRevisionViewQuery($input: QueryModelInput!, $revisionId: ID!) {
     model(input: $input) {
       id
+      ...FixModelUrlCasing
       revision(id: $revisionId) {
         createdAtTimestamp
         content {
@@ -44,6 +46,8 @@ export const ModelRevisionView: FC<Props> = ({
       revisionId,
     }
   );
+
+  useFixModelUrlCasing(data.model);
 
   const typename = data.model.revision.content.__typename;
   if (typename !== "SquiggleSnippet") {

--- a/packages/hub/src/app/users/[username]/models/[slug]/view/page.tsx
+++ b/packages/hub/src/app/users/[username]/models/[slug]/view/page.tsx
@@ -6,6 +6,7 @@ import { ModelPage$key } from "@/__generated__/ModelPage.graphql";
 import { ModelPageFragment, useModelPageQuery } from "../ModelPage";
 import { ViewModelRevision } from "../ViewModelRevision";
 import { ViewModelRevisionContent } from "../ViewModelRevisionContent";
+import { useFixModelUrlCasing } from "../FixModelUrlCasing";
 
 export default function OuterModelPage({
   params,
@@ -16,6 +17,7 @@ export default function OuterModelPage({
     ownerUsername: params.username,
     slug: params.slug,
   });
+  useFixModelUrlCasing(modelRef);
 
   const model = useFragment<ModelPage$key>(ModelPageFragment, modelRef);
 

--- a/packages/hub/src/routes.ts
+++ b/packages/hub/src/routes.ts
@@ -28,8 +28,7 @@ export function patchModelRoute({
 }) {
   const match = pathname.match("^/users/[^/]+/models/[^/]+($|/.*)");
   if (!match) {
-    // not a model route; should we throw an error instead?
-    return pathname;
+    throw new Error("Not a model route");
   }
   return `/users/${username}/models/${slug}${match[1]}`;
 }

--- a/packages/hub/src/routes.ts
+++ b/packages/hub/src/routes.ts
@@ -16,6 +16,24 @@ export function isModelRoute(url: string) {
   return url.match("^/users/[^/]+/models/[^/]+$");
 }
 
+// used by useFixModelUrlCasing hook
+export function patchModelRoute({
+  pathname,
+  username,
+  slug,
+}: {
+  pathname: string;
+  username: string;
+  slug: string;
+}) {
+  const match = pathname.match("^/users/[^/]+/models/[^/]+($|/.*)");
+  if (!match) {
+    // not a model route; should we throw an error instead?
+    return pathname;
+  }
+  return `/users/${username}/models/${slug}${match[1]}`;
+}
+
 export function modelForRelativeValuesExportRoute({
   username,
   slug,


### PR DESCRIPTION
Fixes #1926.

Citext works fine, but automatic redirects are a bit of a pain. I had to write a special hook (`useFixModelUrlCasing`) and call it in all model subpages.

If there are pages where we don't call it, it's not a big deal, the casing in URL will just be not correct, and the content will still load correctly.

Ideally, we should also do the same thing on wrong user links and relative-values links, but since the implementation is a bit verbose, I don't want to write more extra code for those cases. Usernames don't ever change, and we don't have renames for relative-values definitions.

There's also this weird error that happens on redirects:
<img width="954" alt="Captura de pantalla 2023-06-28 a la(s) 19 59 41" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/c19c02ec-9800-4f12-99f2-8ca95c3e0363">
I can't find the reason for it, might be React/Next.js bug. It doesn't affect anything and I suspect it'll be hidden in prod (I checked React source code...).