### PR TITLE
lang: replace vString escape function with JSON.stringify

### DIFF
--- a/packages/squiggle-lang/__tests__/ast/toExpression_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/toExpression_test.ts
@@ -4,7 +4,7 @@ describe("Peggy to Expression", () => {
   describe("literals operators parenthesis", () => {
     // Note that there is always an outer block. Otherwise, external bindings are ignored at the first statement
     testToExpression("1", "1", "1");
-    testToExpression("'hello'", "'hello'", "'hello'");
+    testToExpression("'hello'", '"hello"', '"hello"');
     testToExpression("true", "true", "true");
     testToExpression("1+2", "(add)(1, 2)", "3");
     testToExpression("add(1,2)", "(add)(1, 2)", "3");
@@ -48,19 +48,19 @@ describe("Peggy to Expression", () => {
     testToExpression("[0, 1, 2]", "[0, 1, 2]", "[0,1,2]");
     testToExpression(
       "['hello', 'world']",
-      "['hello', 'world']",
-      "['hello','world']"
+      '["hello", "world"]',
+      '["hello","world"]'
     );
     testToExpression("([0,1,2])[1]", "($_atIndex_$)([0, 1, 2], 1)", "1");
   });
 
   describe("dicts", () => {
-    testToExpression("{a: 1, b: 2}", "{'a': 1, 'b': 2}", "{a: 1,b: 2}");
+    testToExpression("{a: 1, b: 2}", '{"a": 1, "b": 2}', "{a: 1,b: 2}");
     testToExpression("{1+0: 1, 2+0: 2}", "{(add)(1, 0): 1, (add)(2, 0): 2}"); // key can be any expression
     testToExpression("dict.property", "Error(dict is not defined)");
     testToExpression(
       "dict={property: 1}; dict.property",
-      "dict = {{'property': 1}}; ($_atIndex_$)(dict, 'property')",
+      'dict = {{"property": 1}}; ($_atIndex_$)(dict, "property")',
       "1"
     );
   });

--- a/packages/squiggle-lang/__tests__/library/builtin_test.ts
+++ b/packages/squiggle-lang/__tests__/library/builtin_test.ts
@@ -2,11 +2,11 @@ import { testEvalToBe } from "../helpers/reducerHelpers.js";
 
 describe("Operators", () => {
   describe("concat", () => {
-    testEvalToBe("'foo' + 'bar'", "'foobar'");
-    testEvalToBe("'foo' + '3'", `'foo3'`);
-    testEvalToBe("'foo: ' + Sym.normal(3,2)", "'foo: Normal(3,2)'");
-    testEvalToBe("concat('foo', '3')", "'foo3'");
-    testEvalToBe("concat('a ', 'b')", "'a b'");
+    testEvalToBe("'foo' + 'bar'", '"foobar"');
+    testEvalToBe("'foo' + '3'", `"foo3"`);
+    testEvalToBe("'foo: ' + Sym.normal(3,2)", '"foo: Normal(3,2)"');
+    testEvalToBe("concat('foo', '3')", '"foo3"');
+    testEvalToBe("concat('a ', 'b')", '"a b"');
   });
   describe("equal", () => {
     testEvalToBe("3 == 5", "false");

--- a/packages/squiggle-lang/__tests__/library/dict_test.ts
+++ b/packages/squiggle-lang/__tests__/library/dict_test.ts
@@ -11,9 +11,9 @@ describe("Dict", () => {
     "Dict.mergeMany([{a: 1, b: 2}, {c: 3, d: 4}, {c: 5, e: 6}])",
     "{a: 1,b: 2,c: 5,d: 4,e: 6}"
   );
-  testEvalToBe("Dict.keys({a: 1, b: 2})", "['a','b']");
+  testEvalToBe("Dict.keys({a: 1, b: 2})", '["a","b"]');
   testEvalToBe("Dict.values({a: 1, b: 2})", "[1,2]");
-  testEvalToBe("Dict.toList({a: 1, b: 2})", "[['a',1],['b',2]]");
+  testEvalToBe("Dict.toList({a: 1, b: 2})", '[["a",1],["b",2]]');
   testEvalToBe("Dict.fromList([['a', 1], ['b', 2]])", "{a: 1,b: 2}");
   testEvalToBe("Dict.map({a: 1, b: 2}, {|x| x * 2})", "{a: 2,b: 4}");
   testEvalToBe(

--- a/packages/squiggle-lang/__tests__/library/list_test.ts
+++ b/packages/squiggle-lang/__tests__/library/list_test.ts
@@ -14,7 +14,7 @@ describe("List functions", () => {
   });
 
   describe("make", () => {
-    testEvalToBe("List.make(3, 'HI')", "['HI','HI','HI']");
+    testEvalToBe("List.make(3, 'HI')", '["HI","HI","HI"]');
     testEvalToBe("make(3, 'HI')", "Error(make is not defined)");
   });
 
@@ -36,7 +36,7 @@ describe("List functions", () => {
   describe("concat", () => {
     testEvalToBe("List.concat([1, 2, 3], [4, 5, 6])", "[1,2,3,4,5,6]");
     testEvalToBe("List.concat([], [1, 2, 3])", "[1,2,3]");
-    testEvalToBe("List.concat(['cake'], [1, 2, 3])", "['cake',1,2,3]");
+    testEvalToBe("List.concat(['cake'], [1, 2, 3])", '["cake",1,2,3]');
   });
 
   describe("reverse", () => {
@@ -67,10 +67,10 @@ describe("List functions", () => {
 
   describe("uniq", () => {
     testEvalToBe("arr=[1,2,3,1,2,3]; List.uniq(arr)", "[1,2,3]");
-    testEvalToBe("arr=[1,'1']; List.uniq(arr)", "[1,'1']");
+    testEvalToBe("arr=[1,'1']; List.uniq(arr)", '[1,"1"]');
     testEvalToBe(
       "arr=[1,1, 'test', 'test', false, false, true]; List.uniq(arr)",
-      "[1,'test',false,true]"
+      '[1,"test",false,true]'
     );
     testEvalToBe(
       "arr=[1,2,normal(50,1)]; List.uniq(arr)",
@@ -146,9 +146,9 @@ describe("List functions", () => {
   });
 
   describe("join", () => {
-    testEvalToBe("arr=['a', 'b', 'c']; List.join(arr, '-')", "'a-b-c'");
-    testEvalToBe("arr=['a', 'b', 'c']; List.join(arr, ' ')", "'a b c'");
-    testEvalToBe("arr=['a', 'b', 'c']; List.join(arr)", "'a,b,c'");
+    testEvalToBe("arr=['a', 'b', 'c']; List.join(arr, '-')", '"a-b-c"');
+    testEvalToBe("arr=['a', 'b', 'c']; List.join(arr, ' ')", '"a b c"');
+    testEvalToBe("arr=['a', 'b', 'c']; List.join(arr)", '"a,b,c"');
   });
 
   describe("flatten", () => {

--- a/packages/squiggle-lang/__tests__/library/sym_test.ts
+++ b/packages/squiggle-lang/__tests__/library/sym_test.ts
@@ -122,7 +122,7 @@ describe("distribution functions", () => {
     testEvalToBe("stdev(Sym.logistic(5,1))", "1.8137993642342178");
   });
   describe("toString", () => {
-    testEvalToBe("toString(Sym.normal(5,2))", "'Normal(5,2)'");
+    testEvalToBe("toString(Sym.normal(5,2))", '"Normal(5,2)"');
   });
   describe("normalize", () => {
     testEvalToBe("normalize(Sym.normal(5,2))", "Normal(5,2)");

--- a/packages/squiggle-lang/__tests__/reducer/annotations_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/annotations_test.ts
@@ -4,7 +4,7 @@ import { testEvalToBe, testEvalToMatch } from "../helpers/reducerHelpers.js";
 describe("annotations", () => {
   describe(".parameters", () => {
     testEvalToBe("f(x: [3,5]) = x; List.length(f.parameters)", "1");
-    testEvalToBe("f(x: [3,5]) = x; f.parameters[0].name", "'x'");
+    testEvalToBe("f(x: [3,5]) = x; f.parameters[0].name", '"x"');
     testEvalToBe("f(x: [3,5]) = x; f.parameters[0].domain.min", "3");
     testEvalToBe("f(x: [3,5]) = x; f.parameters[0].domain.max", "5");
   });

--- a/packages/squiggle-lang/__tests__/reducer/ternaryOperator_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/ternaryOperator_test.ts
@@ -1,14 +1,14 @@
 import { testEvalToBe, testToExpression } from "../helpers/reducerHelpers.js";
 
 describe("Parse ternary operator", () => {
-  testToExpression("true ? 'YES' : 'NO'", "true ? ('YES') : ('NO')");
+  testToExpression("true ? 'YES' : 'NO'", 'true ? ("YES") : ("NO")');
 });
 
 describe("Evaluate ternary operator", () => {
-  testEvalToBe("true ? 'YES' : 'NO'", "'YES'");
-  testEvalToBe("false ? 'YES' : 'NO'", "'NO'");
-  testEvalToBe("2 > 1 ? 'YES' : 'NO'", "'YES'");
-  testEvalToBe("2 <= 1 ? 'YES' : 'NO'", "'NO'");
+  testEvalToBe("true ? 'YES' : 'NO'", '"YES"');
+  testEvalToBe("false ? 'YES' : 'NO'", '"NO"');
+  testEvalToBe("2 > 1 ? 'YES' : 'NO'", '"YES"');
+  testEvalToBe("2 <= 1 ? 'YES' : 'NO'", '"NO"');
   testEvalToBe(
     "1+1 ? 'YES' : 'NO'",
     "Error(Expected type: Boolean but got: Number)"

--- a/packages/squiggle-lang/__tests__/reducer/various_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/various_test.ts
@@ -34,7 +34,7 @@ describe("eval", () => {
       await expectEvalToBe("[]", "[]");
     });
     testEvalToBe("[1, 2, 3]", "[1,2,3]");
-    testEvalToBe("['hello', 'world']", "['hello','world']");
+    testEvalToBe("['hello', 'world']", '["hello","world"]');
     testEvalToBe("([0,1,2])[1]", "1");
     testDescriptionEvalToBe(
       "index not found",
@@ -110,7 +110,7 @@ describe("test exceptions", () => {
   testDescriptionEvalToBe(
     "javascript exception",
     "javascriptraise('div by 0')",
-    "Error(JS Exception: Error: 'div by 0')"
+    'Error(JS Exception: Error: "div by 0")'
   );
   // testDescriptionEvalToBe(
   //   "rescript exception",

--- a/packages/squiggle-lang/__tests__/value/value_test.ts
+++ b/packages/squiggle-lang/__tests__/value/value_test.ts
@@ -3,7 +3,7 @@ import { vNumber, vString } from "../../src/value/index.js";
 describe("Value", () => {
   test("toString", () => {
     expect(vNumber(1).toString()).toEqual("1");
-    expect(vString("a").toString()).toEqual("'a'");
+    expect(vString("a").toString()).toEqual('"a"');
   });
 });
 

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -165,7 +165,7 @@ class VString extends BaseValue {
     super();
   }
   toString() {
-    return `'${this.value}'`;
+    return JSON.stringify(this.value);
   }
 }
 export const vString = (v: string) => new VString(v);


### PR DESCRIPTION
Fixes #1696

Better than previous PR on the issue.

Speaking of testing and Jest — now (since #2067) in many cases we can replace manual testcase escaping with JSON.stringify — I guess we can trust that one more than ourselves.

And maybe while we're at it, either find a hack to get the Jest stack printout to show correct locations of errors, or move `.toBe()`  upwards. 
![image](https://github.com/quantified-uncertainty/squiggle/assets/6453661/dae46864-b39c-4006-99fd-5cef136c6ce6)
Searching those mistargeted traces is really time consuming in big test changes like this one