### PR TITLE
Charts should filter out infinity values from the domain

### DIFF
--- a/packages/components/src/components/FunctionChart/DistFunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart/DistFunctionChart.tsx
@@ -121,17 +121,32 @@ export const DistFunctionChart: FC<FunctionChart1DistProps> = ({
 
   const { xScale, yScale } = useMemo(() => {
     const xScale = sqScaleToD3(plot.xScale);
-    xScale.domain(d3.extent(data, (d) => d.x) as [number, number]);
+    xScale.domain(
+      d3.extent(
+        data.filter((d) => isFinite(d.x)),
+        (d) => d.x
+      ) as [number, number]
+    );
 
     const yScale = scaleLinear().domain([
       Math.min(
         ...data.map((d) =>
-          Math.min(...Object.values(d.areas).map((p) => p[0]), d[50])
+          Math.min(
+            ...Object.values(d.areas)
+              .map((p) => p[0])
+              .filter(isFinite),
+            d[50]
+          )
         )
       ),
       Math.max(
         ...data.map((d) =>
-          Math.max(...Object.values(d.areas).map((p) => p[1]), d[50])
+          Math.max(
+            ...Object.values(d.areas)
+              .map((p) => p[1])
+              .filter(isFinite),
+            d[50]
+          )
         )
       ),
     ]);

--- a/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
@@ -44,10 +44,20 @@ export const NumericFunctionChart: FC<Props> = ({
       context.clearRect(0, 0, width, height);
 
       const xScale = sqScaleToD3(plot.xScale);
-      xScale.domain(d3.extent(functionImage, (d) => d.x) as [number, number]);
+      xScale.domain(
+        d3.extent(
+          functionImage.filter((d) => isFinite(d.x)),
+          (d) => d.x
+        ) as [number, number]
+      );
 
       const yScale = sqScaleToD3(plot.yScale);
-      yScale.domain(d3.extent(functionImage, (d) => d.y) as [number, number]);
+      yScale.domain(
+        d3.extent(
+          functionImage.filter((d) => isFinite(d.y)),
+          (d) => d.y
+        ) as [number, number]
+      );
 
       const { frame, padding } = drawAxes({
         context,

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -56,6 +56,7 @@ const SquiggleViewerOuter = forwardRef<
       <span onClick={unfocus} className={navLinkStyle}>
         {focused.root === "bindings" ? "Variables" : focused.root}
       </span>
+
       {focused
         .itemsAsValuePaths()
         .slice(0, -1)
@@ -67,6 +68,7 @@ const SquiggleViewerOuter = forwardRef<
             </div>
           </div>
         ))}
+      <ChevronRightIcon className="text-slate-300" size={24} />
     </div>
   );
 

--- a/packages/components/src/stories/SquiggleChart/Functions.stories.tsx
+++ b/packages/components/src/stories/SquiggleChart/Functions.stories.tsx
@@ -44,6 +44,15 @@ Plot.numericFn({
   },
 };
 
+export const WithInfiniteValues: Story = {
+  name: "With Infinite Values",
+  args: {
+    code: sq`
+    fn(t:[1,100]) = if t < 40 then 1/0 else t
+`,
+  },
+};
+
 export const CustomTickFormat: Story = {
   name: "Custom tick format",
   args: {


### PR DESCRIPTION
This addresses Issue #6 here:
https://github.com/quantified-uncertainty/squiggle/issues/2001

Frustratingly, this does sort of create a different issue, where infinity-y points "disappear", which is pretty bad. I'm not sure what to do here.

I think we'll probably want/need some "show function items as a table" functionality later, or a better function chart with dots to show which parts are calculated, and which are interpolated. 