### PR TITLE
Fix "find in editor" for Squiggle Hub

### DIFF
--- a/packages/components/src/components/SquiggleViewer/VariableBox.tsx
+++ b/packages/components/src/components/SquiggleViewer/VariableBox.tsx
@@ -30,6 +30,7 @@ import {
   getChildrenValues,
   pathToShortName,
 } from "./utils.js";
+import { useEffectRef } from "../../lib/hooks/useEffectRef.js";
 
 type SettingsMenuParams = {
   // Used to notify VariableBox that settings have changed, so that VariableBox could re-render itself.
@@ -120,28 +121,20 @@ export const VariableBox: FC<VariableBoxProps> = ({
 
   const name = pathToShortName(path);
 
-  // should be callback to not fire on each render
-  const saveRef = useCallback(
-    (element: HTMLDivElement) => {
-      dispatch({
-        type: "REGISTER_ITEM_HANDLE",
-        payload: { path, element },
-      });
-    },
-    [dispatch, path]
-  );
+  // We should switch to ref cleanups after https://github.com/facebook/react/pull/25686 is released.
+  const saveRef = useEffectRef((element: HTMLDivElement) => {
+    dispatch({
+      type: "REGISTER_ITEM_HANDLE",
+      payload: { path, element },
+    });
 
-  useEffect(() => {
-    // This code is a bit risky, because I'm not sure about the order in which ref callbacks and effect cleanups fire.
-    // But it works in practice.
-    // We should switch to ref cleanups after https://github.com/facebook/react/pull/25686 is released.
     return () => {
       dispatch({
         type: "UNREGISTER_ITEM_HANDLE",
         payload: { path },
       });
     };
-  }, [dispatch, path]);
+  });
 
   const hasBodyContent = Boolean(path.items.length);
   const isOpen = isFocused || !settings.collapsed;

--- a/packages/components/src/lib/hooks/useEffectRef.ts
+++ b/packages/components/src/lib/hooks/useEffectRef.ts
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2019 Baidu EFE team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+// Copied from https://github.com/ecomfe/react-hooks/blob/2dae90c2fa543f66898edf92a0fec19753776580/packages/effect-ref/src/index.ts
+// (via https://github.com/KurtGokhan/rfcs/blob/main/text/0000-callback-ref-cleanup.md#existing-workarounds)
+// When React 18.3 is released, this can be removed and replaced with ref cleanup functions.
+
+import { useCallback, useRef } from "react";
+
+export type EffectRef<E extends HTMLElement = HTMLElement> = (
+  element: E | null
+) => void;
+
+export type RefCallback<E extends HTMLElement = HTMLElement> = (
+  element: E
+) => (() => void) | void;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
+export function useEffectRef<E extends HTMLElement = HTMLElement>(
+  callback: RefCallback<E>
+): EffectRef<E> {
+  const disposeRef = useRef<() => void>(noop);
+  const effect = useCallback(
+    (element: E | null) => {
+      disposeRef.current();
+      // To ensure every dispose function is called only once.
+      disposeRef.current = noop;
+
+      if (element) {
+        const dispose = callback(element);
+
+        if (typeof dispose === "function") {
+          disposeRef.current = dispose;
+        }
+        // Have an extra type check to work with javascript.
+        else if (dispose !== undefined) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            "Effect ref callback must return undefined or a dispose function"
+          );
+        }
+      }
+    },
+    [callback]
+  );
+
+  return effect;
+}


### PR DESCRIPTION
"Find in editor" was broken because of flaky useEffect solution that I used. (Either because Next.js uses a canary React version, or because it remounts components on initial render).