### PR TITLE
Default sampleCount in squiggle-lang is 1k, like in playground

### DIFF
--- a/packages/squiggle-lang/__tests__/library/dist_test.ts
+++ b/packages/squiggle-lang/__tests__/library/dist_test.ts
@@ -146,7 +146,13 @@ describe("eval on distribution functions", () => {
   describe("subtract", () => {
     testEvalToBe("10 - normal(5, 1)", "Normal(5,1)");
     testEvalToBe("normal(5, 1) - 10", "Normal(-5,1)");
-    testEvalToBe("mean(1 - toPointSet(normal(5, 2)))", "-4.002309896304692");
+    test("mean(1 - toPointSet(normal(5, 2)))", async () => {
+      const result = await testRun("mean(1 - toPointSet(normal(5, 2)))");
+      if (result.tag !== "Number") {
+        fail();
+      }
+      expect(Math.abs(result.value - -4)).toBeLessThan(0.3); // FIXME - unstable
+    });
   });
   describe("multiply", () => {
     testEvalToBe("normal(10, 2) * 2", "Normal(20,4)");

--- a/packages/squiggle-lang/src/dist/distOperations/algebraicCombination.ts
+++ b/packages/squiggle-lang/src/dist/distOperations/algebraicCombination.ts
@@ -135,7 +135,7 @@ const preferConvolutionToMonteCarlo = (args: CombinationArgs): boolean => {
 
   const convolutionIsFasterThanMonteCarlo = () =>
     args.t1.expectedConvolutionCost() * args.t2.expectedConvolutionCost() <
-    magicNumbers.OpCost.monteCarloCost;
+    args.env.sampleCount;
 
   return (
     !hasSampleSetDist() &&

--- a/packages/squiggle-lang/src/magicNumbers.ts
+++ b/packages/squiggle-lang/src/magicNumbers.ts
@@ -2,14 +2,14 @@ export const epsilon_float = 2.22044604925031308e-16; // via pervasives.js
 
 export const Environment = {
   defaultXYPointLength: 1000,
-  defaultSampleCount: 10000,
+  defaultSampleCount: 1000,
   sparklineLength: 20,
 };
 
 export const OpCost = {
   floatCost: 1,
   symbolicCost: 1000,
-  //   // Discrete cost is the length of the xyShape
+  // Discrete cost is the length of the xyShape
   mixedCost: 1000,
   continuousCost: 1000,
   wildcardCost: 1000,

--- a/packages/squiggle-lang/src/magicNumbers.ts
+++ b/packages/squiggle-lang/src/magicNumbers.ts
@@ -8,12 +8,12 @@ export const Environment = {
 
 export const OpCost = {
   floatCost: 1,
+  // FIXME - these depend on runtime env and other variables and shouldn't be global
   symbolicCost: 1000,
   // Discrete cost is the length of the xyShape
   mixedCost: 1000,
   continuousCost: 1000,
   wildcardCost: 1000,
-  monteCarloCost: Environment.defaultSampleCount,
 };
 
 export const Epsilon = {


### PR DESCRIPTION
We discussed before how we should do this.

Also, it fixes #1693.

As an interesting consequence, it affects `preferConvolutionToMonteCarlo`, which previously used _default_ sample count (see the diff).