### PR TITLE
Swap row/column order in table chart dimension

### DIFF
--- a/.changeset/tall-dragons-cheer.md
+++ b/.changeset/tall-dragons-cheer.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Swap row/column order in table chart dimension

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -144,9 +144,9 @@ export const getBoxProps = (
           <div className="items-center flex space-x-1">
             <TableCellsIcon size={14} className="flex opacity-60" />
             <div>
-              {table.columnCount}
-              <span className="opacity-60">x</span>
               {table.rowCount}
+              <span className="opacity-60">x</span>
+              {table.columnCount}
             </div>
           </div>
         ),


### PR DESCRIPTION
The standard order for table dimentions is `rows x columns` (see e.g. https://en.wikipedia.org/wiki/Matrix_(mathematics))