### PR TITLE
Relation indices

### DIFF
--- a/packages/hub/prisma/migrations/20230809204921_relation_indices/migration.sql
+++ b/packages/hub/prisma/migrations/20230809204921_relation_indices/migration.sql
@@ -1,0 +1,26 @@
+-- CreateIndex
+CREATE INDEX "Account_userId_idx" ON "Account"("userId");
+
+-- CreateIndex
+CREATE INDEX "Model_ownerId_idx" ON "Model"("ownerId");
+
+-- CreateIndex
+CREATE INDEX "ModelRevision_modelId_idx" ON "ModelRevision"("modelId");
+
+-- CreateIndex
+CREATE INDEX "RelativeValuesDefinition_ownerId_idx" ON "RelativeValuesDefinition"("ownerId");
+
+-- CreateIndex
+CREATE INDEX "RelativeValuesDefinitionRevision_definitionId_idx" ON "RelativeValuesDefinitionRevision"("definitionId");
+
+-- CreateIndex
+CREATE INDEX "RelativeValuesExport_modelRevisionId_idx" ON "RelativeValuesExport"("modelRevisionId");
+
+-- CreateIndex
+CREATE INDEX "RelativeValuesExport_definitionId_idx" ON "RelativeValuesExport"("definitionId");
+
+-- CreateIndex
+CREATE INDEX "RelativeValuesPairCache_exportId_idx" ON "RelativeValuesPairCache"("exportId");
+
+-- CreateIndex
+CREATE INDEX "Session_userId_idx" ON "Session"("userId");

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Account {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+  @@index([userId])
 }
 
 model Session {
@@ -49,7 +50,10 @@ model Session {
   sessionToken String   @unique
   userId       String
   expires      DateTime
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }
 
 model User {
@@ -99,6 +103,7 @@ model Model {
   currentRevisionId String?        @unique
 
   @@unique([slug, ownerId])
+  @@index([ownerId])
   @@index([createdAt])
 }
 
@@ -119,6 +124,8 @@ model ModelRevision {
 
   // required by Prisma, but unused since `model` field should point at the same entity
   currentRevisionModel Model? @relation("CurrentRevision")
+
+  @@index([modelId])
 }
 
 model SquiggleSnippet {
@@ -152,6 +159,7 @@ model RelativeValuesDefinition {
 
   @@unique([slug, ownerId])
   @@index([createdAt])
+  @@index([ownerId])
 }
 
 model RelativeValuesDefinitionRevision {
@@ -170,6 +178,8 @@ model RelativeValuesDefinitionRevision {
 
   // required by Prisma, but unused since `model` field should point at the same entity
   relativeValuesDefinition RelativeValuesDefinition? @relation("CurrentRevision")
+
+  @@index([definitionId])
 }
 
 // Note that model revisions are associated with definitions (and not definition revisions).
@@ -187,6 +197,8 @@ model RelativeValuesExport {
   cache RelativeValuesPairCache[]
 
   @@unique([modelRevisionId, definitionId, variableName], name: "uniqueKey")
+  @@index([modelRevisionId]) // duplicates the @@unique above and probably not necessary, but doesn't hurt
+  @@index([definitionId])
 }
 
 model RelativeValuesPairCache {
@@ -203,4 +215,6 @@ model RelativeValuesPairCache {
   // { median, mean, min, max, uncertainty } object.
   // Maybe this should be split into postgres columns later.
   result Json?
+
+  @@index([exportId])
 }

--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -306,7 +306,7 @@ export function createSquigglePrinter(
             "}",
           ]);
         case "String":
-          return ['"', node.value, '"'];
+          return [JSON.stringify(node.value)];
         case "Ternary":
           return [
             node.kind === "C" ? [] : "if ",

--- a/packages/prettier-plugin/test/strings.test.ts
+++ b/packages/prettier-plugin/test/strings.test.ts
@@ -1,0 +1,22 @@
+import { format } from "./helpers.js";
+
+describe("strings", () => {
+  test("simple string", async () => {
+    expect(await format(`"foo"`)).toBe(`"foo"`);
+  });
+
+  test("single quote string", async () => {
+    expect(await format(`'foo'`)).toBe(`"foo"`);
+  });
+
+  test("single quote string with double quote inside", async () => {
+    expect(await format(`'foo: "bar"'`)).toBe(`"foo: \\"bar\\""`);
+  });
+
+  // https://github.com/quantified-uncertainty/squiggle/issues/2207
+  test("string with escaped characters", async () => {
+    expect(await format(`"This is something \\" \\' \\" else"`)).toBe(
+      `"This is something \\" ' \\" else"`
+    );
+  });
+});


### PR DESCRIPTION
Similar to https://github.com/quantified-uncertainty/metaforecast/pull/102.

Probably won't improve Squiggle Hub performance immediately (our DB is tiny and full scans are not a problem), but will help in the long run.

This PR is done on top of #2216 to keep the migration history linear.