### PR TITLE
Fix dist function tooltip positioning

### DIFF
--- a/packages/components/src/components/FunctionChart/DistFunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart/DistFunctionChart.tsx
@@ -1,6 +1,6 @@
-import { flip, offset, useFloating } from "@floating-ui/react";
+import { FloatingPortal, flip, offset, useFloating } from "@floating-ui/react";
 import * as d3 from "d3";
-import { FC, useCallback, useMemo, useRef } from "react";
+import { FC, useCallback, useContext, useMemo, useRef } from "react";
 
 import {
   Env,
@@ -27,6 +27,7 @@ import { canvasClasses, unwrapOrFailure } from "../../lib/utility.js";
 import { DistributionsChart } from "../DistributionsChart/index.js";
 import { ImageErrors } from "./ImageErrors.js";
 import { getFunctionImage } from "./utils.js";
+import { TailwindContext } from "@quri/ui";
 
 type FunctionChart1DistProps = {
   plot: SqDistFnPlot;
@@ -277,21 +278,26 @@ export const DistFunctionChart: FC<FunctionChart1DistProps> = ({
     placement: "bottom-start",
     middleware: [offset(4), flip()],
   });
+  const { selector: tailwindSelector } = useContext(TailwindContext);
 
   const renderChartAtCursor = () => {
     return (
-      <div
-        ref={refs.setFloating}
-        className="z-30 rounded-md bg-white shadow-lg border"
-        style={{
-          position: strategy,
-          top: y ?? 0,
-          left: x ?? 0,
-          width: refs.reference.current?.getBoundingClientRect().width,
-        }}
-      >
-        {distChartAtCursor}
-      </div>
+      <FloatingPortal>
+        <div className={tailwindSelector}>
+          <div
+            ref={refs.setFloating}
+            className="z-30 rounded-md bg-white shadow-lg border"
+            style={{
+              position: strategy,
+              top: y ?? 0,
+              left: x ?? 0,
+              width: refs.reference.current?.getBoundingClientRect().width,
+            }}
+          >
+            {distChartAtCursor}
+          </div>
+        </div>
+      </FloatingPortal>
     );
   };
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -80,4 +80,7 @@ export {
 
 export { useToast, WithToasts } from "./components/WithToasts/index.js";
 
-export { TailwindProvider } from "./components/TailwindProvider.js";
+export {
+  TailwindProvider,
+  TailwindContext,
+} from "./components/TailwindProvider.js";


### PR DESCRIPTION
Followup to https://github.com/quantified-uncertainty/squiggle/pull/2149#issuecomment-1659485348.

Previous version didn't use FloatingPortal, because the behavior on scroll was weird in the storybook.

This caused a bug mentioned in the link above; we wrap the viewer in multiple overflow-auto areas, so rendering the tooltip inside the scroll area wasn't possible (it didn't fit). Floating-ui tried to flip the tooltip, but then it got covered by Nextra's menu.

In this version, I render the tooltip in the `<body>`-level portal. Behavior on scroll in storybook is slightly buggy because of that, but it's not important.

<img width="882" alt="Captura de pantalla 2023-08-07 a la(s) 16 11 57" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/50a9f4c2-4900-4623-b81d-3dd0226000ca">

<img width="914" alt="Captura de pantalla 2023-08-07 a la(s) 16 11 51" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/b8b0f9b0-2e0f-418e-8e6e-177510f348ab">
