### PR TITLE
(Minor) Improve error message when ternary condition is wrong

### DIFF
--- a/packages/squiggle-lang/__tests__/reducer/ternaryOperator_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/ternaryOperator_test.ts
@@ -9,5 +9,8 @@ describe("Evaluate ternary operator", () => {
   testEvalToBe("false ? 'YES' : 'NO'", "'NO'");
   testEvalToBe("2 > 1 ? 'YES' : 'NO'", "'YES'");
   testEvalToBe("2 <= 1 ? 'YES' : 'NO'", "'NO'");
-  testEvalToBe("1+1 ? 'YES' : 'NO'", "Error(Expected type: Boolean but got: )");
+  testEvalToBe(
+    "1+1 ? 'YES' : 'NO'",
+    "Error(Expected type: Boolean but got: Number)"
+  );
 });

--- a/packages/squiggle-lang/src/reducer/index.ts
+++ b/packages/squiggle-lang/src/reducer/index.ts
@@ -184,7 +184,11 @@ const evaluateTernary: SubReducerFn<"Ternary"> = (
     context
   );
   if (predicateResult.type !== "Bool") {
-    return throwFrom(new REExpectedType("Boolean", ""), context, ast);
+    return throwFrom(
+      new REExpectedType("Boolean", predicateResult.type),
+      context,
+      ast
+    );
   }
 
   const [value] = context.evaluate(


### PR DESCRIPTION
`1 ? 2 : 3`

Before: `Expected type: Boolean but got:`

Now: `Expected type: Boolean but got: Number`