### PR TITLE
AST as S-expressions

### DIFF
--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -1,3 +1,4 @@
+import { ASTNode, parse } from "../../src/ast/parse.js";
 import {
   testEvalError,
   testEvalToBe,
@@ -6,239 +7,418 @@ import {
 
 describe("Peggy parse", () => {
   describe("float", () => {
-    testParse("1.", "{1}");
-    testParse("1.1", "{1.1}");
-    testParse(".1", "{0.1}");
-    testParse(".001", "{0.001}");
-    testParse("0.1", "{0.1}");
-    testParse("1e1", "{1e1}");
-    testParse("1e-1", "{1e-1}");
-    testParse(".1e1", "{0.1e1}");
-    testParse("0.1e1", "{0.1e1}");
-    testParse("0.1e+3", "{0.1e3}");
-    testParse("0.1e+2+5", "{(0.1e2 + 5)}");
-    testParse("0.1e+2-5", "{(0.1e2 - 5)}");
-    testParse("100e-2-5", "{(100e-2 - 5)}");
+    test.each([
+      ["1.", { integer: 1, fractional: null, exponent: null }],
+      ["1.1", { integer: 1, fractional: "1", exponent: null }],
+      [".1", { integer: 0, fractional: "1", exponent: null }],
+      [".001", { integer: 0, fractional: "001", exponent: null }],
+      ["0.1", { integer: 0, fractional: "1", exponent: null }],
+      ["1e1", { integer: 1, fractional: null, exponent: 1 }],
+      ["1e-1", { integer: 1, fractional: null, exponent: -1 }],
+      [".1e1", { integer: 0, fractional: "1", exponent: 1 }],
+      ["0.1e1", { integer: 0, fractional: "1", exponent: 1 }],
+      ["0.1e+3", { integer: 0, fractional: "1", exponent: 3 }],
+      ["0.1e-3", { integer: 0, fractional: "1", exponent: -3 }],
+    ] satisfies [string, Pick<Extract<ASTNode, { type: "Float" }>, "integer" | "fractional" | "exponent">][])(
+      "%s",
+      (code, expected) => {
+        const result = parse(code, "test");
+        if (
+          !(
+            result.ok &&
+            result.value.type === "Program" &&
+            result.value.statements.length === 1
+          )
+        ) {
+          fail();
+        }
+        const value = result.value.statements[0];
+        if (value.type !== "Float") {
+          fail();
+        }
+        expect(value).toMatchObject(expected);
+      }
+    );
+    testParse("0.1e+2+5", "(Program (InfixCall + 0.1e2 5))");
+    testParse("0.1e+2-5", "(Program (InfixCall - 0.1e2 5))");
+    testParse("100e-2-5", "(Program (InfixCall - 100e-2 5))");
   });
 
   describe("literals operators parenthesis", () => {
-    testParse("1", "{1}");
-    testParse("'hello'", "{'hello'}");
-    testParse("true", "{true}");
-    testParse("1+2", "{(1 + 2)}");
-    testParse("add(1,2)", "{(:add 1 2)}");
-    testParse("(1)", "{1}");
-    testParse("(1+2)", "{(1 + 2)}");
+    testParse("1", "(Program 1)");
+    testParse("'hello'", "(Program 'hello')");
+    testParse("true", "(Program true)");
+    testParse("1+2", "(Program (InfixCall + 1 2))");
+    testParse("add(1,2)", "(Program (Call :add 1 2))");
+    testParse("(1)", "(Program 1)");
+    testParse("(1+2)", "(Program (InfixCall + 1 2))");
   });
 
   describe("unary", () => {
-    testParse("-1", "{(-1)}");
-    testParse("!true", "{(!true)}");
-    testParse("1 + -1", "{(1 + (-1))}");
-    testParse("-a[0]", "{(-:a[0])}");
-    testParse("!a[0]", "{(!:a[0])}");
+    testParse("-1", "(Program (UnaryCall - 1))");
+    testParse("!true", "(Program (UnaryCall ! true))");
+    testParse("1 + -1", "(Program (InfixCall + 1 (UnaryCall - 1)))");
+    testParse("-a[0]", "(Program (UnaryCall - (BracketLookup :a 0)))");
+    testParse("!a[0]", "(Program (UnaryCall ! (BracketLookup :a 0)))");
   });
 
   describe("multiplicative", () => {
-    testParse("1 * 2", "{(1 * 2)}");
-    testParse("1 / 2", "{(1 / 2)}");
-    testParse("1 * 2 * 3", "{((1 * 2) * 3)}");
-    testParse("1 * 2 / 3", "{((1 * 2) / 3)}");
-    testParse("1 / 2 * 3", "{((1 / 2) * 3)}");
-    testParse("1 / 2 / 3", "{((1 / 2) / 3)}");
-    testParse("1 * 2 + 3 * 4", "{((1 * 2) + (3 * 4))}");
-    testParse("1 * 2 - 3 * 4", "{((1 * 2) - (3 * 4))}");
-    testParse("1 * 2 .+ 3 * 4", "{((1 * 2) .+ (3 * 4))}");
-    testParse("1 * 2 .- 3 * 4", "{((1 * 2) .- (3 * 4))}");
-    testParse("1 * 2 + 3 .* 4", "{((1 * 2) + (3 .* 4))}");
-    testParse("1 * 2 + 3 / 4", "{((1 * 2) + (3 / 4))}");
-    testParse("1 * 2 + 3 ./ 4", "{((1 * 2) + (3 ./ 4))}");
-    testParse("1 * 2 - 3 .* 4", "{((1 * 2) - (3 .* 4))}");
-    testParse("1 * 2 - 3 / 4", "{((1 * 2) - (3 / 4))}");
-    testParse("1 * 2 - 3 ./ 4", "{((1 * 2) - (3 ./ 4))}");
-    testParse("1 * 2 - 3 * 4^5", "{((1 * 2) - (3 * (4 ^ 5)))}");
-    testParse("1 * 2 - 3 * 4^5^6", "{((1 * 2) - (3 * ((4 ^ 5) ^ 6)))}");
-    testParse("1 * -a[-2]", "{(1 * (-:a[(-2)]))}");
+    testParse("1 * 2", "(Program (InfixCall * 1 2))");
+    testParse("1 / 2", "(Program (InfixCall / 1 2))");
+
+    // left-associative
+    testParse("1 * 2 * 3", "(Program (InfixCall * (InfixCall * 1 2) 3))");
+    testParse("1 * 2 / 3", "(Program (InfixCall / (InfixCall * 1 2) 3))");
+    testParse("1 / 2 * 3", "(Program (InfixCall * (InfixCall / 1 2) 3))");
+    testParse("1 / 2 / 3", "(Program (InfixCall / (InfixCall / 1 2) 3))");
+
+    // precedence
+    testParse(
+      "1 * 2 + 3 * 4",
+      "(Program (InfixCall + (InfixCall * 1 2) (InfixCall * 3 4)))"
+    );
+    testParse(
+      "1 * 2 - 3 * 4",
+      "(Program (InfixCall - (InfixCall * 1 2) (InfixCall * 3 4)))"
+    );
+    testParse(
+      "1 * 2 .+ 3 * 4",
+      "(Program (InfixCall .+ (InfixCall * 1 2) (InfixCall * 3 4)))"
+    );
+    testParse(
+      "1 * 2 .- 3 * 4",
+      "(Program (InfixCall .- (InfixCall * 1 2) (InfixCall * 3 4)))"
+    );
+    testParse(
+      "1 * 2 + 3 .* 4",
+      "(Program (InfixCall + (InfixCall * 1 2) (InfixCall .* 3 4)))"
+    );
+    testParse(
+      "1 * 2 + 3 / 4",
+      "(Program (InfixCall + (InfixCall * 1 2) (InfixCall / 3 4)))"
+    );
+    testParse(
+      "1 * 2 + 3 ./ 4",
+      "(Program (InfixCall + (InfixCall * 1 2) (InfixCall ./ 3 4)))"
+    );
+    testParse(
+      "1 * 2 - 3 .* 4",
+      "(Program (InfixCall - (InfixCall * 1 2) (InfixCall .* 3 4)))"
+    );
+    testParse(
+      "1 * 2 - 3 / 4",
+      "(Program (InfixCall - (InfixCall * 1 2) (InfixCall / 3 4)))"
+    );
+    testParse(
+      "1 * 2 - 3 ./ 4",
+      "(Program (InfixCall - (InfixCall * 1 2) (InfixCall ./ 3 4)))"
+    );
+    testParse(
+      "1 * 2 - 3 * 4^5",
+      "(Program (InfixCall - (InfixCall * 1 2) (InfixCall * 3 (InfixCall ^ 4 5))))"
+    );
+    testParse(
+      "1 * 2 - 3 * 4^5^6",
+      "(Program (InfixCall - (InfixCall * 1 2) (InfixCall * 3 (InfixCall ^ (InfixCall ^ 4 5) 6))))"
+    );
+    testParse(
+      "1 * -a[-2]",
+      "(Program (InfixCall * 1 (UnaryCall - (BracketLookup :a (UnaryCall - 2)))))"
+    );
   });
 
   describe("multi-line", () => {
-    testParse("x=1; 2", "{:x = {1}; 2}");
-    testParse("x=1; y=2", "{:x = {1}; :y = {2}}");
+    testParse("x=1; 2", "(Program (LetStatement :x (Block 1)) 2)");
+    testParse(
+      "x=1; y=2",
+      "(Program (LetStatement :x (Block 1)) (LetStatement :y (Block 2)))"
+    );
   });
 
   describe("variables", () => {
-    testParse("x = 1", "{:x = {1}}");
-    testParse("x", "{:x}");
-    testParse("x = 1; x", "{:x = {1}; :x}");
+    testParse("x = 1", "(Program (LetStatement :x (Block 1)))");
+    testParse("x", "(Program :x)");
+    testParse("x = 1; x", "(Program (LetStatement :x (Block 1)) :x)");
   });
 
   describe("functions", () => {
-    testParse("identity(x) = x", "{:identity = {|:x| {:x}}}"); // Function definitions become lambda assignments
-    testParse("identity(x)", "{(:identity :x)}");
+    testParse(
+      "identity(x) = x",
+      "(Program (DefunStatement :identity (Lambda :x (Block :x))))"
+    ); // Function definitions become lambda assignments
+    testParse("identity(x)", "(Program (Call :identity :x))");
   });
 
   describe("arrays", () => {
-    testParse("[]", "{[]}");
-    testParse("[0, 1, 2]", "{[0; 1; 2]}");
-    testParse("['hello', 'world']", "{['hello'; 'world']}");
-    testParse("([0,1,2])[1]", "{[0; 1; 2][1]}");
+    testParse("[]", "(Program (Array))");
+    testParse("[0, 1, 2]", "(Program (Array 0 1 2))");
+    testParse("['hello', 'world']", "(Program (Array 'hello' 'world'))");
+    testParse("([0,1,2])[1]", "(Program (BracketLookup (Array 0 1 2) 1))");
   });
 
   describe("records", () => {
-    testParse("{a: 1, b: 2}", "{{'a': 1, 'b': 2}}");
-    testParse("{1+0: 1, 2+0: 2}", "{{(1 + 0): 1, (2 + 0): 2}}"); // key can be any expression
-    testParse("record.property", "{:record.property}");
+    testParse(
+      "{a: 1, b: 2}",
+      "(Program (Record (KeyValue 'a' 1) (KeyValue 'b' 2)))"
+    );
+    testParse(
+      "{1+0: 1, 2+0: 2}",
+      "(Program (Record (KeyValue (InfixCall + 1 0) 1) (KeyValue (InfixCall + 2 0) 2)))"
+    ); // key can be any expression
+    testParse("record.property", "(Program (DotLookup :record property))");
   });
 
   describe("post operators", () => {
     //function call, array and record access are post operators with higher priority than unary operators
-    testParse("a==!b(1)", "{(:a == (!(:b 1)))}");
-    testParse("a==!b[1]", "{(:a == (!:b[1]))}");
-    testParse("a==!b.one", "{(:a == (!:b.one))}");
+    testParse(
+      "a==!b(1)",
+      "(Program (InfixCall == :a (UnaryCall ! (Call :b 1))))"
+    );
+    testParse(
+      "a==!b[1]",
+      "(Program (InfixCall == :a (UnaryCall ! (BracketLookup :b 1))))"
+    );
+    testParse(
+      "a==!b.one",
+      "(Program (InfixCall == :a (UnaryCall ! (DotLookup :b one))))"
+    );
   });
 
   describe("comments", () => {
-    testParse("1 # This is a line comment", "{1}");
-    testParse("1 // This is a line comment", "{1}");
-    testParse("1 /* This is a multi line comment */", "{1}");
-    testParse("/* This is a multi line comment */ 1", "{1}");
+    testParse("1 # This is a line comment", "(Program 1)");
+    testParse("1 // This is a line comment", "(Program 1)");
+    testParse("1 /* This is a multi line comment */", "(Program 1)");
+    testParse("/* This is a multi line comment */ 1", "(Program 1)");
     testParse(
       `
   /* This is 
   a multi line 
   comment */
   1`,
-      "{1}"
+      "(Program 1)"
     );
 
-    testParse("/* first comment */ 1 + /* second comment */ 2", "{(1 + 2)}");
-    testParse("/* comment * with * stars */ 1", "{1}");
-    testParse("/* /* */ 1", "{1}");
+    testParse(
+      "/* first comment */ 1 + /* second comment */ 2",
+      "(Program (InfixCall + 1 2))"
+    );
+    testParse("/* comment * with * stars */ 1", "(Program 1)");
+    testParse("/* /* */ 1", "(Program 1)");
   });
 
   describe("ternary operator", () => {
-    testParse("true ? 2 : 3", "{(::$$_ternary_$$ true 2 3)}");
+    testParse("true ? 2 : 3", "(Program (Ternary true 2 3))");
     testParse(
       "false ? 2 : false ? 4 : 5",
-      "{(::$$_ternary_$$ false 2 (::$$_ternary_$$ false 4 5))}"
+      "(Program (Ternary false 2 (Ternary false 4 5)))"
     ); // nested ternary
   });
 
   describe("if then else", () => {
-    testParse("if true then 2 else 3", "{(::$$_ternary_$$ true {2} {3})}");
+    testParse(
+      "if true then 2 else 3",
+      "(Program (Ternary true (Block 2) (Block 3)))"
+    );
     testParse(
       "if false then {2} else {3}",
-      "{(::$$_ternary_$$ false {2} {3})}"
+      "(Program (Ternary false (Block 2) (Block 3)))"
     );
     testParse(
       "if false then {2} else if false then {4} else {5}",
-      "{(::$$_ternary_$$ false {2} (::$$_ternary_$$ false {4} {5}))}"
+      "(Program (Ternary false (Block 2) (Ternary false (Block 4) (Block 5))))"
     ); //nested if
   });
 
   describe("logical", () => {
-    testParse("true || false", "{(true || false)}");
-    testParse("true && false", "{(true && false)}");
-    testParse("a * b + c", "{((:a * :b) + :c)}"); // for comparison
-    testParse("a && b || c", "{((:a && :b) || :c)}");
-    testParse("a && b || c && d", "{((:a && :b) || (:c && :d))}");
-    testParse("a && !b || c", "{((:a && (!:b)) || :c)}");
-    testParse("a && b==c || d", "{((:a && (:b == :c)) || :d)}");
-    testParse("a && b!=c || d", "{((:a && (:b != :c)) || :d)}");
-    testParse("a && !(b==c) || d", "{((:a && (!(:b == :c))) || :d)}");
-    testParse("a && b>=c || d", "{((:a && (:b >= :c)) || :d)}");
-    testParse("a && !(b>=c) || d", "{((:a && (!(:b >= :c))) || :d)}");
-    testParse("a && b<=c || d", "{((:a && (:b <= :c)) || :d)}");
-    testParse("a && b>c || d", "{((:a && (:b > :c)) || :d)}");
-    testParse("a && b<c || d", "{((:a && (:b < :c)) || :d)}");
-    testParse("a && b<c[i] || d", "{((:a && (:b < :c[:i])) || :d)}");
-    testParse("a && b<c.i || d", "{((:a && (:b < :c.i)) || :d)}");
-    testParse("a && b<c(i) || d", "{((:a && (:b < (:c :i))) || :d)}");
-    testParse("a && b<1+2 || d", "{((:a && (:b < (1 + 2))) || :d)}");
-    testParse("a && b<1+2*3 || d", "{((:a && (:b < (1 + (2 * 3)))) || :d)}");
+    testParse("true || false", "(Program (InfixCall || true false))");
+    testParse("true && false", "(Program (InfixCall && true false))");
+    testParse("a * b + c", "(Program (InfixCall + (InfixCall * :a :b) :c))"); // for comparison
+    testParse(
+      "a && b || c",
+      "(Program (InfixCall || (InfixCall && :a :b) :c))"
+    );
+    testParse(
+      "a && b || c && d",
+      "(Program (InfixCall || (InfixCall && :a :b) (InfixCall && :c :d)))"
+    );
+    testParse(
+      "a && !b || c",
+      "(Program (InfixCall || (InfixCall && :a (UnaryCall ! :b)) :c))"
+    );
+    testParse(
+      "a && b==c || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall == :b :c)) :d))"
+    );
+    testParse(
+      "a && b!=c || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall != :b :c)) :d))"
+    );
+    testParse(
+      "a && !(b==c) || d",
+      "(Program (InfixCall || (InfixCall && :a (UnaryCall ! (InfixCall == :b :c))) :d))"
+    );
+    testParse(
+      "a && b>=c || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall >= :b :c)) :d))"
+    );
+    testParse(
+      "a && !(b>=c) || d",
+      "(Program (InfixCall || (InfixCall && :a (UnaryCall ! (InfixCall >= :b :c))) :d))"
+    );
+    testParse(
+      "a && b<=c || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall <= :b :c)) :d))"
+    );
+    testParse(
+      "a && b>c || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall > :b :c)) :d))"
+    );
+    testParse(
+      "a && b<c || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b :c)) :d))"
+    );
+    testParse(
+      "a && b<c[i] || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b (BracketLookup :c :i))) :d))"
+    );
+    testParse(
+      "a && b<c.i || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b (DotLookup :c i))) :d))"
+    );
+    testParse(
+      "a && b<c(i) || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b (Call :c :i))) :d))"
+    );
+    testParse(
+      "a && b<1+2 || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b (InfixCall + 1 2))) :d))"
+    );
+    testParse(
+      "a && b<1+2*3 || d",
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b (InfixCall + 1 (InfixCall * 2 3)))) :d))"
+    );
     testParse(
       "a && b<1+2*-3+4 || d",
-      "{((:a && (:b < ((1 + (2 * (-3))) + 4))) || :d)}"
+      "(Program (InfixCall || (InfixCall && :a (InfixCall < :b (InfixCall + (InfixCall + 1 (InfixCall * 2 (UnaryCall - 3))) 4))) :d))"
     );
     testParse(
       "a && b<1+2*3 || d ? true : false",
-      "{(::$$_ternary_$$ ((:a && (:b < (1 + (2 * 3)))) || :d) true false)}"
+      "(Program (Ternary (InfixCall || (InfixCall && :a (InfixCall < :b (InfixCall + 1 (InfixCall * 2 3)))) :d) true false))"
     );
   });
 
   describe("pipe", () => {
-    testParse("1 -> add(2)", "{(1 -> :add(2))}");
-    testParse("-1 -> add(2)", "{((-1) -> :add(2))}");
-    testParse("-a[1] -> add(2)", "{((-:a[1]) -> :add(2))}");
-    testParse("-f(1) -> add(2)", "{((-(:f 1)) -> :add(2))}");
-    testParse("1 + 2 -> add(3)", "{(1 + (2 -> :add(3)))}");
-    testParse("1 -> add(2) * 3", "{((1 -> :add(2)) * 3)}");
-    testParse("1 -> subtract(2)", "{(1 -> :subtract(2))}");
-    testParse("-1 -> subtract(2)", "{((-1) -> :subtract(2))}");
-    testParse("1 -> subtract(2) * 3", "{((1 -> :subtract(2)) * 3)}");
+    testParse("1 -> add(2)", "(Program (Pipe 1 :add 2))");
+    testParse("-1 -> add(2)", "(Program (Pipe (UnaryCall - 1) :add 2))");
+    testParse(
+      "-a[1] -> add(2)",
+      "(Program (Pipe (UnaryCall - (BracketLookup :a 1)) :add 2))"
+    );
+    testParse(
+      "-f(1) -> add(2)",
+      "(Program (Pipe (UnaryCall - (Call :f 1)) :add 2))"
+    );
+    testParse("1 + 2 -> add(3)", "(Program (InfixCall + 1 (Pipe 2 :add 3)))");
+    testParse("1 -> add(2) * 3", "(Program (InfixCall * (Pipe 1 :add 2) 3))");
+    testParse("1 -> subtract(2)", "(Program (Pipe 1 :subtract 2))");
+    testParse(
+      "-1 -> subtract(2)",
+      "(Program (Pipe (UnaryCall - 1) :subtract 2))"
+    );
+    testParse(
+      "1 -> subtract(2) * 3",
+      "(Program (InfixCall * (Pipe 1 :subtract 2) 3))"
+    );
   });
 
   describe("elixir pipe", () => {
     //handled together with -> so there is no need for seperate tests
-    testParse("1 |> add(2)", "{(1 -> :add(2))}");
+    testParse("1 |> add(2)", "(Program (Pipe 1 :add 2))");
   });
 
   describe("to", () => {
-    testParse("1 to 2", "{(1 to 2)}");
-    testParse("-1 to -2", "{((-1) to (-2))}"); // lower than unary
-    testParse("a[1] to a[2]", "{(:a[1] to :a[2])}"); // lower than post
-    testParse("a.p1 to a.p2", "{(:a.p1 to :a.p2)}"); // lower than post
-    testParse("1 to 2 + 3", "{(1 to (2 + 3))}");
+    testParse("1 to 2", "(Program (InfixCall to 1 2))");
+    testParse(
+      "-1 to -2",
+      "(Program (InfixCall to (UnaryCall - 1) (UnaryCall - 2)))"
+    ); // lower than unary
+    testParse(
+      "a[1] to a[2]",
+      "(Program (InfixCall to (BracketLookup :a 1) (BracketLookup :a 2)))"
+    ); // lower than post
+    testParse(
+      "a.p1 to a.p2",
+      "(Program (InfixCall to (DotLookup :a p1) (DotLookup :a p2)))"
+    ); // lower than post
+    testParse("1 to 2 + 3", "(Program (InfixCall to 1 (InfixCall + 2 3)))");
     testParse(
       "1->add(2) to 3->add(4) -> add(4)",
-      "{((1 -> :add(2)) to ((3 -> :add(4)) -> :add(4)))}"
+      "(Program (InfixCall to (Pipe 1 :add 2) (Pipe (Pipe 3 :add 4) :add 4)))"
     ); // lower than chain
   });
 
   describe("inner block", () => {
     // inner blocks are 0 argument lambdas. They can be used whenever a value is required.
     // Like lambdas they have a local scope.
-    testParse("x={y=1; y}; x", "{:x = {:y = {1}; :y}; :x}");
+    testParse(
+      "x={y=1; y}; x",
+      "(Program (LetStatement :x (Block (LetStatement :y (Block 1)) :y)) :x)"
+    );
   });
 
   describe("lambda", () => {
-    testParse("{|x| x}", "{{|:x| :x}}");
-    testParse("f={|x| x}", "{:f = {|:x| :x}}");
-    testParse("f(x)=x", "{:f = {|:x| {:x}}}"); // Function definitions are lambda assignments
-    testParse("f(x)=x ? 1 : 0", "{:f = {|:x| {(::$$_ternary_$$ :x 1 0)}}}"); // Function definitions are lambda assignments
+    testParse("{|x| x}", "(Program (Lambda :x :x))");
+    testParse("f={|x| x}", "(Program (LetStatement :f (Lambda :x :x)))");
+    testParse("f(x)=x", "(Program (DefunStatement :f (Lambda :x (Block :x))))"); // Function definitions are lambda assignments
+    testParse(
+      "f(x)=x ? 1 : 0",
+      "(Program (DefunStatement :f (Lambda :x (Block (Ternary :x 1 0)))))"
+    ); // Function definitions are lambda assignments
   });
 
   describe("Using lambda as value", () => {
     testParse(
       "myadd(x,y)=x+y; z=myadd; z",
-      "{:myadd = {|:x,:y| {(:x + :y)}}; :z = {:myadd}; :z}"
+      "(Program (DefunStatement :myadd (Lambda :x :y (Block (InfixCall + :x :y)))) (LetStatement :z (Block :myadd)) :z)"
     );
     testParse(
       "myadd(x,y)=x+y; z=[myadd]; z",
-      "{:myadd = {|:x,:y| {(:x + :y)}}; :z = {[:myadd]}; :z}"
+      "(Program (DefunStatement :myadd (Lambda :x :y (Block (InfixCall + :x :y)))) (LetStatement :z (Block (Array :myadd))) :z)"
     );
     testParse(
       "myaddd(x,y)=x+y; z={x: myaddd}; z",
-      "{:myaddd = {|:x,:y| {(:x + :y)}}; :z = {{'x': :myaddd}}; :z}"
+      "(Program (DefunStatement :myaddd (Lambda :x :y (Block (InfixCall + :x :y)))) (LetStatement :z (Block (Record (KeyValue 'x' :myaddd)))) :z)"
     );
-    testParse("f({|x| x+1})", "{(:f {|:x| (:x + 1)})}");
-    testParse("map(arr, {|x| x+1})", "{(:map :arr {|:x| (:x + 1)})}");
-    testParse("map([1,2,3], {|x| x+1})", "{(:map [1; 2; 3] {|:x| (:x + 1)})}");
+    testParse(
+      "f({|x| x+1})",
+      "(Program (Call :f (Lambda :x (InfixCall + :x 1))))"
+    );
+    testParse(
+      "map(arr, {|x| x+1})",
+      "(Program (Call :map :arr (Lambda :x (InfixCall + :x 1))))"
+    );
+    testParse(
+      "map([1,2,3], {|x| x+1})",
+      "(Program (Call :map (Array 1 2 3) (Lambda :x (InfixCall + :x 1))))"
+    );
     testParse(
       "[1,2,3]->map({|x| x+1})",
-      "{([1; 2; 3] -> :map({|:x| (:x + 1)}))}"
+      "(Program (Pipe (Array 1 2 3) :map (Lambda :x (InfixCall + :x 1))))"
     );
   });
   describe("unit", () => {
-    testParse("1m", "{(unit 1 m)}");
-    testParse("1M", "{(unit 1 M)}");
+    testParse("1m", "(Program (UnitValue 1 m))");
+    testParse("1M", "(Program (UnitValue 1 M))");
     testEvalToBe("1M", "1000000");
     testEvalError("1q");
-    testParse("1k+2M", "{((unit 1 k) + (unit 2 M))}");
+    testParse(
+      "1k+2M",
+      "(Program (InfixCall + (UnitValue 1 k) (UnitValue 2 M)))"
+    );
   });
   describe("Module", () => {
-    testParse("x", "{:x}");
-    testParse("Math.pi", "{:Math.pi}");
+    testParse("x", "(Program :x)");
+    testParse("Math.pi", "(Program :Math.pi)");
   });
 });
 
@@ -247,19 +427,19 @@ describe("parsing new line", () => {
     `
  a + 
  b`,
-    "{(:a + :b)}"
+    "(Program (InfixCall + :a :b))"
   );
   testParse(
     `
  x=
  1`,
-    "{:x = {1}}"
+    "(Program (LetStatement :x (Block 1)))"
   );
   testParse(
     `
  x=1
  y=2`,
-    "{:x = {1}; :y = {2}}"
+    "(Program (LetStatement :x (Block 1)) (LetStatement :y (Block 2)))"
   );
   testParse(
     `
@@ -267,7 +447,7 @@ describe("parsing new line", () => {
   y=2;
   y }
  x`,
-    "{:x = {:y = {2}; :y}; :x}"
+    "(Program (LetStatement :x (Block (LetStatement :y (Block 2)) :y)) :x)"
   );
   testParse(
     `
@@ -275,7 +455,7 @@ describe("parsing new line", () => {
   y=2
   y }
  x`,
-    "{:x = {:y = {2}; :y}; :x}"
+    "(Program (LetStatement :x (Block (LetStatement :y (Block 2)) :y)) :x)"
   );
   testParse(
     `
@@ -284,7 +464,7 @@ describe("parsing new line", () => {
   y 
   }
  x`,
-    "{:x = {:y = {2}; :y}; :x}"
+    "(Program (LetStatement :x (Block (LetStatement :y (Block 2)) :y)) :x)"
   );
   testParse(
     `
@@ -292,7 +472,7 @@ describe("parsing new line", () => {
  y=2
  z=3
  `,
-    "{:x = {1}; :y = {2}; :z = {3}}"
+    "(Program (LetStatement :x (Block 1)) (LetStatement :y (Block 2)) (LetStatement :z (Block 3)))"
   );
   testParse(
     `
@@ -303,7 +483,7 @@ describe("parsing new line", () => {
   x+y+z
  }
  `,
-    "{:f = {:x = {1}; :y = {2}; :z = {3}; ((:x + :y) + :z)}}"
+    "(Program (LetStatement :f (Block (LetStatement :x (Block 1)) (LetStatement :y (Block 2)) (LetStatement :z (Block 3)) (InfixCall + (InfixCall + :x :y) :z))))"
   );
   testParse(
     `
@@ -316,7 +496,7 @@ describe("parsing new line", () => {
  g=f+4
  g
  `,
-    "{:f = {:x = {1}; :y = {2}; :z = {3}; ((:x + :y) + :z)}; :g = {(:f + 4)}; :g}"
+    "(Program (LetStatement :f (Block (LetStatement :x (Block 1)) (LetStatement :y (Block 2)) (LetStatement :z (Block 3)) (InfixCall + (InfixCall + :x :y) :z))) (LetStatement :g (Block (InfixCall + :f 4))) :g)"
   );
   testParse(
     `
@@ -338,7 +518,7 @@ describe("parsing new line", () => {
   p ->
   q 
  `,
-    "{:f = {:x = {1}; :y = {2}; :z = {3}; ((:x + :y) + :z)}; :g = {(:f + 4)}; (((:g -> :h()) -> :p()) -> :q())}"
+    "(Program (LetStatement :f (Block (LetStatement :x (Block 1)) (LetStatement :y (Block 2)) (LetStatement :z (Block 3)) (InfixCall + (InfixCall + :x :y) :z))) (LetStatement :g (Block (InfixCall + :f 4))) (Pipe (Pipe (Pipe :g :h) :p) :q))"
   );
   testParse(
     `
@@ -347,7 +527,7 @@ describe("parsing new line", () => {
   c |>
   d 
  `,
-    "{(((:a -> :b()) -> :c()) -> :d())}"
+    "(Program (Pipe (Pipe (Pipe :a :b) :c) :d))"
   );
   testParse(
     `
@@ -357,6 +537,6 @@ describe("parsing new line", () => {
   d +
   e
  `,
-    "{((((:a -> :b()) -> :c()) -> :d()) + :e)}"
+    "(Program (InfixCall + (Pipe (Pipe (Pipe :a :b) :c) :d) :e))"
   );
 });

--- a/packages/squiggle-lang/src/ast/parse.ts
+++ b/packages/squiggle-lang/src/ast/parse.ts
@@ -46,50 +46,39 @@ export function parse(expr: string, source: string): ParseResult {
 // This function is just for the sake of tests.
 // For real generation of Squiggle code from AST try our prettier plugin.
 function nodeToString(node: ASTNode): string {
+  const sExpr = (components: (ASTNode | string)[]) =>
+    "(" +
+    node.type +
+    (components.length ? " " : "") +
+    components
+      .map((component) =>
+        typeof component === "string" ? component : nodeToString(component)
+      )
+      .join(" ") +
+    ")";
+
   switch (node.type) {
     case "Block":
     case "Program":
-      return "{" + node.statements.map(nodeToString).join("; ") + "}";
+      return sExpr(node.statements);
     case "Array":
-      return "[" + node.elements.map(nodeToString).join("; ") + "]";
+      return sExpr(node.elements);
     case "Record":
-      return "{" + node.elements.map(nodeToString).join(", ") + "}";
+      return sExpr(node.elements);
     case "Boolean":
       return String(node.value);
     case "Call":
-      return (
-        "(" +
-        nodeToString(node.fn) +
-        " " +
-        node.args.map(nodeToString).join(" ") +
-        ")"
-      );
+      return sExpr([node.fn, ...node.args]);
     case "InfixCall":
-      return (
-        "(" +
-        nodeToString(node.args[0]) +
-        " " +
-        node.op +
-        " " +
-        nodeToString(node.args[1]) +
-        ")"
-      );
+      return sExpr([node.op, ...node.args]);
     case "Pipe":
-      return (
-        "(" +
-        nodeToString(node.leftArg) +
-        " -> " +
-        nodeToString(node.fn) +
-        "(" +
-        node.rightArgs.map(nodeToString).join(",") +
-        "))"
-      );
+      return sExpr([node.leftArg, node.fn, ...node.rightArgs]);
     case "DotLookup":
-      return nodeToString(node.arg) + "." + node.key;
+      return sExpr([node.arg, node.key]);
     case "BracketLookup":
-      return nodeToString(node.arg) + "[" + nodeToString(node.key) + "]";
+      return sExpr([node.arg, node.key]);
     case "UnaryCall":
-      return "(" + node.op + nodeToString(node.arg) + ")";
+      return sExpr([node.op, node.arg]);
     case "Float":
       // see also: "Float" branch in expression/compile.ts
       return `${node.integer}${
@@ -98,36 +87,22 @@ function nodeToString(node: ASTNode): string {
     case "Identifier":
       return `:${node.value}`;
     case "KeyValue":
-      return nodeToString(node.key) + ": " + nodeToString(node.value);
+      return sExpr([node.key, node.value]);
     case "Lambda":
-      return (
-        "{|" +
-        node.args.map(nodeToString).join(",") +
-        "| " +
-        nodeToString(node.body) +
-        "}"
-      );
+      return sExpr([...node.args, node.body]);
     case "LetStatement":
-      return nodeToString(node.variable) + " = " + nodeToString(node.value);
+      return sExpr([node.variable, node.value]);
     case "DefunStatement":
-      return nodeToString(node.variable) + " = " + nodeToString(node.value);
+      return sExpr([node.variable, node.value]);
     case "String":
       return `'${node.value}'`; // TODO - quote?
     case "Ternary":
-      return (
-        "(::$$_ternary_$$ " +
-        nodeToString(node.condition) +
-        " " +
-        nodeToString(node.trueExpression) +
-        " " +
-        nodeToString(node.falseExpression) +
-        ")"
-      );
+      return sExpr([node.condition, node.trueExpression, node.falseExpression]);
     case "Void":
       return "()";
     case "UnitValue":
       // S-expression; we should migrate to S-expressions for other branches too, for easier testing.
-      return "(unit " + nodeToString(node.value) + " " + node.unit + ")";
+      return sExpr([node.value, node.unit]);
 
     default:
       throw new Error(`Unknown node: ${node satisfies never}`);


### PR DESCRIPTION
Internal technical followup to #2037 (includes commits from that PR).

We now serialize ASTs to standard S-expressions; that makes tests more predictable.

Also, tests for floats test AST internals instead of string serialization.