### PR TITLE
Support Identifier shorthand entries in dict AST nodes; preserve on formatting

### DIFF
--- a/packages/prettier-plugin/test/dicts.test.ts
+++ b/packages/prettier-plugin/test/dicts.test.ts
@@ -9,6 +9,10 @@ describe("dicts", () => {
     expect(await format("{foo: 5}")).toBe("{ foo: 5 }");
   });
 
+  test("shorthand", async () => {
+    expect(await format("{foo, bar: bar, baz}")).toBe("{ foo, bar: bar, baz }");
+  });
+
   test("simple string key", async () => {
     expect(await format('{"fooBar123": 5}')).toBe("{ fooBar123: 5 }");
   });

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -170,15 +170,13 @@ describe("Peggy parse", () => {
       "(Program (Dict (KeyValue 'a' 1) (KeyValue 'b' 2)))"
     );
     testParse(
-      "{a, b, }",
-      "(Program (Dict (KeyValue 'a' :a) (KeyValue 'b' :b)))"
+      "{a: 1, b: 2,}",
+      "(Program (Dict (KeyValue 'a' 1) (KeyValue 'b' 2)))"
     );
-    testParse("{a, b}", "(Program (Dict (KeyValue 'a' :a) (KeyValue 'b' :b)))");
-    testParse(
-      "{a, b: 2}",
-      "(Program (Dict (KeyValue 'a' :a) (KeyValue 'b' 2)))"
-    );
-    testParse("{a,}", "(Program (Dict (KeyValue 'a' :a)))");
+    testParse("{a, b, }", "(Program (Dict :a :b))");
+    testParse("{a, b}", "(Program (Dict :a :b))");
+    testParse("{a, b: 2}", "(Program (Dict :a (KeyValue 'b' 2)))");
+    testParse("{a,}", "(Program (Dict :a))");
     testParse(
       "{1+0: 1, 2+0: 2}",
       "(Program (Dict (KeyValue (InfixCall + 1 0) 1) (KeyValue (InfixCall + 2 0) 2)))"

--- a/packages/squiggle-lang/__tests__/public_smoke_test.ts
+++ b/packages/squiggle-lang/__tests__/public_smoke_test.ts
@@ -28,9 +28,6 @@ describe("Dict", () => {
   test("Return dict", async () => {
     expect((await testRun("{a:1}")).toString()).toEqual("{a: 1}");
   });
-  test("Inherit syntax for dicts", async () => {
-    expect((await testRun("a=1; {a, }")).toString()).toEqual("{a: 1}");
-  });
 });
 
 describe("Continues", () => {

--- a/packages/squiggle-lang/__tests__/reducer/functionAssignment_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/functionAssignment_test.ts
@@ -1,4 +1,8 @@
-import { testEvalToBe, testToExpression } from "../helpers/reducerHelpers.js";
+import {
+  MySkip,
+  testEvalToBe,
+  testToExpression,
+} from "../helpers/reducerHelpers.js";
 
 describe("Parse function assignment", () => {
   testToExpression("f(x)=x", "f = {|x| {x}}");
@@ -11,4 +15,9 @@ describe("Evaluate function assignment", () => {
 
 describe("Shadowing", () => {
   testEvalToBe("x = 5; f(y) = x*y; x = 6; f(2)", "10");
+});
+
+describe("Shadowing builtins", () => {
+  // TODO, https://github.com/quantified-uncertainty/squiggle/issues/1336
+  MySkip.testEvalToBe("add(x, y) = x * y; 2 + 3", "5");
 });

--- a/packages/squiggle-lang/__tests__/reducer/various_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/various_test.ts
@@ -71,6 +71,9 @@ describe("eval", () => {
     }`,
         "{a: 1,b: 2}"
       ));
+    test("shorthand", async () => {
+      await expectEvalToBe("a=1; {a, b: a }", "{a: 1,b: 1}");
+    });
   });
 
   describe("multi-line", () => {

--- a/packages/squiggle-lang/src/ast/peggyParser.peggy
+++ b/packages/squiggle-lang/src/ast/peggyParser.peggy
@@ -359,11 +359,10 @@ dictConstructor 'dict'
   / '{' _nl args:array_dictEntries _nl '}'
     { return h.nodeDict(args, location()); }
 
-  array_dictEntries = @(keyValuePair / keyValueInherit)| 1.., commaSeparator|commaSeparator?
-
-  keyValueInherit
-    = key:identifier
-    { return h.nodeKeyValue(key, key, location()); }
+  array_dictEntries = @(
+    keyValuePair
+    / identifier // shorthand
+  )| 1.., commaSeparator|commaSeparator?
 
   keyValuePair
     = key:expression _ ':' _nl value:expression

--- a/packages/squiggle-lang/src/public/SqValuePath.ts
+++ b/packages/squiggle-lang/src/public/SqValuePath.ts
@@ -42,20 +42,28 @@ export class SqValuePath {
         case "Dict": {
           for (const pair of ast.elements) {
             if (
-              locationContains(
+              !locationContains(
                 {
                   source: ast.location.source,
-                  start: pair.key.location.start,
-                  end: pair.value.location.end,
+                  start: pair.location.start,
+                  end: pair.location.end,
                 },
                 offset
-              ) &&
+              )
+            ) {
+              continue;
+            }
+
+            if (
+              pair.type === "KeyValue" &&
               pair.key.type === "String" // only string keys are supported
             ) {
               return [
                 { type: "string", value: pair.key.value },
                 ...findLoop(pair.value),
               ];
+            } else if (pair.type === "Identifier") {
+              return [{ type: "string", value: pair.value }]; // this is a final node, no need to findLoop recursively
             }
           }
           return [];


### PR DESCRIPTION
Fixes #2132.

Note: this breaks again #1336, which was partially fixed by accident with my compiler changes in 0.8.0 release.

I've added a (skipped) test for it and will fix it properly later.