### PR TITLE
Float components in AST

### DIFF
--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -139,10 +139,16 @@ export function createSquigglePrinter(
           ]);
         case "Boolean":
           return node.value ? "true" : "false";
-        case "Float":
-          return String(node.value);
-        case "Integer":
-          return String(node.value);
+        case "Float": {
+          const fractional =
+            node.fractional === null
+              ? ""
+              : "." + (node.fractional.replace(/0*$/, "") || "0"); // cut all trailing zeroes, but keep at least one
+
+          const exponent = node.exponent === null ? "" : `e${node.exponent}`;
+
+          return `${node.integer}${fractional}${exponent}`;
+        }
         case "Array":
           return group([
             "[",

--- a/packages/prettier-plugin/test/numbers.test.ts
+++ b/packages/prettier-plugin/test/numbers.test.ts
@@ -1,0 +1,45 @@
+import { format } from "./helpers.js";
+
+// In general, this behavior matches prettier for JS.
+describe("numbers", () => {
+  test("integer", async () => {
+    expect(await format("123")).toBe("123");
+  });
+
+  test("negative integer", async () => {
+    expect(await format("-123")).toBe("-123");
+  });
+
+  test("fixed point", async () => {
+    expect(await format("1.5")).toBe("1.5");
+  });
+
+  test("fixed point with trailing zero", async () => {
+    expect(await format("1.0")).toBe("1.0");
+  });
+
+  test("fixed point with multiple trailing zeroes", async () => {
+    expect(await format("1.000")).toBe("1.0");
+  });
+
+  test("fixed point without fractional part", async () => {
+    expect(await format("1.")).toBe("1");
+  });
+
+  test("floating point with fake fractional part", async () => {
+    expect(await format("1.e3")).toBe("1e3");
+  });
+  test("floating point with single zero fractional part", async () => {
+    expect(await format("1.0e3")).toBe("1.0e3");
+  });
+  test("floating point with multiple zeroes as fractional part", async () => {
+    expect(await format("1.000e3")).toBe("1.0e3");
+  });
+
+  test("floating point with explicit plus sign for exponent", async () => {
+    expect(await format("1e+3")).toBe("1e3");
+  });
+  test("floating point with negative exponent", async () => {
+    expect(await format("1e-3")).toBe("1e-3");
+  });
+});

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -9,15 +9,16 @@ describe("Peggy parse", () => {
     testParse("1.", "{1}");
     testParse("1.1", "{1.1}");
     testParse(".1", "{0.1}");
+    testParse(".001", "{0.001}");
     testParse("0.1", "{0.1}");
-    testParse("1e1", "{10}");
-    testParse("1e-1", "{0.1}");
-    testParse(".1e1", "{1}");
-    testParse("0.1e1", "{1}");
-    testParse("0.1e+3", "{100}");
-    testParse("0.1e+2+5", "{(10 + 5)}");
-    testParse("0.1e+2-5", "{(10 - 5)}");
-    testParse("100e-2-5", "{(1 - 5)}");
+    testParse("1e1", "{1e1}");
+    testParse("1e-1", "{1e-1}");
+    testParse(".1e1", "{0.1e1}");
+    testParse("0.1e1", "{0.1e1}");
+    testParse("0.1e+3", "{0.1e3}");
+    testParse("0.1e+2+5", "{(0.1e2 + 5)}");
+    testParse("0.1e+2-5", "{(0.1e2 - 5)}");
+    testParse("100e-2-5", "{(100e-2 - 5)}");
   });
 
   describe("literals operators parenthesis", () => {

--- a/packages/squiggle-lang/src/ast/parse.ts
+++ b/packages/squiggle-lang/src/ast/parse.ts
@@ -91,11 +91,12 @@ function nodeToString(node: ASTNode): string {
     case "UnaryCall":
       return "(" + node.op + nodeToString(node.arg) + ")";
     case "Float":
-      return String(node.value);
+      // see also: "Float" branch in expression/compile.ts
+      return `${node.integer}${
+        node.fractional === null ? "" : `.${node.fractional}`
+      }${node.exponent === null ? "" : `e${node.exponent}`}`;
     case "Identifier":
       return `:${node.value}`;
-    case "Integer":
-      return String(node.value);
     case "KeyValue":
       return nodeToString(node.key) + ": " + nodeToString(node.value);
     case "Lambda":

--- a/packages/squiggle-lang/src/ast/peggyHelpers.ts
+++ b/packages/squiggle-lang/src/ast/peggyHelpers.ts
@@ -90,9 +90,15 @@ type NodeDotLookup = N<"DotLookup", { arg: ASTNode; key: string }>;
 
 type NodeBracketLookup = N<"BracketLookup", { arg: ASTNode; key: ASTNode }>;
 
-type NodeFloat = N<"Float", { value: number }>;
-
-type NodeInteger = N<"Integer", { value: number }>;
+type NodeFloat = N<
+  "Float",
+  {
+    // floats are always positive, `-123` is an unary operation
+    integer: number;
+    fractional: string | null; // heading zeros are significant, so we can't store this as a number
+    exponent: number | null;
+  }
+>;
 
 type NodeIdentifier = N<"Identifier", { value: string }>;
 
@@ -158,7 +164,6 @@ export type ASTNode =
   | NodeDotLookup
   | NodeBracketLookup
   | NodeFloat
-  | NodeInteger
   | NodeIdentifier
   | NodeLetStatement
   | NodeDefunStatement
@@ -246,7 +251,7 @@ export function nodeRecord(
 ): NodeRecord {
   const symbols: NodeRecord["symbols"] = {};
   for (const element of elements) {
-    if (element.key.type === "String" || element.key.type === "Integer") {
+    if (element.key.type === "String") {
       symbols[element.key.value] = element;
     }
   }
@@ -289,20 +294,17 @@ export function nodeBoolean(
 ): NodeBoolean {
   return { type: "Boolean", value, location };
 }
-export function nodeFloat(value: number, location: LocationRange): NodeFloat {
-  return { type: "Float", value, location };
+export function nodeFloat(
+  args: Omit<NodeFloat, "type" | "location">,
+  location: LocationRange
+): NodeFloat {
+  return { type: "Float", ...args, location };
 }
 export function nodeIdentifier(
   value: string,
   location: LocationRange
 ): NodeIdentifier {
   return { type: "Identifier", value, location };
-}
-export function nodeInteger(
-  value: number,
-  location: LocationRange
-): NodeInteger {
-  return { type: "Integer", value, location };
 }
 export function nodeKeyValue(
   key: ASTNode,

--- a/packages/squiggle-lang/src/ast/peggyParser.peggy
+++ b/packages/squiggle-lang/src/ast/peggyParser.peggy
@@ -269,7 +269,7 @@ string 'string'
   = characters:("'" @([^'])* "'") { return h.nodeString(characters.join(''), location()); }
   / characters:('"' @([^"])* '"') { return h.nodeString(characters.join(''), location()); }
 
-number = number:(float / integer) unit:unitIdentifier?
+number = number:float unit:unitIdentifier?
   {
     if (unit === null) {
       return number;
@@ -279,16 +279,39 @@ number = number:(float / integer) unit:unitIdentifier?
     }
   }
 
-integer 'number'
-  = d+ !"\." ![e]i
-  { return h.nodeInteger(parseInt(text()), location()); }
+float 'number' = significand:floatSignificand exponent:floatExponent?
+  {
+    return h.nodeFloat({
+      integer: significand.integer,
+      fractional: significand.fractional,
+      exponent,
+    }, location());
+  }
+  
+  floatSignificand =
+    integer:intLiteral "." fractional:($d+)? {
+      return {
+        integer,
+        fractional,
+      };
+    }
+    / integer:intLiteral {
+      return {
+        integer,
+        fractional: null,
+      };
+    }
+    / "." fractional:$(d+) {
+      return {
+        integer: 0,
+        fractional,
+      };
+    }
 
-float 'number'
-  = $(((d+ "\." d*) / ("\." d+)) floatExponent? / d+ floatExponent)
-  { return h.nodeFloat(parseFloat(text()), location()); }
-
-    floatExponent = [e]i ('-'/'+')? d+
-    d = [0-9]
+  floatExponent = [e]i @value:signedIntLiteral
+  intLiteral = d+ { return parseInt(text(), 10); }
+  signedIntLiteral = ('-'/'+')? d+ { return parseInt(text(), 10); }
+  d = [0-9]
 
 boolean 'boolean'
   = ('true' / 'false') ! [a-z]i ! [_$]

--- a/packages/squiggle-lang/src/expression/compile.ts
+++ b/packages/squiggle-lang/src/expression/compile.ts
@@ -221,10 +221,17 @@ function compileToContent(
       ];
     case "Boolean":
       return [expression.eValue(vBool(ast.value)), context];
-    case "Float":
-      return [expression.eValue(vNumber(ast.value)), context];
-    case "Integer":
-      return [expression.eValue(vNumber(ast.value)), context];
+    case "Float": {
+      const value = parseFloat(
+        `${ast.integer}${ast.fractional === null ? "" : `.${ast.fractional}`}${
+          ast.exponent === null ? "" : `e${ast.exponent}`
+        }`
+      );
+      if (Number.isNaN(value)) {
+        throw new ICompileError("Failed to compile a number", ast.location);
+      }
+      return [expression.eValue(vNumber(value)), context];
+    }
     case "String":
       return [expression.eValue(vString(ast.value)), context];
     case "Void":


### PR DESCRIPTION
Fixes #2030.

Storing floats in AST this way is a bit awkward; here's the shape I ended up with:
```
  {
    // floats are always positive, `-123` is an unary operation
    integer: number;
    fractional: string | null; // heading zeros are significant, so we can't store this as a number
    exponent: number | null;
  }
```

Then I had to compile it back to string and parse with `parseFloat` in `expression/compile.ts`.

I'm not sure how JS does it. I've verified that Prettier is aware of different formats, but I suspect that JS engines like V8 parses floats to numbers immediately (it's even possible to do it in lexer, floats are easy enough to match with a single regex).