### PR TITLE
Show strings as markdown

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,6 +24,7 @@
     "@quri/squiggle-lang": "workspace:*",
     "@quri/ui": "workspace:*",
     "@react-hook/size": "^2.1.2",
+    "@tailwindcss/typography": "^0.5.9",
     "@types/d3": "^7.4.0",
     "clsx": "^2.0.0",
     "codemirror": "^6.0.1",
@@ -33,6 +34,7 @@
     "prettier": "^3.0.0",
     "react": "^18.2.0",
     "react-hook-form": "^7.45.2",
+    "react-markdown": "^8.0.7",
     "react-resizable": "^3.0.5",
     "vscode-uri": "^3.0.7",
     "zod": "^3.21.4"

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -30,6 +30,7 @@ import { clsx } from "clsx";
 import { TableChart } from "../TableChart/index.js";
 import { DistPreview } from "../DistributionsChart/DistPreview.js";
 import { TableCellsIcon } from "@quri/ui";
+import ReactMarkdown from "react-markdown";
 
 // We use an extra left margin for some elements to align them with parent variable name
 const leftMargin = "ml-1.5";
@@ -103,7 +104,9 @@ export const getBoxProps = (
         ),
         children: () => (
           <div className="text-neutral-800 text-sm px-2 py-1 my-1">
-            {value.value}
+            <ReactMarkdown className="prose max-w-4xl">
+              {value.value}
+            </ReactMarkdown>
           </div>
         ),
       };

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { SquigglePlayground as Component } from "../components/SquigglePlayground/index.js";
 import { Button } from "@quri/ui";
 import { sq } from "@quri/squiggle-lang";
+import { blockComment } from "@codemirror/commands";
 
 /**
  * A Squiggle playground is an environment where you can play around with all settings, including sampling settings, in Squiggle.
@@ -189,6 +190,41 @@ varScatter = Plot.scatter({
   xDist: varDist,
   yDist: (-3 to 3) * 5 - varDist ^ 2
 })
+`,
+    height: 800,
+  },
+};
+
+export const Markdown: Story = {
+  name: "Markdown",
+  args: {
+    defaultCode: `"# Header 1  
+Content under first header  
+## Header 2  
+Stuff under the second header. 
+Text continued on this line.
+
+This is a new paragraph.
+
+### Header 3  
+Stuff under the third header  
+
+Longer text goes here.
+[link](https://google.com)
+**bold** and *italics*
+
+![image](https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Dog_anatomy_lateral_skeleton_view.jpg/560px-Dog_anatomy_lateral_skeleton_view.jpg)
+
+---
+
+\`\`\`js
+foo = 23
+bar = 123
+\`\`\`
+
+\`test123\`
+\`\`test123\`\`
+"
 `,
     height: 800,
   },

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -4,6 +4,7 @@ export default {
   content: ["./src/**/*.{ts,tsx}", "../ui/src/**/*.{ts,tsx}"],
   plugins: [
     require("./src/tailwind-plugin.cts"),
+    require("@tailwindcss/typography"),
     require("@tailwindcss/forms"),
   ],
 } satisfies Config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@react-hook/size':
         specifier: ^2.1.2
         version: 2.1.2(react@18.2.0)
+      '@tailwindcss/typography':
+        specifier: ^0.5.9
+        version: 0.5.9(tailwindcss@3.3.2)
       '@types/d3':
         specifier: ^7.4.0
         version: 7.4.0
@@ -120,6 +123,9 @@ importers:
       react-hook-form:
         specifier: ^7.45.2
         version: 7.45.2(react@18.2.0)
+      react-markdown:
+        specifier: ^8.0.7
+        version: 8.0.7(@types/react@18.2.14)(react@18.2.0)
       react-resizable:
         specifier: ^3.0.5
         version: 3.0.5(react-dom@18.2.0)(react@18.2.0)


### PR DESCRIPTION
Very straightforward, we just show strings as markdown, with no further edits/polish. Happy to consider more changes after, as we start using.
<img width="1234" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/00c89a41-4a63-4005-bb5c-917baa4fd047">
