### PR TITLE
Fix types for react-hook-form 7.45

### DIFF
--- a/packages/hub/src/relative-values/components/RelativeValuesDefinitionForm/index.tsx
+++ b/packages/hub/src/relative-values/components/RelativeValuesDefinitionForm/index.tsx
@@ -241,7 +241,7 @@ const HTMLForm: FC = () => {
                   label: item.id,
                   value: item.id,
                 }))}
-                onChange={(item) => field.onChange(item?.value)}
+                onChange={(item) => field.onChange(item?.value ?? null)}
                 isClearable={true}
               />
             );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,7 @@
     "framer-motion": "^10.12.18",
     "react-colorful": "^5.6.1",
     "react-hook-form": "^7.45.1",
-    "react-textarea-autosize": "^8.5.0",
+    "react-textarea-autosize": "8.4.1",
     "react-use": "^17.4.0"
   },
   "devDependencies": {

--- a/packages/ui/src/forms/common/ControlledFormField.tsx
+++ b/packages/ui/src/forms/common/ControlledFormField.tsx
@@ -1,26 +1,36 @@
 import { ReactNode } from "react";
 import {
-  ControllerRenderProps,
-  FieldPath,
+  FieldPathByValue,
   FieldValues,
   RegisterOptions,
 } from "react-hook-form";
 
 import { ControlledFormInput } from "./ControlledFormInput.js";
 import { FieldLayout, FormFieldLayoutProps } from "./FormFieldLayout.js";
+import { PatchedControllerRenderProps } from "./types.js";
 
 export type ControlledFormFieldProps<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TValueType = unknown,
+  TName extends FieldPathByValue<TValues, TValueType> = FieldPathByValue<
+    TValues,
+    TValueType
+  >
 > = FormFieldLayoutProps & {
   name: TName;
   rules?: RegisterOptions<TValues, TName>;
-  children: (props: ControllerRenderProps<TValues, TName>) => ReactNode;
+  children: (
+    props: PatchedControllerRenderProps<TValues, TValueType, TName>
+  ) => ReactNode;
 };
 
 export function ControlledFormField<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TValueType,
+  TName extends FieldPathByValue<TValues, TValueType> = FieldPathByValue<
+    TValues,
+    TValueType
+  >
 >({
   name,
   rules,
@@ -28,7 +38,7 @@ export function ControlledFormField<
   description,
   inlineLabel,
   children,
-}: ControlledFormFieldProps<TValues, TName>) {
+}: ControlledFormFieldProps<TValues, TValueType, TName>) {
   return (
     <FieldLayout
       label={label}

--- a/packages/ui/src/forms/common/ControlledFormInput.tsx
+++ b/packages/ui/src/forms/common/ControlledFormInput.tsx
@@ -2,28 +2,40 @@ import { ReactNode } from "react";
 import {
   Controller,
   ControllerRenderProps,
-  FieldPath,
+  FieldPathByValue,
+  FieldPathValue,
   FieldValues,
   UseControllerProps,
   useFormContext,
 } from "react-hook-form";
 
 import { WithRHFError } from "./WithRHFError.js";
+import { PatchedControllerRenderProps } from "./types.js";
 
 type Props<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TValueType,
+  TName extends FieldPathByValue<TValues, TValueType> = FieldPathByValue<
+    TValues,
+    TValueType
+  >
 > = {
   name: TName;
   rules?: UseControllerProps<TValues, TName>["rules"];
-  children: (props: ControllerRenderProps<TValues, TName>) => ReactNode;
+  children: (
+    props: PatchedControllerRenderProps<TValues, TValueType, TName>
+  ) => ReactNode;
 };
 
 // Helper component for custom controlled react-hook-form connected components.
 export function ControlledFormInput<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
->({ name, rules, children }: Props<TValues, TName>) {
+  TValueType,
+  TName extends FieldPathByValue<TValues, TValueType> = FieldPathByValue<
+    TValues,
+    TValueType
+  >
+>({ name, rules, children }: Props<TValues, TValueType, TName>) {
   const { control } = useFormContext<TValues>();
 
   return (
@@ -32,7 +44,17 @@ export function ControlledFormInput<
         name={name}
         control={control}
         rules={rules}
-        render={({ field }) => <div>{children(field) ?? null}</div>}
+        render={({ field }) => (
+          <div>
+            {children(
+              // our controller components don't allow ChangeEvent events;
+              // also, Typescript is not smart enough to infer that FieldPathByValue is the inverse of FieldPathValue
+              field as Omit<typeof field, "onChange"> & {
+                onChange: (event: TValueType) => void;
+              }
+            )}
+          </div>
+        )}
       />
     </WithRHFError>
   );

--- a/packages/ui/src/forms/common/types.ts
+++ b/packages/ui/src/forms/common/types.ts
@@ -1,4 +1,10 @@
-import { FieldPath, FieldValues, RegisterOptions } from "react-hook-form";
+import {
+  ControllerRenderProps,
+  FieldPath,
+  FieldPathByValue,
+  FieldValues,
+  RegisterOptions,
+} from "react-hook-form";
 import { FormFieldLayoutProps } from "./FormFieldLayout.js";
 
 type StringRules<
@@ -18,7 +24,10 @@ type NumberRules<
 // These types is useful for specific field/*FormField declarations.
 export type CommonStringFieldProps<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TName extends FieldPathByValue<TValues, string> = FieldPathByValue<
+    TValues,
+    string
+  >
 > = Omit<FormFieldLayoutProps, "inlineLabel"> & {
   name: TName;
   rules?: StringRules<TValues, TName>;
@@ -26,7 +35,10 @@ export type CommonStringFieldProps<
 
 export type CommonNumberFieldProps<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TName extends FieldPathByValue<
+    TValues,
+    number | undefined
+  > = FieldPathByValue<TValues, number | undefined>
 > = Omit<FormFieldLayoutProps, "inlineLabel"> & {
   name: TName;
   rules?: NumberRules<TValues, TName>;
@@ -39,4 +51,15 @@ export type CommonUnknownFieldProps<
   name: TName;
   // TODO - allow more rules?
   rules?: Pick<RegisterOptions<TValues, TName>, "required" | "validate">;
+};
+
+export type PatchedControllerRenderProps<
+  TValues extends FieldValues,
+  TValueType,
+  TName extends FieldPathByValue<TValues, TValueType> = FieldPathByValue<
+    TValues,
+    TValueType
+  >
+> = Omit<ControllerRenderProps<TValues, TName>, "onChange"> & {
+  onChange: (event: TValueType) => void;
 };

--- a/packages/ui/src/forms/fields/ColorFormField.tsx
+++ b/packages/ui/src/forms/fields/ColorFormField.tsx
@@ -1,15 +1,18 @@
-import { FieldPath, FieldValues } from "react-hook-form";
+import { FieldPathByValue, FieldValues } from "react-hook-form";
 
 import { ControlledFormField } from "../common/ControlledFormField.js";
-import { StyledColorInput } from "../styled/StyledColorInput.js";
 import { CommonStringFieldProps } from "../common/types.js";
+import { StyledColorInput } from "../styled/StyledColorInput.js";
 
 export function ColorFormField<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TName extends FieldPathByValue<TValues, string> = FieldPathByValue<
+    TValues,
+    string
+  >
 >({ ...fieldProps }: CommonStringFieldProps<TValues, TName>) {
   return (
-    <ControlledFormField {...fieldProps} inlineLabel>
+    <ControlledFormField<TValues, string, TName> {...fieldProps} inlineLabel>
       {({ value, onChange }) => (
         <StyledColorInput value={value} onChange={onChange} />
       )}

--- a/packages/ui/src/forms/fields/NumberFormField.tsx
+++ b/packages/ui/src/forms/fields/NumberFormField.tsx
@@ -1,4 +1,4 @@
-import { FieldPath, FieldValues } from "react-hook-form";
+import { FieldPathByValue, FieldValues } from "react-hook-form";
 
 import { ControlledFormField } from "../common/ControlledFormField.js";
 import { CommonNumberFieldProps } from "../common/types.js";
@@ -6,7 +6,10 @@ import { StyledInput, type StyledInputProps } from "../styled/StyledInput.js";
 
 export function NumberFormField<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TName extends FieldPathByValue<
+    TValues,
+    number | undefined
+  > = FieldPathByValue<TValues, number | undefined>
 >({
   placeholder,
   rules = {},

--- a/packages/ui/src/forms/fields/TextAreaFormField.tsx
+++ b/packages/ui/src/forms/fields/TextAreaFormField.tsx
@@ -1,4 +1,4 @@
-import { FieldPath, FieldValues } from "react-hook-form";
+import { FieldPathByValue, FieldValues } from "react-hook-form";
 
 import { FormField } from "../common/FormField.js";
 import { CommonStringFieldProps } from "../common/types.js";
@@ -9,7 +9,10 @@ import {
 
 export function TextAreaFormField<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TName extends FieldPathByValue<TValues, string> = FieldPathByValue<
+    TValues,
+    string
+  >
 >({
   placeholder,
   ...fieldProps

--- a/packages/ui/src/forms/fields/TextFormField.tsx
+++ b/packages/ui/src/forms/fields/TextFormField.tsx
@@ -1,4 +1,4 @@
-import { FieldPath, FieldValues } from "react-hook-form";
+import { FieldPathByValue, FieldValues } from "react-hook-form";
 
 import { FormField } from "../common/FormField.js";
 import { CommonStringFieldProps } from "../common/types.js";
@@ -6,7 +6,10 @@ import { StyledInput, type StyledInputProps } from "../styled/StyledInput.js";
 
 export function TextFormField<
   TValues extends FieldValues,
-  TName extends FieldPath<TValues> = FieldPath<TValues>
+  TName extends FieldPathByValue<TValues, string> = FieldPathByValue<
+    TValues,
+    string
+  >
 >({
   placeholder,
   size,

--- a/packages/ui/src/forms/styled/StyledTextArea.tsx
+++ b/packages/ui/src/forms/styled/StyledTextArea.tsx
@@ -1,6 +1,11 @@
 import { TextareaHTMLAttributes, forwardRef } from "react";
-import TextareaAutosize from "react-textarea-autosize";
+import ImportedTextareaAutosize from "react-textarea-autosize";
 import { clsx } from "clsx";
+
+// ESM hack; can be removed after we upgrade to >8.5.0
+// but that depends on https://github.com/Andarist/react-textarea-autosize/issues/379
+const TextareaAutosize =
+  ImportedTextareaAutosize as unknown as typeof ImportedTextareaAutosize.default;
 
 export type StyledTextAreaProps = Omit<
   TextareaHTMLAttributes<HTMLTextAreaElement>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4509,7 +4509,7 @@ __metadata:
     react-colorful: ^5.6.1
     react-dom: ^18.2.0
     react-hook-form: ^7.45.1
-    react-textarea-autosize: ^8.5.0
+    react-textarea-autosize: 8.4.1
     react-use: ^17.4.0
     rollup-plugin-node-builtins: ^2.1.2
     storybook: ^7.0.24
@@ -19627,7 +19627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-textarea-autosize@npm:^8.3.2":
+"react-textarea-autosize@npm:8.4.1, react-textarea-autosize@npm:^8.3.2":
   version: 8.4.1
   resolution: "react-textarea-autosize@npm:8.4.1"
   dependencies:
@@ -19637,19 +19637,6 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: b200437cd68938c23b13944fe6fdfeb32a6d949ac88588307f14d6fcdaba3044b8c7d8e239851b081f2101d433b93d4cf5aa027543b170b84f2a0cbe6fc9093f
-  languageName: node
-  linkType: hard
-
-"react-textarea-autosize@npm:^8.5.0":
-  version: 8.5.0
-  resolution: "react-textarea-autosize@npm:8.5.0"
-  dependencies:
-    "@babel/runtime": ^7.20.13
-    use-composed-ref: ^1.3.0
-    use-latest: ^1.2.1
-  peerDependencies:
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: c5fde6100b74277d75a796a7b3b2287759ed16173c34b58cfa541bca474a09d23e7695f6c9aab4e9b5f35cb4f05792d5e0fb669d926efba536f82c7b7b75e5e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Caused by https://github.com/react-hook-form/react-hook-form/pull/10342.

Thanks to `FieldPathByValue`, our form component types are now more strict, and check not just for the name being present in form, but also for its specific type (string, number, etc.).