### PR TITLE
Fix flaky tests

### DIFF
--- a/packages/squiggle-lang/__tests__/library/sym_test.ts
+++ b/packages/squiggle-lang/__tests__/library/sym_test.ts
@@ -209,11 +209,11 @@ describe("distribution functions", () => {
   describe("log", () => {
     testEvalToBe("log(2, Sym.uniform(5,8))", "Sample Set Distribution");
     testEvalToBe(
-      "log(Sym.normal(5,2), 3)",
+      "log(Sym.normal(0,2), 3)",
       "Error(Distribution Math Error: Logarithm of input error: First input must be completely greater than 0)"
     );
     testEvalToBe(
-      "log(normal(5,2), Sym.normal(10,1))",
+      "log(normal(0,2), Sym.normal(10,1))",
       "Error(Distribution Math Error: Logarithm of input error: First input must be completely greater than 0)"
     );
     testEvalToBe("log(2, 0.0001 to 5)", "Sample Set Distribution"); // log with low values, see https://github.com/quantified-uncertainty/squiggle/issues/1098


### PR DESCRIPTION
2.5 sigma on 1000 samples is not enough:

https://github.com/quantified-uncertainty/squiggle/actions/runs/5686353321/job/15412981199?pr=2113:
```
  FAIL __tests__/library/sym_test.ts
    ● distribution functions › log › log(normal(5,2), Sym.normal(10,1))
  
      expect(received).toBe(expected) // Object.is equality
  
      Expected: "Error(Distribution Math Error: Logarithm of input error: First input must be completely greater than 0)"
      Received: "Sample Set Distribution"
  
        57 |
        58 | export async function expectEvalToBe(code: string, answer: string) {
      > 59 |   expect(resultToString(await evaluateStringToResult(code))).toBe(answer);
           |                                                              ^
        60 | }
        61 |
        62 | export async function expectEvalToMatch(
  
        at toBe (__tests__/helpers/reducerHelpers.ts:59:62)
        at Object.<anonymous> (__tests__/helpers/reducerHelpers.ts:70:26)
```