### PR TITLE
Quick fix so that pathAsString uses string pathItem names

### DIFF
--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -13,10 +13,6 @@ export type LocalItemSettings = {
 
 export type MergedItemSettings = PlaygroundSettings;
 
-export function pathAsString(path: SqValuePath) {
-  return path.items.join(".");
-}
-
 export const pathItemFormat = (item: PathItem): string => {
   if (item.type === "cellAddress") {
     return `Cell (${item.value.row},${item.value.column})`;
@@ -24,6 +20,10 @@ export const pathItemFormat = (item: PathItem): string => {
     return String(item.value);
   }
 };
+
+export function pathAsString(path: SqValuePath) {
+  return path.items.map(pathItemFormat).join(".");
+}
 
 export function pathToShortName(path: SqValuePath): string | undefined {
   const isTopLevel = path.items.length === 0;

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -45,7 +45,15 @@ export const WithNestedResult: Story = {
 e = [1,2,3,4,5,6,7,8,9,10,11]
 b = a + 4
 c = a + 2
-d = {e: {f: {g1: a, g2: b, g3: {h: {i: a}}}}}
+nested = {e: {f: {g1: a, g2: b, g3: {h: {i: a}}}}}
+e = 6
+t = 7
+y = 7
+u = 1
+g = 1
+e = 3
+q = 5
+w = 2
     `,
     height: 800,
   },


### PR DESCRIPTION
This closes https://github.com/quantified-uncertainty/squiggle/issues/2098