### PR TITLE
Vercel deployments cleanup script

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["squiggle-website", "@quri/hub"]
+  "ignore": ["squiggle-website", "@quri/hub", "@quri/ops"]
 }

--- a/.github/workflows/cleanup-vercel-deployments.yml
+++ b/.github/workflows/cleanup-vercel-deployments.yml
@@ -1,0 +1,27 @@
+name: Clean up Vercel deployments
+
+on:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "42 19 * * 0"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run cleanup script
+        working-directory: ./packages/ops
+        env:
+          VERCEL_API_TOKEN: "${{ secrets.VERCEL_API_TOKEN }}"
+        run: tsx ./scripts/cleanup-vercel-deployments.tsx

--- a/packages/ops/README.md
+++ b/packages/ops/README.md
@@ -1,0 +1,3 @@
+This private package includes various scripts for maintaining this repository.
+
+Terraform configs for QURI infrastructure are located in a separate repo, https://github.com/quantified-uncertainty/ops.

--- a/packages/ops/package.json
+++ b/packages/ops/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@quri/ops",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "@types/node": "^20.4.7",
+    "tsx": "^3.12.7",
+    "typescript": "^5.1.6"
+  },
+  "dependencies": {
+    "zod": "^3.21.4"
+  }
+}

--- a/packages/ops/scripts/cleanup-vercel-deployments.ts
+++ b/packages/ops/scripts/cleanup-vercel-deployments.ts
@@ -1,0 +1,160 @@
+import { z } from "zod";
+
+const VERCEL_API_TOKEN = process.env.VERCEL_API_TOKEN;
+
+const teamId = "quantified-uncertainty";
+const project = "quri-hub";
+const keepDays = 3;
+
+type ApiParams = ConstructorParameters<typeof URLSearchParams>[0];
+
+async function apiCall(method: string, endpoint: string, params?: ApiParams) {
+  let url = `https://api.vercel.com/${endpoint}`;
+  if (params) {
+    url += `?${new URLSearchParams(params)}`;
+  }
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${VERCEL_API_TOKEN}`,
+    },
+  });
+  const json = (await response.json()) as unknown;
+  if (typeof json !== "object" || !json) {
+    throw new Error(`Expected object, got: ${json}`);
+  }
+  if ("error" in json) {
+    throw new Error(JSON.stringify(json));
+  }
+  if (process.env.DEBUG) {
+    console.log(json);
+  }
+  return json;
+}
+
+const singleDeploymentSchema = z.object({
+  id: z.string(),
+  recommendedUnit: z.nullable(z.string()).optional(),
+  createdAt: z.number(),
+});
+
+async function findCurrentProductionDeployment() {
+  // https://vercel.com/docs/rest-api/endpoints#get-a-deployment-by-id-or-url
+  const json = await apiCall("GET", "v13/deployments/squigglehub.org", {
+    teamId,
+    state: "READY",
+    target: "production",
+  });
+
+  return singleDeploymentSchema.parse(json);
+}
+
+const paginationSchema = z.object({
+  next: z.nullable(z.number()),
+});
+
+const deploymentsSchema = z.object({
+  pagination: paginationSchema,
+  deployments: z.array(
+    z.object({
+      uid: z.string(),
+      name: z.string(),
+      created: z.number(),
+      meta: z.object({
+        githubCommitRef: z.string(),
+      }),
+    })
+  ),
+});
+
+type Deployment = z.infer<typeof deploymentsSchema>["deployments"][number];
+
+async function deleteDeployment(deployment: Deployment) {
+  // https://vercel.com/docs/rest-api/endpoints#delete-a-deployment
+  if (deployment.name !== project) {
+    throw new Error(
+      `Expected a deployment from ${project}, got: ${deployment.name}`
+    );
+  }
+  console.log(
+    `Deleting ${deployment.uid}, branch ${deployment.meta.githubCommitRef}`
+  );
+  await apiCall("DELETE", `/v13/deployments/${deployment.uid}`, { teamId });
+}
+
+async function* fetchDeployments(params: Record<string, string>) {
+  // https://vercel.com/docs/rest-api/endpoints#list-deployments
+  let pageParams: ApiParams = { ...params };
+  while (1) {
+    const json = await apiCall("GET", "v6/deployments", pageParams);
+
+    const response = deploymentsSchema.parse(json);
+    for (const deployment of response.deployments) {
+      yield deployment;
+    }
+    if (response.pagination.next) {
+      pageParams.until = String(response.pagination.next);
+    } else {
+      break;
+    }
+  }
+}
+
+async function cleanupOldProductionDeployments() {
+  const currentDeployment = await findCurrentProductionDeployment();
+
+  for await (const deployment of fetchDeployments({
+    teamId,
+    app: project,
+    state: "READY",
+    target: "production",
+  })) {
+    if (deployment.uid === currentDeployment.id) {
+      // this is a current deployment
+      console.log(`Keeping ${deployment.uid}, it's a current deployement`);
+      continue;
+    }
+
+    if (deployment.created >= currentDeployment.createdAt) {
+      // too fresh, there might be a race condition and this is the real current deployment
+      console.log(
+        `Keeping ${deployment.uid}, it was created after current deployment`
+      );
+      continue;
+    }
+
+    if (
+      deployment.created >=
+      currentDeployment.createdAt - 86_400_000 * keepDays
+    ) {
+      console.log(`Keeping ${deployment.uid}, it's too fresh`);
+      continue;
+    }
+
+    await deleteDeployment(deployment);
+  }
+}
+
+async function cleanupOldPreviewDeployments() {
+  const now = new Date().getTime();
+  for await (const deployment of fetchDeployments({
+    teamId,
+    app: project,
+    state: "READY",
+    target: "preview",
+  })) {
+    if (deployment.created >= now - 86400 * keepDays) {
+      console.log(`Keeping ${deployment.uid}, it's too fresh`);
+      continue;
+    }
+
+    await deleteDeployment(deployment);
+  }
+}
+
+async function main() {
+  await cleanupOldProductionDeployments();
+  await cleanupOldPreviewDeployments();
+}
+
+main();

--- a/packages/ops/scripts/cleanup-vercel-deployments.ts
+++ b/packages/ops/scripts/cleanup-vercel-deployments.ts
@@ -106,7 +106,6 @@ async function cleanupOldProductionDeployments() {
   for await (const deployment of fetchDeployments({
     teamId,
     app: project,
-    state: "READY",
     target: "production",
   })) {
     if (deployment.uid === currentDeployment.id) {
@@ -140,7 +139,6 @@ async function cleanupOldPreviewDeployments() {
   for await (const deployment of fetchDeployments({
     teamId,
     app: project,
-    state: "READY",
     target: "preview",
   })) {
     if (deployment.created >= now - 86400 * keepDays) {

--- a/packages/ops/tsconfig.json
+++ b/packages/ops/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "es2020",
+    "moduleResolution": "node16",
+    "target": "es2022",
+    "esModuleInterop": true,
+    "rootDir": "scripts",
+    "noEmit": true,
+    // type check settings
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["scripts/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,22 @@ importers:
         specifier: ^3.12.7
         version: 3.12.7
 
+  packages/ops:
+    dependencies:
+      zod:
+        specifier: ^3.21.4
+        version: 3.21.4
+    devDependencies:
+      '@types/node':
+        specifier: ^20.4.7
+        version: 20.4.7
+      tsx:
+        specifier: ^3.12.7
+        version: 3.12.7
+      typescript:
+        specifier: ^5.1.6
+        version: 5.1.6
+
   packages/prettier-plugin:
     dependencies:
       '@quri/squiggle-lang':


### PR DESCRIPTION
I've already ran this locally.

Current approach:
- remove all deployments on `production` environment, except for the current deployment or any deployment that's less than 3 days old compared to the current deployment
- remove all deployments on `preview` environment, except for any deployment that's less than 3 days old

Configured on `quri-hub` only. (I accidentally ran this on all projects once and removed production deployment for website and metaforecast for a few minutes...)

In the future, it should remove preview deployments if there's no open PR, or if there's a newer deployment for that PR. But that would require polling Github API, not just Vercel API.