### PR TITLE
Hub /status page

### DIFF
--- a/packages/hub/schema.graphql
+++ b/packages/hub/schema.graphql
@@ -35,6 +35,12 @@ interface Error {
   message: String!
 }
 
+type GlobalStatistics {
+  models: Int!
+  relativeValuesDefinitions: Int!
+  users: Int!
+}
+
 type Me {
   email: String
   username: String
@@ -195,6 +201,7 @@ type PageInfo {
 }
 
 type Query {
+  globalStatistics: GlobalStatistics!
   me: Me!
   model(input: QueryModelInput!): QueryModelResult!
   models(after: String, before: String, first: Int, last: Int): ModelConnection!

--- a/packages/hub/src/app/status/StatusPage.tsx
+++ b/packages/hub/src/app/status/StatusPage.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import StatusPageQueryNode, {
+  StatusPageQuery,
+} from "@/__generated__/StatusPageQuery.graphql";
+import { H1 } from "@/components/ui/Headers";
+import { SerializablePreloadedQuery } from "@/relay/loadSerializableQuery";
+import { useSerializablePreloadedQuery } from "@/relay/useSerializablePreloadedQuery";
+import { FC } from "react";
+import { usePreloadedQuery } from "react-relay";
+import { graphql } from "relay-runtime";
+
+const Query = graphql`
+  query StatusPageQuery {
+    globalStatistics {
+      users
+      models
+      relativeValuesDefinitions
+    }
+  }
+`;
+
+const StatRow: FC<{ name: string; value: number }> = ({ name, value }) => (
+  <tr className="border">
+    <td className="p-4 font-bold">{name}</td>
+    <td className="p-4">{value}</td>
+  </tr>
+);
+
+export const StatusPage: FC<{
+  query: SerializablePreloadedQuery<
+    typeof StatusPageQueryNode,
+    StatusPageQuery
+  >;
+}> = ({ query }) => {
+  const queryRef = useSerializablePreloadedQuery(query);
+  const { globalStatistics: stats } = usePreloadedQuery(Query, queryRef);
+
+  return (
+    <div>
+      <H1>Global statistics</H1>
+      <table className="table-auto mt-8">
+        <tbody>
+          <StatRow name="Users" value={stats.users} />
+          <StatRow name="Models" value={stats.models} />
+          <StatRow
+            name="Relative Values Definitions"
+            value={stats.relativeValuesDefinitions}
+          />
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/packages/hub/src/app/status/page.tsx
+++ b/packages/hub/src/app/status/page.tsx
@@ -1,0 +1,19 @@
+import QueryNode, {
+  StatusPageQuery,
+} from "@/__generated__/StatusPageQuery.graphql";
+import { NarrowPageLayout } from "@/components/layout/NarrowPageLayout";
+import { loadSerializableQuery } from "@/relay/loadSerializableQuery";
+import { StatusPage } from "./StatusPage";
+
+export default async function OuterFrontPage() {
+  const query = await loadSerializableQuery<typeof QueryNode, StatusPageQuery>(
+    QueryNode.params,
+    {}
+  );
+
+  return (
+    <NarrowPageLayout>
+      <StatusPage query={query} />
+    </NarrowPageLayout>
+  );
+}

--- a/packages/hub/src/graphql/queries/globalStatistics.ts
+++ b/packages/hub/src/graphql/queries/globalStatistics.ts
@@ -1,0 +1,27 @@
+import { builder } from "@/graphql/builder";
+import { prisma } from "@/prisma";
+
+const GlobalStatistics = builder.simpleObject("GlobalStatistics", {}, (t) => ({
+  users: t.int({
+    async resolve() {
+      return await prisma.user.count();
+    },
+  }),
+  models: t.int({
+    async resolve() {
+      return await prisma.model.count();
+    },
+  }),
+  relativeValuesDefinitions: t.int({
+    async resolve() {
+      return await prisma.relativeValuesDefinition.count();
+    },
+  }),
+}));
+
+builder.queryField("globalStatistics", (t) =>
+  t.field({
+    type: GlobalStatistics,
+    resolve: () => ({}),
+  })
+);

--- a/packages/hub/src/graphql/schema.ts
+++ b/packages/hub/src/graphql/schema.ts
@@ -11,6 +11,7 @@ import "./queries/models";
 import "./queries/runSquiggle";
 import "./queries/userByUsername";
 import "./queries/users";
+import "./queries/globalStatistics";
 
 import "./mutations/createRelativeValuesDefinition";
 import "./mutations/createSquiggleSnippetModel";


### PR DESCRIPTION
<img width="1496" alt="Captura de pantalla 2023-08-09 a la(s) 14 59 06" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/c499828d-27f0-4d49-a68e-dae214bd09b5">

`/status` URL is parallel to https://metaforecast.org/status.

Stats are global (will count private models too) and public. Mostly for internal use, no need to post this URL anywhere.