### PR TITLE
Better log scale error message

### DIFF
--- a/.changeset/soft-insects-march.md
+++ b/.changeset/soft-insects-march.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Improved log scale range error message

--- a/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
@@ -79,7 +79,7 @@ export const NumericFunctionChart: FC<Props> = ({
       ) {
         frame.enter();
         frame.fillText(
-          "Invalid X Scale settings",
+          "Log scale requires positive X Scale range",
           frame.width / 2,
           frame.height / 2,
           {


### PR DESCRIPTION
For #2001; text suggested by ChatGPT.

<img width="679" alt="Captura de pantalla 2023-07-30 a la(s) 13 50 39" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/f1ae8ec7-d013-4fd1-b93a-41258208627d">

It might be better to pick a different default range for log scales, but I'm not sure what it should be (`[1..100]`? `[0.01..10]`?), and it would cause an inconsistency because `functionChartDefaults.min/max` UI seting is scale-independent.