### PR TITLE
Textarea autosize upgrade

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,7 +37,7 @@
     "framer-motion": "^10.12.18",
     "react-colorful": "^5.6.1",
     "react-hook-form": "^7.45.1",
-    "react-textarea-autosize": "8.4.1",
+    "react-textarea-autosize": "8.5.2",
     "react-use": "^17.4.0"
   },
   "devDependencies": {

--- a/packages/ui/src/forms/styled/StyledColorInput.tsx
+++ b/packages/ui/src/forms/styled/StyledColorInput.tsx
@@ -1,6 +1,7 @@
 import { HexColorInput, HexColorPicker } from "react-colorful";
 
-import { Dropdown, DropdownMenu } from "../../index.js";
+import { Dropdown } from "../../components/Dropdown/index.js";
+import { DropdownMenu } from "../../components/Dropdown/DropdownMenu.js";
 
 type Props = {
   value: string;

--- a/packages/ui/src/forms/styled/StyledTextArea.tsx
+++ b/packages/ui/src/forms/styled/StyledTextArea.tsx
@@ -1,11 +1,6 @@
 import { TextareaHTMLAttributes, forwardRef } from "react";
-import ImportedTextareaAutosize from "react-textarea-autosize";
+import TextareaAutosize from "react-textarea-autosize";
 import { clsx } from "clsx";
-
-// ESM hack; can be removed after we upgrade to >8.5.0
-// but that depends on https://github.com/Andarist/react-textarea-autosize/issues/379
-const TextareaAutosize =
-  ImportedTextareaAutosize as unknown as typeof ImportedTextareaAutosize.default;
 
 export type StyledTextAreaProps = Omit<
   TextareaHTMLAttributes<HTMLTextAreaElement>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4509,7 +4509,7 @@ __metadata:
     react-colorful: ^5.6.1
     react-dom: ^18.2.0
     react-hook-form: ^7.45.1
-    react-textarea-autosize: 8.4.1
+    react-textarea-autosize: 8.5.2
     react-use: ^17.4.0
     rollup-plugin-node-builtins: ^2.1.2
     storybook: ^7.0.24
@@ -19627,7 +19627,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-textarea-autosize@npm:8.4.1, react-textarea-autosize@npm:^8.3.2":
+"react-textarea-autosize@npm:8.5.2":
+  version: 8.5.2
+  resolution: "react-textarea-autosize@npm:8.5.2"
+  dependencies:
+    "@babel/runtime": ^7.20.13
+    use-composed-ref: ^1.3.0
+    use-latest: ^1.2.1
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 48504e1c7bea01ea9632a2f663271519693926bb4dbdba7f7353178078df95a877fb298ff56e8ba41a324b212da2b3df13524de54c6a32a2de8241e46dceba98
+  languageName: node
+  linkType: hard
+
+"react-textarea-autosize@npm:^8.3.2":
   version: 8.4.1
   resolution: "react-textarea-autosize@npm:8.4.1"
   dependencies:


### PR DESCRIPTION
https://github.com/Andarist/react-textarea-autosize/issues/379 is now fixed upstream, so we can upgrade.

(I'll merge this immediately after CI checks)