### PR TITLE
List.reduceWhile

### DIFF
--- a/packages/squiggle-lang/__tests__/library/list_test.ts
+++ b/packages/squiggle-lang/__tests__/library/list_test.ts
@@ -92,6 +92,44 @@ describe("List functions", () => {
       "9"
     );
   });
+
+  describe("reduceWhile", () => {
+    testEvalToBe(
+      "List.reduceWhile([5, 6, 7], 0, {|acc, curr| acc + curr}, {|acc| acc < 12})",
+      "11"
+    );
+
+    testEvalToBe(
+      "List.reduceWhile([5, 6, 7], 10, {|acc, curr| acc + curr}, {|acc| acc < 23})",
+      "21"
+    );
+
+    testEvalToBe(
+      "List.reduceWhile([5, 6, 7], { x: 0 }, {|acc, curr| { x: acc.x + curr }}, {|acc| acc.x < 13})",
+      "{x: 11}"
+    );
+
+    testEvalToBe(
+      "List.reduceWhile([5, 6, 7], 10, {|acc, curr| acc + curr}, {|acc| acc < 5})",
+      "10"
+    );
+
+    testEvalToBe(
+      "List.reduceWhile([5, 6, 7], 0, {|acc, curr| acc + curr}, {|acc| acc < 100})",
+      "18"
+    );
+
+    testEvalToBe(
+      "List.reduceWhile([], 5, {|acc, curr| acc + curr}, {|acc| acc < 10})",
+      "5"
+    );
+
+    testEvalToBe(
+      "List.reduceWhile([], 5, {|acc, curr| acc + curr}, {|acc| acc < 0})",
+      "5"
+    );
+  });
+
   describe("reverse", () => {
     testEvalToBe("arr=[1,2,3]; List.reverse(arr)", "[3,2,1]");
   });

--- a/packages/squiggle-lang/__tests__/library/list_test.ts
+++ b/packages/squiggle-lang/__tests__/library/list_test.ts
@@ -94,36 +94,43 @@ describe("List functions", () => {
   });
 
   describe("reduceWhile", () => {
+    // basic
     testEvalToBe(
       "List.reduceWhile([5, 6, 7], 0, {|acc, curr| acc + curr}, {|acc| acc < 12})",
       "11"
     );
 
+    // non-trivial init value
     testEvalToBe(
       "List.reduceWhile([5, 6, 7], 10, {|acc, curr| acc + curr}, {|acc| acc < 23})",
       "21"
     );
 
+    // acc has a different type from array elements
     testEvalToBe(
       "List.reduceWhile([5, 6, 7], { x: 0 }, {|acc, curr| { x: acc.x + curr }}, {|acc| acc.x < 13})",
       "{x: 11}"
     );
 
+    // stop before the first element
     testEvalToBe(
       "List.reduceWhile([5, 6, 7], 10, {|acc, curr| acc + curr}, {|acc| acc < 5})",
       "10"
     );
 
+    // don't stop until the end
     testEvalToBe(
       "List.reduceWhile([5, 6, 7], 0, {|acc, curr| acc + curr}, {|acc| acc < 100})",
       "18"
     );
 
+    // empty list
     testEvalToBe(
       "List.reduceWhile([], 5, {|acc, curr| acc + curr}, {|acc| acc < 10})",
       "5"
     );
 
+    // empty list, intiial value doesn't fit the condition
     testEvalToBe(
       "List.reduceWhile([], 5, {|acc, curr| acc + curr}, {|acc| acc < 0})",
       "5"

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -193,6 +193,41 @@ export const library = [
     ],
   }),
   maker.make({
+    name: "reduceWhile",
+    requiresNamespace: true,
+    examples: [
+      // Args: (list, initialValue, step, condition)
+      // Returns the last value that fits the condition.
+      // If even initial value doesn't fit the condition, it will be returned anyway;
+      // So the result isn't guaranteed to fit the condition.
+      `List.reduceWhile([1,4,5], 0, {|acc, curr| acc + curr }), {|acc| acc < 5})`,
+    ],
+    definitions: [
+      makeDefinition(
+        [frArray(frAny), frAny, frLambda, frLambda],
+        ([array, initialValue, step, condition], context) => {
+          let acc = initialValue;
+          for (let i = 0; i < array.length; i++) {
+            const newAcc = step.call([acc, array[i]], context);
+
+            const checkResult = condition.call([newAcc], context);
+            if (checkResult.type !== "Bool") {
+              throw new REOther(
+                `Condition should return a boolean value, got: ${checkResult.type}`
+              );
+            }
+            if (!checkResult.value) {
+              // condition failed
+              return acc;
+            }
+            acc = newAcc;
+          }
+          return acc;
+        }
+      ),
+    ],
+  }),
+  maker.make({
     name: "filter",
     requiresNamespace: false,
     examples: [`List.filter([1,4,5], {|x| x>3})`],

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -200,7 +200,7 @@ export const library = [
       // Returns the last value that fits the condition.
       // If even initial value doesn't fit the condition, it will be returned anyway;
       // So the result isn't guaranteed to fit the condition.
-      `List.reduceWhile([1,4,5], 0, {|acc, curr| acc + curr }), {|acc| acc < 5})`,
+      `List.reduceWhile([1,4,5], 0, {|acc, curr| acc + curr }, {|acc| acc < 5})`,
     ],
     definitions: [
       makeDefinition(

--- a/packages/website/docs/Api/List.md
+++ b/packages/website/docs/Api/List.md
@@ -141,6 +141,27 @@ Works like `reduce`, but the function is applied to each item from the last back
 
 See [Rescript implementation](https://rescript-lang.org/docs/manual/latest/api/belt/array#reducereverse).
 
+### reduceWhile
+
+```
+List.reduceWhile: (list<'b>, 'a, ('a, 'b) => 'a, ('a) => bool) => 'a
+```
+
+Works like `reduce`, but stops when the accumulator doesn't satisfy the condition, and returns the last accumulator that satisfies the condition (or the initial value if even the initial value doesn't satisfy the condition).
+
+This is useful for simulating processes that need to stop based on the process state.
+
+Example:
+
+```js
+addUpTo(limit) = List.reduceWhile(
+  List.upTo(1, 100),
+  0,
+  {|acc, value| acc + value},
+  {|acc| acc <= limit}
+)
+```
+
 ### join
 
 ```

--- a/packages/website/docs/Api/List.md
+++ b/packages/website/docs/Api/List.md
@@ -154,12 +154,11 @@ This is useful for simulating processes that need to stop based on the process s
 Example:
 
 ```js
-addUpTo(limit) = List.reduceWhile(
-  List.upTo(1, 100),
-  0,
-  {|acc, value| acc + value},
-  {|acc| acc <= limit}
-)
+/** Adds first two elements, returns `11`. */
+List.reduceWhile([5, 6, 7], 0, {|acc, curr| acc + curr}, {|acc| acc < 15})
+
+/** Adds first two elements, returns `{ x: 11 }`. */
+List.reduceWhile([5, 6, 7], { x: 0 }, {|acc, curr| { x: acc.x + curr }}, {|acc| acc.x < 15})
 ```
 
 ### join


### PR DESCRIPTION
Experimental function for early-stop reduces, helps with simulating processes.

This can be treated as a specialized version of #1196.

TODO:
- [x] tests
- [x] documentation
- [ ] decide if this is solid enough to publish under `List` and not under `Danger`