### PR TITLE
Fix shortcut tooltips on non-macs

### DIFF
--- a/packages/components/src/components/SquigglePlayground/RunControls/RunMenuItem.tsx
+++ b/packages/components/src/components/SquigglePlayground/RunControls/RunMenuItem.tsx
@@ -1,9 +1,9 @@
-import React from "react";
 import { RefreshIcon } from "@heroicons/react/solid/esm/index.js";
+import React from "react";
 
 import { PlayIcon } from "@quri/ui";
 
-import { isMac } from "../../../lib/utility.js";
+import { modKey } from "../../../lib/utility.js";
 import { MenuItem } from "../MenuItem.js";
 import { RunnerState } from "./useRunnerState.js";
 
@@ -13,7 +13,7 @@ export const RunMenuItem: React.FC<RunnerState & { isRunning: boolean }> = ({
   isRunning,
 }) => {
   const showAsRunning = !autorunMode && isRunning;
-  const text = `Run (${isMac() ? "Cmd+Enter" : "Ctrl+Enter"})`;
+  const text = `Run (${modKey()}+Enter)`;
 
   return (
     <MenuItem

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -15,7 +15,7 @@ import { z } from "zod";
 import { AdjustmentsVerticalIcon, Bars3CenterLeftIcon, Button } from "@quri/ui";
 
 import { useSquiggle, useUncontrolledCode } from "../../lib/hooks/index.js";
-import { getErrors, isMac } from "../../lib/utility.js";
+import { altKey, getErrors } from "../../lib/utility.js";
 import { CodeEditor, CodeEditorHandle } from "../CodeEditor.js";
 import { DynamicSquiggleViewer } from "../DynamicSquiggleViewer.js";
 import {
@@ -152,11 +152,7 @@ export const SquigglePlayground: React.FC<PlaygroundProps> = (props) => {
           tooltipText="Configuration"
         />
         <MenuItem
-          tooltipText={
-            isMac()
-              ? "Format Code (Option+Shift+f)"
-              : "Format Code (Alt+Shift+f)"
-          }
+          tooltipText={`Format Code (${altKey()}+Shift+f)`}
           icon={Bars3CenterLeftIcon}
           onClick={editorRef.current?.format}
         />

--- a/packages/components/src/lib/utility.ts
+++ b/packages/components/src/lib/utility.ts
@@ -85,12 +85,20 @@ export function isMac() {
   // Browser-only. Defaults to `false` when `window` is not available.
 
   // TODO - support https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform
-  // when it will become available in Typescript types.
+  // when it will become available in modern browsers.
   // Note: MacIntel is valid even for ARM macs.
-  return typeof window !== "undefined" &&
-    window.navigator.platform === "MacIntel"
-    ? "Cmd+Enter"
-    : "Ctrl+Enter";
+  return (
+    typeof window !== "undefined" && window.navigator.platform === "MacIntel"
+  );
+}
+
+export function modKey() {
+  // Matches Codemirror; https://codemirror.net/docs/ref/#view.KeyBinding
+  return isMac() ? "Cmd" : "Ctrl";
+}
+
+export function altKey() {
+  return isMac() ? "Option" : "Alt";
 }
 
 //This is important to make sure that canvas elements properly stretch


### PR DESCRIPTION
There was a bug in `isMac()` function.