### PR TITLE
Scale.log fixes

### DIFF
--- a/packages/components/src/lib/d3/patchedScales.ts
+++ b/packages/components/src/lib/d3/patchedScales.ts
@@ -55,11 +55,13 @@ function tickFormatWithCustom(
   return d3.tickFormat(start, stop, count, specifier);
 }
 
+type ScaleLinear = d3.ScaleLinear<number, number, never>;
+type ScaleLogarithmic = d3.ScaleLogarithmic<number, number, never>;
+type ScaleSymLog = d3.ScaleSymLog<number, number, never>;
+type ScalePower = d3.ScalePower<number, number, never>;
+
 function patchLinearishTickFormat<
-  T extends
-    | d3.ScaleLinear<number, number, never>
-    | d3.ScaleSymLog<number, number, never>
-    | d3.ScalePower<number, number, never>,
+  T extends ScaleLinear | ScaleSymLog | ScalePower,
 >(scale: T): T {
   // copy-pasted from https://github.com/d3/d3-scale/blob/83555bd759c7314420bd4240642beda5e258db9e/src/linear.js#L14
   scale.tickFormat = (count, specifier) => {
@@ -70,23 +72,11 @@ function patchLinearishTickFormat<
   return scale;
 }
 
-// Original d3.scale* should never be used; they won't support our custom tick formats.
-
-export function scaleLinear() {
-  return patchLinearishTickFormat(d3.scaleLinear());
+function patchSymlogTickFormat(scale: ScaleSymLog): ScaleSymLog {
+  return patchLinearishTickFormat(scale);
 }
 
-export function scaleSymlog() {
-  return patchLinearishTickFormat(d3.scaleSymlog());
-}
-
-export function scalePow() {
-  return patchLinearishTickFormat(d3.scalePow());
-}
-
-export function scaleLog() {
-  // log scale tickFormat is special
-  const scale = d3.scaleLog();
+function patchLogarithmicTickFormat(scale: ScaleLogarithmic): ScaleLogarithmic {
   const logScaleTickFormat = scale.tickFormat;
   scale.tickFormat = (count, specifier) => {
     return logScaleTickFormat(
@@ -100,4 +90,22 @@ export function scaleLog() {
     );
   };
   return scale;
+}
+
+// Original d3.scale* should never be used; they won't support our custom tick formats.
+
+export function scaleLinear() {
+  return patchLinearishTickFormat(d3.scaleLinear());
+}
+
+export function scaleSymlog() {
+  return patchSymlogTickFormat(d3.scaleSymlog());
+}
+
+export function scalePow() {
+  return patchLinearishTickFormat(d3.scalePow());
+}
+
+export function scaleLog() {
+  return patchLogarithmicTickFormat(d3.scaleLog());
 }

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -109,6 +109,9 @@ export function drawAxes({
       }
 
       const text = xTickFormat(xTick);
+      if (text === "") {
+        continue; // we're probably rendering scaleLog, which has empty labels
+      }
       const { width: textWidth } = context.measureText(text);
       let startX = 0;
       if (i === 0) {
@@ -231,7 +234,7 @@ export function drawCursorLines({
     context.textAlign = "left";
     context.textBaseline = "bottom";
     const text = xLine.scale.tickFormat(
-      undefined,
+      Infinity, // important for scaleLog; https://github.com/d3/d3-scale/tree/main#log_tickFormat
       xLine.format
     )(xLine.scale.invert(point.x));
     const measured = context.measureText(text);
@@ -284,7 +287,7 @@ export function drawCursorLines({
     context.textAlign = "left";
     context.textBaseline = "bottom";
     const text = yLine.scale.tickFormat(
-      undefined,
+      Infinity, // important for scaleLog; https://github.com/d3/d3-scale/tree/main#log_tickFormat
       yLine.format
     )(yLine.scale.invert(point.y));
     const measured = context.measureText(text);

--- a/packages/squiggle-lang/__tests__/helpers/reducerHelpers.ts
+++ b/packages/squiggle-lang/__tests__/helpers/reducerHelpers.ts
@@ -59,8 +59,19 @@ export async function expectEvalToBe(code: string, answer: string) {
   expect(resultToString(await evaluateStringToResult(code))).toBe(answer);
 }
 
+export async function expectEvalToMatch(
+  code: string,
+  expected: string | RegExp
+) {
+  expect(resultToString(await evaluateStringToResult(code))).toMatch(expected);
+}
+
 export function testEvalToBe(expr: string, answer: string) {
   test(expr, async () => await expectEvalToBe(expr, answer));
+}
+
+export function testEvalToMatch(expr: string, expected: string | RegExp) {
+  test(expr, async () => await expectEvalToMatch(expr, expected));
 }
 
 export const MySkip = {

--- a/packages/squiggle-lang/__tests__/library/scale_test.ts
+++ b/packages/squiggle-lang/__tests__/library/scale_test.ts
@@ -1,0 +1,31 @@
+import { testEvalToBe, testEvalToMatch } from "../helpers/reducerHelpers.js";
+
+describe("Scales", () => {
+  testEvalToBe("Scale.linear()", "Linear scale");
+  testEvalToMatch(
+    "Scale.linear({ min: 10, max: 5 })",
+    "Max must be greater than min, got: min=10, max=5"
+  );
+
+  testEvalToBe("Scale.log()", "Logarithmic scale");
+  testEvalToMatch(
+    "Scale.log({ min: 10, max: 5 })",
+    "Max must be greater than min, got: min=10, max=5"
+  );
+  testEvalToMatch(
+    "Scale.log({ min: -1 })",
+    "Min must be over 0 for log scale, got: -1"
+  );
+
+  testEvalToBe("Scale.symlog()", "Symlog scale");
+  testEvalToMatch(
+    "Scale.symlog({ min: 10, max: 5 })",
+    "Max must be greater than min, got: min=10, max=5"
+  );
+
+  testEvalToBe("Scale.power({ exponent: 2 })", "Power scale (2)");
+  testEvalToMatch(
+    "Scale.power({ min: 10, max: 5, exponent: 2 })",
+    "Max must be greater than min, got: min=10, max=5"
+  );
+});

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -8,6 +8,7 @@ import {
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 import { vScale } from "../value/index.js";
+import { REOther } from "../errors/messages.js";
 
 const maker = new FnFactory({
   nameSpace: "Scale",
@@ -20,6 +21,14 @@ const commonRecord = frRecord(
   ["tickFormat", frOptional(frString)]
 );
 
+function checkMinMax(min: number | null, max: number | null) {
+  if (min !== null && max !== null && max <= min) {
+    throw new REOther(
+      `Max must be greater than min, got: min=${min}, max=${max}`
+    );
+  }
+}
+
 export const library = [
   maker.make({
     name: "linear",
@@ -27,6 +36,8 @@ export const library = [
     examples: [`Scale.linear({ min: 3, max: 10 })`],
     definitions: [
       makeDefinition([commonRecord], ([{ min, max, tickFormat }]) => {
+        checkMinMax(min, max);
+
         return vScale({
           type: "linear",
           min: min ?? undefined,
@@ -45,7 +56,11 @@ export const library = [
     examples: [`Scale.log({ min: 1, max: 100 })`],
     definitions: [
       makeDefinition([commonRecord], ([{ min, max, tickFormat }]) => {
-        // TODO - check that min > 0?
+        if (min !== null && min <= 0) {
+          throw new REOther(`Min must be over 0 for log scale, got: ${min}`);
+        }
+        checkMinMax(min, max);
+
         return vScale({
           type: "log",
           min: min ?? undefined,
@@ -64,6 +79,8 @@ export const library = [
     examples: [`Scale.symlog({ min: -10, max: 10 })`],
     definitions: [
       makeDefinition([commonRecord], ([{ min, max, tickFormat }]) => {
+        checkMinMax(min, max);
+
         return vScale({
           type: "symlog",
           min: min ?? undefined,
@@ -91,6 +108,8 @@ export const library = [
           ),
         ],
         ([{ min, max, tickFormat, exponent }]) => {
+          checkMinMax(min, max);
+
           return vScale({
             type: "power",
             min: min ?? undefined,


### PR DESCRIPTION
Fixes #2031.

> Without a given min and max value in the scale, at certain widths, it doesn't show any axis ticks.  
> Note: This error only appears for me when the dist is wide enough. When it's under ~600px, it looks fine. 
> Another note: When hovering, I often see no number, just an empty box.

The root cause for this is that `d3.scaleLog().ticks()` and `d3.scaleLog.tickFormat()` are special.

Full docs: https://github.com/d3/d3-scale/tree/main#log_ticks

I'll try to explain what's going on.

D3 scales have two methods, `.ticks(count)` and `.tickFormat(count, specifier)`. First one outputs an array of ticks to render, and second one return a format function that turns values into strings.

There are two modes for `.ticks(count)` on log scales:
1. Output powers of base only, if count < number of powers of base that fit in the domain.

Example:
```
> scaleLog().domain([5,12000]).ticks(3)
[ 10, 100, 1000, 10000 ]
```

2. Output all steps between different powers of base, if count is greater than that.

Example:
```
> scaleLog().domain([5,12000]).ticks(4)
[
     5,    6,     7,    8,    9,   10,
    20,   30,    40,   50,   60,   70,
    80,   90,   100,  200,  300,  400,
   500,  600,   700,  800,  900, 1000,
  2000, 3000,  4000, 5000, 6000, 7000,
  8000, 9000, 10000
]
```

(I think there might be off-by-one error here in d3's implementation, but it's not very important; d3.ticks() is never guaranteed to be precise)

Since the second mode outputs a lot of ticks, and ticks in [5..10] range are close to each other, `tickFormat()` returns an empty string for some ticks.

This affects both hover values and actual ticks.

For hovers, there's a special mode for tickFormat, `tickFormat(Infinity)`, that I now use in `drawCursorLines`.

For tick labels, the problem was that we have our own algorithm for fitting labels in `drawAxes`, which forces labels to never overlap. But it could be unlucky and pick only the ticks that are empty. (I'm not sure about the details, but skipping empty labels helped.)