### PR TITLE
Adjustable symlog param

### DIFF
--- a/packages/components/src/components/PlaygroundSettings.tsx
+++ b/packages/components/src/components/PlaygroundSettings.tsx
@@ -41,9 +41,9 @@ function scaleTypeToSqScale(
     case "linear":
       return SqLinearScale.create(args);
     case "log":
-      return SqLogScale.create(args);
+      return SqLogScale.create({ base: 10, ...args });
     case "symlog":
-      return SqSymlogScale.create(args);
+      return SqSymlogScale.create({ constant: 10, ...args });
     case "exp":
       return SqPowerScale.create({ exponent: 0.1, ...args });
     default:

--- a/packages/components/src/components/PlaygroundSettings.tsx
+++ b/packages/components/src/components/PlaygroundSettings.tsx
@@ -43,9 +43,9 @@ function scaleTypeToSqScale(
     case "log":
       return SqLogScale.create(args);
     case "symlog":
-      return SqSymlogScale.create({ constant: 10, ...args });
+      return SqSymlogScale.create(args);
     case "exp":
-      return SqPowerScale.create({ exponent: 0.1, ...args });
+      return SqPowerScale.create(args);
     default:
       // should never happen, just a precaution
       throw new Error("Internal error");

--- a/packages/components/src/components/PlaygroundSettings.tsx
+++ b/packages/components/src/components/PlaygroundSettings.tsx
@@ -41,7 +41,7 @@ function scaleTypeToSqScale(
     case "linear":
       return SqLinearScale.create(args);
     case "log":
-      return SqLogScale.create({ base: 10, ...args });
+      return SqLogScale.create(args);
     case "symlog":
       return SqSymlogScale.create({ constant: 10, ...args });
     case "exp":

--- a/packages/components/src/lib/d3/index.ts
+++ b/packages/components/src/lib/d3/index.ts
@@ -23,7 +23,7 @@ export function sqScaleToD3(
     case "power":
       return scalePow().exponent(scale.exponent);
     case "log":
-      return scaleLog().base(scale.base);
+      return scaleLog();
     default:
       throw new Error(`Unknown scale: ${scale satisfies never}`);
   }

--- a/packages/components/src/lib/d3/index.ts
+++ b/packages/components/src/lib/d3/index.ts
@@ -19,11 +19,11 @@ export function sqScaleToD3(
     case "linear":
       return scaleLinear();
     case "symlog":
-      return scaleSymlog().constant(1);
+      return scaleSymlog().constant(scale.constant);
     case "power":
       return scalePow().exponent(scale.exponent);
     case "log":
-      return scaleLog();
+      return scaleLog().base(scale.base);
     default:
       throw new Error(`Unknown scale: ${scale satisfies never}`);
   }

--- a/packages/components/test/d3.test.ts
+++ b/packages/components/test/d3.test.ts
@@ -7,7 +7,7 @@ import { SqPowerScale } from "@quri/squiggle-lang";
 
 describe.each([
   SqLinearScale.create(),
-  SqLogScale.create({ base: 10 }),
+  SqLogScale.create(),
   SqSymlogScale.create({ constant: 10 }),
   SqPowerScale.create({ exponent: 10 }),
 ])("%s", (sqScale) => {

--- a/packages/components/test/d3.test.ts
+++ b/packages/components/test/d3.test.ts
@@ -8,8 +8,8 @@ import { SqPowerScale } from "@quri/squiggle-lang";
 describe.each([
   SqLinearScale.create(),
   SqLogScale.create(),
-  SqSymlogScale.create({ constant: 1 }),
-  SqPowerScale.create({ exponent: 10 }),
+  SqSymlogScale.create({}),
+  SqPowerScale.create({}),
 ])("%s", (sqScale) => {
   const scale = sqScaleToD3(sqScale);
 

--- a/packages/components/test/d3.test.ts
+++ b/packages/components/test/d3.test.ts
@@ -8,7 +8,7 @@ import { SqPowerScale } from "@quri/squiggle-lang";
 describe.each([
   SqLinearScale.create(),
   SqLogScale.create(),
-  SqSymlogScale.create({ constant: 10 }),
+  SqSymlogScale.create({ constant: 1 }),
   SqPowerScale.create({ exponent: 10 }),
 ])("%s", (sqScale) => {
   const scale = sqScaleToD3(sqScale);

--- a/packages/components/test/d3.test.ts
+++ b/packages/components/test/d3.test.ts
@@ -7,8 +7,8 @@ import { SqPowerScale } from "@quri/squiggle-lang";
 
 describe.each([
   SqLinearScale.create(),
-  SqLogScale.create(),
-  SqSymlogScale.create(),
+  SqLogScale.create({ base: 10 }),
+  SqSymlogScale.create({ constant: 10 }),
   SqPowerScale.create({ exponent: 10 }),
 ])("%s", (sqScale) => {
   const scale = sqScaleToD3(sqScale);

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -10,6 +10,10 @@ import { FnFactory } from "../library/registry/helpers.js";
 import { vScale } from "../value/index.js";
 import { REOther } from "../errors/messages.js";
 import { SqPowerScale, SqSymlogScale } from "../public/SqValue/SqScale.js";
+import {
+  SCALE_SYMLOG_DEFAULT_CONSTANT,
+  SCALE_POWER_DEFAULT_CONSTANT,
+} from "../value/index.js";
 
 const maker = new FnFactory({
   nameSpace: "Scale",
@@ -104,14 +108,13 @@ export const library = [
             min: min ?? undefined,
             max: max ?? undefined,
             tickFormat: tickFormat ?? undefined,
-            constant: constant || SqSymlogScale.defaultConstant,
+            constant: constant ?? undefined,
           });
         }
       ),
       makeDefinition([], () => {
         return vScale({
           type: "symlog",
-          constant: SqSymlogScale.defaultConstant,
         });
       }),
     ],
@@ -138,14 +141,13 @@ export const library = [
             min: min ?? undefined,
             max: max ?? undefined,
             tickFormat: tickFormat ?? undefined,
-            exponent: exponent || SqPowerScale.defaultExponent,
+            exponent: exponent ?? undefined,
           });
         }
       ),
       makeDefinition([], () => {
         return vScale({
           type: "power",
-          exponent: SqPowerScale.defaultExponent,
         });
       }),
     ],

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -9,6 +9,7 @@ import {
 import { FnFactory } from "../library/registry/helpers.js";
 import { vScale } from "../value/index.js";
 import { REOther } from "../errors/messages.js";
+import { SqPowerScale, SqSymlogScale } from "../public/SqValue/SqScale.js";
 
 const maker = new FnFactory({
   nameSpace: "Scale",
@@ -103,12 +104,15 @@ export const library = [
             min: min ?? undefined,
             max: max ?? undefined,
             tickFormat: tickFormat ?? undefined,
-            constant: constant || 0.1,
+            constant: constant || SqSymlogScale.defaultConstant,
           });
         }
       ),
       makeDefinition([], () => {
-        return vScale({ type: "symlog", constant: 0.1 });
+        return vScale({
+          type: "symlog",
+          constant: SqSymlogScale.defaultConstant,
+        });
       }),
     ],
   }),
@@ -134,7 +138,7 @@ export const library = [
             min: min ?? undefined,
             max: max ?? undefined,
             tickFormat: tickFormat ?? undefined,
-            exponent: exponent || 0.1,
+            exponent: exponent || SqPowerScale.defaultExponent,
           });
         }
       ),

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -60,11 +60,10 @@ export const library = [
           frRecord(
             ["min", frOptional(frNumber)],
             ["max", frOptional(frNumber)],
-            ["tickFormat", frOptional(frString)],
-            ["base", frOptional(frNumber)]
+            ["tickFormat", frOptional(frString)]
           ),
         ],
-        ([{ min, max, tickFormat, base }]) => {
+        ([{ min, max, tickFormat }]) => {
           if (min !== null && min <= 0) {
             throw new REOther(`Min must be over 0 for log scale, got: ${min}`);
           }
@@ -74,12 +73,11 @@ export const library = [
             min: min ?? undefined,
             max: max ?? undefined,
             tickFormat: tickFormat ?? undefined,
-            base: base || 10,
           });
         }
       ),
       makeDefinition([], () => {
-        return vScale({ type: "log", base: 10 });
+        return vScale({ type: "log" });
       }),
     ],
   }),

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -9,11 +9,6 @@ import {
 import { FnFactory } from "../library/registry/helpers.js";
 import { vScale } from "../value/index.js";
 import { REOther } from "../errors/messages.js";
-import { SqPowerScale, SqSymlogScale } from "../public/SqValue/SqScale.js";
-import {
-  SCALE_SYMLOG_DEFAULT_CONSTANT,
-  SCALE_POWER_DEFAULT_CONSTANT,
-} from "../value/index.js";
 
 const maker = new FnFactory({
   nameSpace: "Scale",
@@ -102,6 +97,9 @@ export const library = [
         ],
         ([{ min, max, tickFormat, constant }]) => {
           checkMinMax(min, max);
+          if (constant !== null && constant === 0) {
+            throw new REOther(`Symlog scale constant cannot be 0.`);
+          }
 
           return vScale({
             type: "symlog",
@@ -135,6 +133,9 @@ export const library = [
         ],
         ([{ min, max, tickFormat, exponent }]) => {
           checkMinMax(min, max);
+          if (exponent !== null && exponent <= 0) {
+            throw new REOther(`Power Scale exponent must be over 0.`);
+          }
 
           return vScale({
             type: "power",

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -142,6 +142,12 @@ export const library = [
           });
         }
       ),
+      makeDefinition([], () => {
+        return vScale({
+          type: "power",
+          exponent: SqPowerScale.defaultExponent,
+        });
+      }),
     ],
   }),
 ];

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -55,21 +55,31 @@ export const library = [
     output: "Scale",
     examples: [`Scale.log({ min: 1, max: 100 })`],
     definitions: [
-      makeDefinition([commonRecord], ([{ min, max, tickFormat }]) => {
-        if (min !== null && min <= 0) {
-          throw new REOther(`Min must be over 0 for log scale, got: ${min}`);
+      makeDefinition(
+        [
+          frRecord(
+            ["min", frOptional(frNumber)],
+            ["max", frOptional(frNumber)],
+            ["tickFormat", frOptional(frString)],
+            ["base", frOptional(frNumber)]
+          ),
+        ],
+        ([{ min, max, tickFormat, base }]) => {
+          if (min !== null && min <= 0) {
+            throw new REOther(`Min must be over 0 for log scale, got: ${min}`);
+          }
+          checkMinMax(min, max);
+          return vScale({
+            type: "log",
+            min: min ?? undefined,
+            max: max ?? undefined,
+            tickFormat: tickFormat ?? undefined,
+            base: base || 10,
+          });
         }
-        checkMinMax(min, max);
-
-        return vScale({
-          type: "log",
-          min: min ?? undefined,
-          max: max ?? undefined,
-          tickFormat: tickFormat ?? undefined,
-        });
-      }),
+      ),
       makeDefinition([], () => {
-        return vScale({ type: "log" });
+        return vScale({ type: "log", base: 10 });
       }),
     ],
   }),
@@ -78,18 +88,29 @@ export const library = [
     output: "Scale",
     examples: [`Scale.symlog({ min: -10, max: 10 })`],
     definitions: [
-      makeDefinition([commonRecord], ([{ min, max, tickFormat }]) => {
-        checkMinMax(min, max);
+      makeDefinition(
+        [
+          frRecord(
+            ["min", frOptional(frNumber)],
+            ["max", frOptional(frNumber)],
+            ["tickFormat", frOptional(frString)],
+            ["constant", frOptional(frNumber)]
+          ),
+        ],
+        ([{ min, max, tickFormat, constant }]) => {
+          checkMinMax(min, max);
 
-        return vScale({
-          type: "symlog",
-          min: min ?? undefined,
-          max: max ?? undefined,
-          tickFormat: tickFormat ?? undefined,
-        });
-      }),
+          return vScale({
+            type: "symlog",
+            min: min ?? undefined,
+            max: max ?? undefined,
+            tickFormat: tickFormat ?? undefined,
+            constant: constant || 0.1,
+          });
+        }
+      ),
       makeDefinition([], () => {
-        return vScale({ type: "symlog" });
+        return vScale({ type: "symlog", constant: 0.1 });
       }),
     ],
   }),
@@ -104,7 +125,7 @@ export const library = [
             ["min", frOptional(frNumber)],
             ["max", frOptional(frNumber)],
             ["tickFormat", frOptional(frString)],
-            ["exponent", frNumber]
+            ["exponent", frOptional(frNumber)]
           ),
         ],
         ([{ min, max, tickFormat, exponent }]) => {
@@ -115,7 +136,7 @@ export const library = [
             min: min ?? undefined,
             max: max ?? undefined,
             tickFormat: tickFormat ?? undefined,
-            exponent,
+            exponent: exponent || 0.1,
           });
         }
       ),

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -1,15 +1,21 @@
-import { CommonScaleArgs, Scale, vScale } from "../../value/index.js";
+import {
+  CommonScaleArgs,
+  Scale,
+  vScale,
+  SCALE_SYMLOG_DEFAULT_CONSTANT,
+  SCALE_POWER_DEFAULT_CONSTANT,
+} from "../../value/index.js";
 
 export const wrapScale = (value: Scale): SqScale => {
   switch (value.type) {
     case "linear":
-      return new SqLinearScale(value);
+      return SqLinearScale.create(value);
     case "log":
-      return new SqLogScale(value);
+      return SqLogScale.create(value);
     case "symlog":
-      return new SqSymlogScale(value);
+      return SqSymlogScale.create(value);
     case "power":
-      return new SqPowerScale(value);
+      return SqPowerScale.create(value);
   }
 };
 
@@ -54,7 +60,7 @@ export class SqLogScale extends SqAbstractScale<"log"> {
 
 export class SqSymlogScale extends SqAbstractScale<"symlog"> {
   tag = "symlog" as const;
-  static defaultConstant = 1;
+  static defaultConstant = SCALE_SYMLOG_DEFAULT_CONSTANT;
 
   static create(args: CommonScaleArgs & { constant?: number }) {
     return new SqSymlogScale({
@@ -65,13 +71,13 @@ export class SqSymlogScale extends SqAbstractScale<"symlog"> {
   }
 
   get constant() {
-    return this._value.constant;
+    return this._value.constant || SCALE_SYMLOG_DEFAULT_CONSTANT;
   }
 }
 
 export class SqPowerScale extends SqAbstractScale<"power"> {
   tag = "power" as const;
-  static defaultExponent = 0.1;
+  static defaultExponent = SCALE_POWER_DEFAULT_CONSTANT;
 
   static create(args: CommonScaleArgs & { exponent?: number }) {
     return new SqPowerScale({
@@ -82,7 +88,7 @@ export class SqPowerScale extends SqAbstractScale<"power"> {
   }
 
   get exponent() {
-    return this._value.exponent;
+    return this._value.exponent || SCALE_POWER_DEFAULT_CONSTANT;
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -47,16 +47,24 @@ export class SqLinearScale extends SqAbstractScale<"linear"> {
 export class SqLogScale extends SqAbstractScale<"log"> {
   tag = "log" as const;
 
-  static create(args: CommonScaleArgs = {}) {
+  static create(args: CommonScaleArgs & { base: number }) {
     return new SqLogScale({ type: "log", ...args });
+  }
+
+  get base() {
+    return this._value.base;
   }
 }
 
 export class SqSymlogScale extends SqAbstractScale<"symlog"> {
   tag = "symlog" as const;
 
-  static create(args: CommonScaleArgs = {}) {
+  static create(args: CommonScaleArgs & { constant: number }) {
     return new SqSymlogScale({ type: "symlog", ...args });
+  }
+
+  get constant() {
+    return this._value.constant;
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -54,9 +54,14 @@ export class SqLogScale extends SqAbstractScale<"log"> {
 
 export class SqSymlogScale extends SqAbstractScale<"symlog"> {
   tag = "symlog" as const;
+  static defaultConstant = 1;
 
-  static create(args: CommonScaleArgs & { constant: number }) {
-    return new SqSymlogScale({ type: "symlog", ...args });
+  static create(args: CommonScaleArgs & { constant?: number }) {
+    return new SqSymlogScale({
+      type: "symlog",
+      ...args,
+      constant: args.constant || this.defaultConstant,
+    });
   }
 
   get constant() {
@@ -66,9 +71,14 @@ export class SqSymlogScale extends SqAbstractScale<"symlog"> {
 
 export class SqPowerScale extends SqAbstractScale<"power"> {
   tag = "power" as const;
+  static defaultExponent = 0.1;
 
-  static create(args: CommonScaleArgs & { exponent: number }) {
-    return new SqPowerScale({ type: "power", ...args });
+  static create(args: CommonScaleArgs & { exponent?: number }) {
+    return new SqPowerScale({
+      type: "power",
+      ...args,
+      exponent: args.exponent || this.defaultExponent,
+    });
   }
 
   get exponent() {

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -60,35 +60,46 @@ export class SqLogScale extends SqAbstractScale<"log"> {
 
 export class SqSymlogScale extends SqAbstractScale<"symlog"> {
   tag = "symlog" as const;
-  static defaultConstant = SCALE_SYMLOG_DEFAULT_CONSTANT;
 
-  static create(args: CommonScaleArgs & { constant?: number }) {
-    return new SqSymlogScale({
+  private _constant: number;
+
+  constructor(args: CommonScaleArgs & { constant?: number }) {
+    super({
       type: "symlog",
       ...args,
-      constant: args.constant || this.defaultConstant,
     });
+    this._constant = args.constant ?? SCALE_SYMLOG_DEFAULT_CONSTANT;
+  }
+
+  static create(args: CommonScaleArgs & { exponent?: number }) {
+    return new SqSymlogScale(args);
   }
 
   get constant() {
-    return this._value.constant || SCALE_SYMLOG_DEFAULT_CONSTANT;
+    return this._constant;
   }
 }
 
 export class SqPowerScale extends SqAbstractScale<"power"> {
   tag = "power" as const;
-  static defaultExponent = SCALE_POWER_DEFAULT_CONSTANT;
+  static readonly defaultExponent = SCALE_POWER_DEFAULT_CONSTANT;
 
-  static create(args: CommonScaleArgs & { exponent?: number }) {
-    return new SqPowerScale({
+  private _exponent: number;
+
+  constructor(args: CommonScaleArgs & { constant?: number }) {
+    super({
       type: "power",
       ...args,
-      exponent: args.exponent || this.defaultExponent,
     });
+    this._exponent = args.constant ?? SqPowerScale.defaultExponent;
+  }
+
+  static create(args: CommonScaleArgs & { exponent?: number }) {
+    return new SqSymlogScale(args);
   }
 
   get exponent() {
-    return this._value.exponent || SCALE_POWER_DEFAULT_CONSTANT;
+    return this._exponent;
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -71,7 +71,7 @@ export class SqSymlogScale extends SqAbstractScale<"symlog"> {
     this._constant = args.constant ?? SCALE_SYMLOG_DEFAULT_CONSTANT;
   }
 
-  static create(args: CommonScaleArgs & { exponent?: number }) {
+  static create(args: CommonScaleArgs & { constant?: number }) {
     return new SqSymlogScale(args);
   }
 
@@ -86,16 +86,16 @@ export class SqPowerScale extends SqAbstractScale<"power"> {
 
   private _exponent: number;
 
-  constructor(args: CommonScaleArgs & { constant?: number }) {
+  constructor(args: CommonScaleArgs & { exponent?: number }) {
     super({
       type: "power",
       ...args,
     });
-    this._exponent = args.constant ?? SqPowerScale.defaultExponent;
+    this._exponent = args.exponent ?? SqPowerScale.defaultExponent;
   }
 
   static create(args: CommonScaleArgs & { exponent?: number }) {
-    return new SqSymlogScale(args);
+    return new SqPowerScale(args);
   }
 
   get exponent() {

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -47,12 +47,8 @@ export class SqLinearScale extends SqAbstractScale<"linear"> {
 export class SqLogScale extends SqAbstractScale<"log"> {
   tag = "log" as const;
 
-  static create(args: CommonScaleArgs & { base: number }) {
+  static create(args: CommonScaleArgs = {}) {
     return new SqLogScale({ type: "log", ...args });
-  }
-
-  get base() {
-    return this._value.base;
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -82,7 +82,6 @@ export class SqSymlogScale extends SqAbstractScale<"symlog"> {
 
 export class SqPowerScale extends SqAbstractScale<"power"> {
   tag = "power" as const;
-  static readonly defaultExponent = SCALE_POWER_DEFAULT_CONSTANT;
 
   private _exponent: number;
 
@@ -91,7 +90,7 @@ export class SqPowerScale extends SqAbstractScale<"power"> {
       type: "power",
       ...args,
     });
-    this._exponent = args.exponent ?? SqPowerScale.defaultExponent;
+    this._exponent = args.exponent ?? SCALE_POWER_DEFAULT_CONSTANT;
   }
 
   static create(args: CommonScaleArgs & { exponent?: number }) {

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -350,7 +350,6 @@ export type Scale = CommonScaleArgs &
       }
     | {
         type: "log";
-        base: number;
       }
     | {
         type: "symlog";

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -353,13 +353,16 @@ export type Scale = CommonScaleArgs &
       }
     | {
         type: "symlog";
-        constant: number;
+        constant?: number;
       }
     | {
         type: "power";
-        exponent: number;
+        exponent?: number;
       }
   );
+
+export const SCALE_SYMLOG_DEFAULT_CONSTANT = 1;
+export const SCALE_POWER_DEFAULT_CONSTANT = 0.1;
 
 class VScale extends BaseValue {
   readonly type = "Scale";

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -350,9 +350,11 @@ export type Scale = CommonScaleArgs &
       }
     | {
         type: "log";
+        base: number;
       }
     | {
         type: "symlog";
+        constant: number;
       }
     | {
         type: "power";

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -132,7 +132,11 @@ Scale.power: ({min: number, max: number, tickFormat: string, exponent: number}) 
 ** Scale.symlog **  
 Symmetric log scale. Useful for plotting data that includes zero or negative values.
 
-The function accepts an additional constant parameter, used as follows: Scale.symlog({constant: 0.1}). This parameter allows you to allocate more pixel space to data with lower or higher absolute values. By adjusting this constant, you effectively control the scale's focus, shifting it between smaller and larger values. For more detailed information on this parameter, refer to the [D3 Documentation](https://d3js.org/d3-scale/symlog).
+The function accepts an additional `constant` parameter, used as follows: `Scale.symlog({constant: 0.1})`. This parameter allows you to allocate more pixel space to data with lower or higher absolute values. By adjusting this constant, you effectively control the scale's focus, shifting it between smaller and larger values. For more detailed information on this parameter, refer to the [D3 Documentation](https://d3js.org/d3-scale/symlog).
+
+The default value for `constant` is `1`.
 
 ** Scale.power **  
 Power scale. Accepts an extra `exponent` parameter, like, `Scale.power({exponent: 2, min: 0, max: 100})`.
+
+The default value for `exponent` is `10`.

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -139,4 +139,4 @@ The default value for `constant` is `1`.
 ** Scale.power **  
 Power scale. Accepts an extra `exponent` parameter, like, `Scale.power({exponent: 2, min: 0, max: 100})`.
 
-The default value for `exponent` is `10`.
+The default value for `exponent` is `0.1`.

--- a/packages/website/docs/Api/Plot.mdx
+++ b/packages/website/docs/Api/Plot.mdx
@@ -121,7 +121,7 @@ We use D3 for the tick formats. You can read about custom tick formats [here](ht
 ```js
 Scale.log: ({min: number, max: number, tickFormat: string}) => scale
 Scale.linear: ({min: number, max: number, tickFormat: string}) => scale
-Scale.symlog: ({min: number, max: number, tickFormat: string}) => scale
+Scale.symlog: ({min: number, max: number, tickFormat: string, constant: number}) => scale
 Scale.power: ({min: number, max: number, tickFormat: string, exponent: number}) => scale
 ```
 
@@ -130,7 +130,9 @@ Scale.power: ({min: number, max: number, tickFormat: string, exponent: number}) 
 ** Scale.linear **
 
 ** Scale.symlog **  
-Symmetric log scale. Useful for plotting data that includes negative values.
+Symmetric log scale. Useful for plotting data that includes zero or negative values.
+
+The function accepts an additional constant parameter, used as follows: Scale.symlog({constant: 0.1}). This parameter allows you to allocate more pixel space to data with lower or higher absolute values. By adjusting this constant, you effectively control the scale's focus, shifting it between smaller and larger values. For more detailed information on this parameter, refer to the [D3 Documentation](https://d3js.org/d3-scale/symlog).
 
 ** Scale.power **  
 Power scale. Accepts an extra `exponent` parameter, like, `Scale.power({exponent: 2, min: 0, max: 100})`.


### PR DESCRIPTION
I found that it's often useful to adjust this in symlog plots. Later, we could auto-adjust this, but I doubt we could do a better job than users.