### PR TITLE
Improve lambda and defun formatting

### DIFF
--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -126,9 +126,15 @@ export function createSquigglePrinter(
         case "DefunStatement":
           return group([
             node.variable.value,
-            "(",
-            join(", ", typedPath(node).map(print, "value", "args")),
-            ")",
+            group([
+              "(",
+              indent([
+                softline,
+                join([",", line], typedPath(node).map(print, "value", "args")),
+              ]),
+              softline,
+              ")",
+            ]),
             " = ",
             typedPath(node).call(print, "value", "body"),
             hardline,
@@ -153,7 +159,7 @@ export function createSquigglePrinter(
           return group([
             "[",
             indent([softline, join([",", line], path.map(print, "elements"))]),
-            ifBreak(",", ""),
+            ifBreak(",", ""), // trailing comma
             softline,
             "]",
           ]);
@@ -241,10 +247,22 @@ export function createSquigglePrinter(
         }
         case "Lambda":
           return group([
-            "{|",
-            join(", ", path.map(print, "args")),
-            "|",
+            "{",
+            indent([
+              softline,
+              group([
+                "|",
+                indent([
+                  softline,
+                  join([",", line], typedPath(node).map(print, "args")),
+                ]),
+                softline,
+                "|",
+              ]),
+              softline,
+            ]),
             path.call(print, "body"),
+            softline,
             "}",
           ]);
         case "Record":

--- a/packages/prettier-plugin/test/lambda.test.ts
+++ b/packages/prettier-plugin/test/lambda.test.ts
@@ -1,0 +1,46 @@
+import { format } from "./helpers.js";
+
+describe("lambda", () => {
+  test("lambda", async () => {
+    expect(await format("f={|x|x*x}")).toBe("f = {|x|x * x}\n");
+  });
+
+  test("lambda with multiple args", async () => {
+    expect(await format("f={|x,y|x*y}")).toBe("f = {|x, y|x * y}\n");
+  });
+
+  test("lambda with long body", async () => {
+    expect(
+      await format(
+        "f={|x,y|yaewrtawieyra+auweyrauweyrauwyer+wekuryakwueyruaweyr+wekuryakwueyruaweyr+wekuryakwueyruaweyr}"
+      )
+    ).toBe(
+      `f = {
+  |x, y|
+  yaewrtawieyra + auweyrauweyrauwyer + wekuryakwueyruaweyr +
+  wekuryakwueyruaweyr +
+  wekuryakwueyruaweyr
+}\n`
+    );
+  });
+
+  test("lambda with long parameters", async () => {
+    expect(
+      await format(
+        "f={|yaewrtawieyra,auweyrauweyrauwyer,wekuryakwueyruaweyr,wekuryakwueyruaweyr,wekuryakwueyruaweyr|123}"
+      )
+    ).toBe(
+      `f = {
+  |
+    yaewrtawieyra,
+    auweyrauweyrauwyer,
+    wekuryakwueyruaweyr,
+    wekuryakwueyruaweyr,
+    wekuryakwueyruaweyr
+  |
+  123
+}
+`
+    );
+  });
+});

--- a/packages/prettier-plugin/test/let.test.ts
+++ b/packages/prettier-plugin/test/let.test.ts
@@ -9,19 +9,26 @@ describe("let", () => {
     expect(await format("x=5+6")).toBe("x = 5 + 6\n");
   });
 
-  test("lambda", async () => {
-    expect(await format("f={|x|x*x}")).toBe("f = {|x|x * x}\n");
-  });
-
-  test("lambda with multiple args", async () => {
-    expect(await format("f={|x,y|x*y}")).toBe("f = {|x, y|x * y}\n");
-  });
-
   test("defun", async () => {
     expect(await format("f(x)=x*x")).toBe("f(x) = x * x\n");
   });
 
   test("defun with multiple args", async () => {
     expect(await format("f(x,y)=x*y")).toBe("f(x, y) = x * y\n");
+  });
+
+  test("defun with long args args", async () => {
+    expect(
+      await format(
+        "f(yaewrtawieyra,auweyrauweyrauwyer,wekuryakwueyruaweyr,wekuryakwueyruaweyr,wekuryakwueyruaweyr)=x*y"
+      )
+    ).toBe(`f(
+  yaewrtawieyra,
+  auweyrauweyrauwyer,
+  wekuryakwueyruaweyr,
+  wekuryakwueyruaweyr,
+  wekuryakwueyruaweyr
+) = x * y
+`);
   });
 });


### PR DESCRIPTION
Before:
```
result(charity_cost, total_cost, effect_in_doubling_consumption, effect_in_DALYs) = 1
```

After:
```
result(
  charity_cost,
  total_cost,
  effect_in_doubling_consumption,
  effect_in_DALYs
) = 1
```

---

Before:
```
f = {|x, y|yaewrtawieyra + auweyrauweyrauwyer + wekuryakwueyruaweyr +
  wekuryakwueyruaweyr +
  wekuryakwueyruaweyr}
```

After:
```
f = {
  |x, y|
  yaewrtawieyra + auweyrauweyrauwyer + wekuryakwueyruaweyr +
  wekuryakwueyruaweyr +
  wekuryakwueyruaweyr
}
```

---

Before:
```
f = {|yaewrtawieyra, auweyrauweyrauwyer, wekuryakwueyruaweyr, wekuryakwueyruaweyr, wekuryakwueyruaweyr|123}
```

After:
```
f = {
  |
    yaewrtawieyra,
    auweyrauweyrauwyer,
    wekuryakwueyruaweyr,
    wekuryakwueyruaweyr,
    wekuryakwueyruaweyr
  |
  123
}
```