### PR TITLE
Use named export for styles in README

### DIFF
--- a/.changeset/pretty-paws-behave.md
+++ b/.changeset/pretty-paws-behave.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Update README to include the correct imports for stylesheets

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -47,7 +47,7 @@ It's possible that in the future you might need to change the `content` or `plug
 In addition, you should import common styles (these include styles from the JS libraries that we use in squiggle-components):
 
 ```js
-import "@quri/squiggle-components/dist/common.css";
+import "@quri/squiggle-components/common.css";
 ```
 
 ### 2. Usage without Tailwind
@@ -55,7 +55,7 @@ import "@quri/squiggle-components/dist/common.css";
 You can import the CSS file that we bundle with this library:
 
 ```js
-import "@quri/squiggle-components/dist/full.css";
+import "@quri/squiggle-components/full.css";
 ```
 
 Note that you have to import this CSS file **only if you don't use Tailwind**.
@@ -118,7 +118,7 @@ Then, add `<TailwindProvider>...</TailwindProvider>` on top of your app (it can 
 In addition, you should import common styles (these include styles from the JS libraries that we use in squiggle-components):
 
 ```js
-import "@quri/squiggle-components/dist/common.css";
+import "@quri/squiggle-components/common.css";
 ```
 
 ## Components


### PR DESCRIPTION
When trying to use the `@quri/squiggle-components`, I noticed I couldn't import `dist/common.css` and `dist/full.css` as the `README` suggests.

It seems like the package is configured to alias these files as `common.css` and `full.css` respectively:

https://github.com/quantified-uncertainty/squiggle/blob/209550db06b5d21a5c7e2fb1dcb508df99f6a29f/packages/components/package.json#L174-L184

I think this also reflects the internal usage:

https://github.com/quantified-uncertainty/squiggle/blob/209550db06b5d21a5c7e2fb1dcb508df99f6a29f/packages/website/src/pages/_app.tsx#L3-L8

I've updated the README to match.