### PR TITLE
Add error boundary to SquiggleViewer

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -33,6 +33,7 @@
     "lodash": "^4.17.21",
     "prettier": "^3.0.0",
     "react": "^18.2.0",
+    "react-error-boundary": "^4.0.10",
     "react-hook-form": "^7.45.2",
     "react-markdown": "^8.0.7",
     "react-resizable": "^3.0.5",

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -1,5 +1,6 @@
 import { FC, forwardRef, memo } from "react";
 
+import { ErrorAlert } from "../Alert.js";
 import { SqError, SqValue, SqValuePath, result } from "@quri/squiggle-lang";
 import { ChevronRightIcon } from "@quri/ui";
 import { useImperativeHandle } from "react";
@@ -8,6 +9,7 @@ import { CodeEditorHandle } from "../CodeEditor.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { ExpressionViewer } from "./ExpressionViewer.js";
+import { ErrorBoundary } from "react-error-boundary";
 import {
   ViewerProvider,
   useFocus,
@@ -36,7 +38,18 @@ const SquiggleViewerBody: FC<{ value: SqValue }> = ({ value }) => {
     return <MessageAlert heading="Focused variable is not defined" />;
   }
 
-  return <ExpressionViewer value={valueToRender} />;
+  return (
+    <ErrorBoundary
+      fallback={
+        <ErrorAlert heading="Error">
+          There has been a JS error. It has been logged to he JS console.
+        </ErrorAlert>
+      }
+      onError={(error, info) => console.error(error, info)}
+    >
+      <ExpressionViewer value={valueToRender} />;
+    </ErrorBoundary>
+  );
 };
 
 const SquiggleViewerOuter = forwardRef<

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -229,3 +229,13 @@ bar = 123
     height: 800,
   },
 };
+
+export const Failure: Story = {
+  name: "Failure",
+  args: {
+    defaultCode: `Table.make(
+      { data:[], columns: [{ name: "Features", fn: {|r|""} }] }
+    )`,
+    height: 800,
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-error-boundary:
+        specifier: ^4.0.10
+        version: 4.0.10(react@18.2.0)
       react-hook-form:
         specifier: ^7.45.2
         version: 7.45.2(react@18.2.0)
@@ -14335,6 +14338,15 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.1.0
     dev: true
+
+  /react-error-boundary@4.0.10(react@18.2.0):
+    resolution: {integrity: sha512-pvVKdi77j2OoPHo+p3rorgE43OjDWiqFkaqkJz8sJKK6uf/u8xtzuaVfj5qJ2JnDLIgF1De3zY5AJDijp+LVPA==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.22.6
+      react: 18.2.0
+    dev: false
 
   /react-hook-form@7.45.2(react@18.2.0):
     resolution: {integrity: sha512-9s45OdTaKN+4NSTbXVqeDITd/nwIg++nxJGL8+OD5uf1DxvhsXQ641kaYHk5K28cpIOTYm71O/fYk7rFaygb3A==}


### PR DESCRIPTION
Adds an error boundary to ExpressionViewer, so that errors inside of it wouldn't propagate everywhere. This fixes at least the recent issue I had here. Later on, if it turns out there are errors in other places, we could move this. 

This closes https://github.com/quantified-uncertainty/squiggle/issues/1953
(or at least, I think we should close it now, then we could easily fix later if needed)