### PR TITLE
Change precision of SummaryTable to 3

### DIFF
--- a/packages/components/src/components/DistributionsChart/SummaryTable.tsx
+++ b/packages/components/src/components/DistributionsChart/SummaryTable.tsx
@@ -51,7 +51,7 @@ const SummaryTableRow: FC<SummaryTableRowProps> = ({
     x: result<number, SqDistributionError>
   ): React.ReactNode => {
     if (x.ok) {
-      return <NumberShower number={x.value} />;
+      return <NumberShower number={x.value} precision={3} />;
     } else {
       return (
         <TextTooltip text={x.value.toString()}>


### PR DESCRIPTION
<img width="1329" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/284939dc-af57-4dc2-bc13-6441b26095dc">

Is often not needed, but gets around this issue:
https://github.com/quantified-uncertainty/squiggle/issues/2212

I imagine later we could do something better here.