### PR TITLE
Equidistant function plot points

### DIFF
--- a/.changeset/tender-gorillas-hear.md
+++ b/.changeset/tender-gorillas-hear.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+pick function points for charting equidistantly on mapped scale

--- a/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
@@ -32,7 +32,7 @@ export const NumericFunctionChart: FC<Props> = ({
   const height = innerHeight + 30; // consider paddings, should match suggestedPadding below
   const { cursor, initCursor } = useCanvasCursor();
 
-  const { functionImage, errors } = useMemo(
+  const { functionImage, errors, xScale } = useMemo(
     () => getFunctionImage(plot, environment),
     [plot, environment]
   );
@@ -40,14 +40,6 @@ export const NumericFunctionChart: FC<Props> = ({
   const draw = useCallback(
     ({ context, width }: DrawContext) => {
       context.clearRect(0, 0, width, height);
-
-      const xScale = sqScaleToD3(plot.xScale);
-      xScale.domain(
-        d3.extent(
-          functionImage.filter((d) => isFinite(d.x)),
-          (d) => d.x
-        ) as [number, number]
-      );
 
       const yScale = sqScaleToD3(plot.yScale);
       yScale.domain(

--- a/packages/components/src/components/FunctionChart/index.tsx
+++ b/packages/components/src/components/FunctionChart/index.tsx
@@ -115,8 +115,8 @@ export const FunctionChart: FC<FunctionChartProps> = ({
       return (
         <NumericFunctionChart
           plot={plot}
-          height={height}
           environment={environment}
+          height={height}
         />
       );
     }

--- a/packages/components/src/components/FunctionChart/utils.ts
+++ b/packages/components/src/components/FunctionChart/utils.ts
@@ -22,12 +22,22 @@ function rangeByCount({
   scale: ScaleContinuousNumeric<number, number, never>;
   count: number;
 }) {
+  const backupRange = scale.range();
   scale.range([0, count - 1]);
+
+  // Otherwise, precision issues can cause out-of-domain values.
+  // That would be bad because annotated functions check their parameters strictly.
+  const backupClamp = scale.clamp();
+  scale.clamp(true);
+
   const items: number[] = [];
   for (let i = 0; i < count; i++) {
     items.push(scale.invert(i));
   }
-  scale.range([0, 1]); // reset to default range
+
+  scale.range(backupRange);
+  scale.clamp(backupClamp);
+
   return items;
 }
 

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -224,11 +224,11 @@ export const getBoxProps = (
               return (
                 <DistFunctionChart
                   plot={plot}
-                  height={settings.chartHeight}
                   environment={{
                     sampleCount: environment.sampleCount / 10,
                     xyPointLength: environment.xyPointLength / 10,
                   }}
+                  height={settings.chartHeight}
                 />
               );
             }
@@ -236,8 +236,8 @@ export const getBoxProps = (
               return (
                 <ScatterChart
                   plot={plot}
-                  height={settings.chartHeight}
                   environment={environment}
+                  height={settings.chartHeight}
                 />
               );
             case "relativeValues":

--- a/packages/components/src/stories/SquiggleChart/Functions.stories.tsx
+++ b/packages/components/src/stories/SquiggleChart/Functions.stories.tsx
@@ -44,6 +44,29 @@ Plot.numericFn({
   },
 };
 
+export const FairLogScaleSampling: Story = {
+  name: "Fair log scale sampling",
+  args: {
+    code: sq`
+numericPlot = Plot.numericFn({
+  fn: {|t| t < 5 ? 1000 : t^2},
+  xScale: Scale.log({
+    min: 1,
+    max: 100
+  })
+})
+
+distPlot = Plot.distFn({
+  fn: {|t| t < 5 ? pointMass(1000) : t^2 to t^2 + 1000},
+  xScale: Scale.log({
+    min: 1,
+    max: 100
+  })
+})
+`,
+  },
+};
+
 export const WithInfiniteValues: Story = {
   name: "Numeric, With Infinite Values",
   args: {


### PR DESCRIPTION
Fixes #2147.

Also, this rolls back x scale value filtration that we discussed in https://github.com/quantified-uncertainty/squiggle/pull/2071/files#r1269871844. The domain should be detected before the function image for points to be picked correctly.

[Before:](https://www.squiggle-language.com/playground#code=eNqrVkpJTUsszSlxzk9JVbJSCsjJL9HLK81NLcpMdsvTqI7JU1BIy7NSqK4pqVEoUbBRMFWwVzA0MDBQsFIoiTOq1QEpqAhOTsxJtVIAU3o5%2BekQfQoKuZlArYY6UE5ihRVIK4hXqxmTV6upVAsAHLsmnA%3D%3D)
<img width="747" alt="Captura de pantalla 2023-08-09 a la(s) 21 45 19" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/482c8970-9d9d-4c72-8fc6-9277d7e2309c">

[After:](https://squiggle-website-git-equidistant-ecf8c9-quantified-uncertainty.vercel.app/playground#code=eNqrVkpJTUsszSlxzk9JVbJSCsjJL9HLK81NLcpMdsvTqI7JU1BIy7NSqK4pqVEoUbBRMFWwVzA0MDBQsFIoiTOq1QEpqAhOTsxJtVIAU3o5%2BekQfQoKuZlArYY6UE5ihRVIK4hXqxmTV6upVAsAHLsmnA%3D%3D)
<img width="739" alt="Captura de pantalla 2023-08-09 a la(s) 21 45 44" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/fdfff1d1-bd0b-4835-a738-194a317d4aa0">

In some cases, e.g. in the examples above, there's less smoothing than before. But I think this is still an improvement on average, and in typical log scale charts it won't be noticeable.