### PR TITLE
Truncate functions resample samplesets to the original length

### DIFF
--- a/packages/squiggle-lang/__tests__/library/sampleSet_test.ts
+++ b/packages/squiggle-lang/__tests__/library/sampleSet_test.ts
@@ -44,6 +44,21 @@ describe("Various SampleSet functions", () => {
   );
 });
 
+describe("truncate", () => {
+  testEvalToBe(
+    "normal(3, 5) -> truncateLeft(0) -> SampleSet.toList -> List.length",
+    "1000"
+  );
+  testEvalToBe(
+    "normal(3, 5) -> truncateRight(0) -> SampleSet.toList -> List.length",
+    "1000"
+  );
+  testEvalToBe(
+    "(2 to 5) -> truncateRight(0)",
+    "Error(Distribution Math Error: Too few samples when constructing sample set)"
+  );
+});
+
 // Beware: float64Array makes it appear in an infinite loop.
 const arrayGen = () =>
   fc

--- a/packages/squiggle-lang/src/dist/SampleSetDist/index.ts
+++ b/packages/squiggle-lang/src/dist/SampleSetDist/index.ts
@@ -93,7 +93,10 @@ export class SampleSetDist extends BaseDist {
     if (rightCutoff !== undefined) {
       truncated = truncated.filter((x) => x <= rightCutoff);
     }
-    return SampleSetDist.make(truncated);
+    return Result.bind(
+      SampleSetDist.make(truncated),
+      (dist) => SampleSetDist.make(dist.sampleN(this.samples.length)) // resample to original length
+    );
   }
 
   // Randomly get one sample from the distribution
@@ -181,46 +184,6 @@ sample everything.
     );
   }
 }
-
-export type SampleSetError =
-  | {
-      type: "TooFewSamples";
-    }
-  | {
-      type: "NonNumericInput";
-      value: string;
-    }
-  | {
-      type: "OperationError";
-      value: OperationError;
-    };
-
-export type PointsetConversionError = "TooFewSamplesForConversionToPointSet";
-
-export const Error = {
-  pointsetConversionErrorToString(err: PointsetConversionError) {
-    if (err === "TooFewSamplesForConversionToPointSet") {
-      return "Too Few Samples to convert to point set";
-    } else {
-      throw new global.Error("Internal error");
-    }
-  },
-
-  toString(err: SampleSetError) {
-    switch (err.type) {
-      case "TooFewSamples":
-        return "Too few samples when constructing sample set";
-      case "NonNumericInput":
-        return `Found a non-number in input: ${err.value}`;
-      case "OperationError":
-        return err.value.toString();
-      default:
-        throw new global.Error(
-          `Internal error: unexpected error type ${(err as any).type}`
-        );
-    }
-  },
-};
 
 const buildSampleSetFromFn = (
   n: number,
@@ -313,7 +276,7 @@ export const mixture = (
   const samples = discreteSamples.map((distIndexToChoose, index) => {
     const chosenDist = dists[distIndexToChoose];
     if (chosenDist.samples.length < index) {
-      throw new global.Error("Mixture unreachable error"); // https://github.com/quantified-uncertainty/squiggle/issues/1405
+      throw new Error("Mixture unreachable error"); // https://github.com/quantified-uncertainty/squiggle/issues/1405
     }
     return chosenDist.samples[index];
   });


### PR DESCRIPTION
This is a fix for #2080 (including the error message fix).

Note that we also reshuffle everything, instead of appending samples to the end.

I think this is a good thing; samplesets shouldn't be ordered, and `.filter` could shift samples around. But it could also be a bad thing in rare cases where someone  did `truncateLeft` that had no effect (just to make sure that there are no bad values) and relied on correlations.