### PR TITLE
Autocomplete improvements & editor refactorings

### DIFF
--- a/.changeset/polite-mugs-poke.md
+++ b/.changeset/polite-mugs-poke.md
@@ -1,0 +1,16 @@
+---
+"@quri/squiggle-components": patch
+"@quri/prettier-plugin-squiggle": patch
+---
+
+Autocompletion improvements:
+- suggest local function names
+- suggest parameter names
+- don't suggest unreachable vars (declared below or in unreachable local scopes)
+- different icon for local functions
+
+Editor grammar improvements:
+- functions with 0 parameters don't break the parser
+- trailing expressions are now really optional (they weren't, but Lezer recovered from it so it didn't matter)
+
+Fixed types in prettier-plugin-squiggle for standalone.js.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -20,6 +20,7 @@
     "@floating-ui/react": "^0.24.3",
     "@heroicons/react": "^1.0.6",
     "@hookform/resolvers": "^3.1.1",
+    "@lezer/common": "^1.0.4",
     "@quri/prettier-plugin-squiggle": "workspace:*",
     "@quri/squiggle-lang": "workspace:*",
     "@quri/ui": "workspace:*",
@@ -130,6 +131,12 @@
       "@typescript-eslint"
     ],
     "rules": {
+      "no-constant-condition": [
+        "error",
+        {
+          "checkLoops": false
+        }
+      ],
       "no-console": "warn",
       "@typescript-eslint/no-empty-function": "off",
       "react/react-in-jsx-scope": "off",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,9 +43,9 @@
   "devDependencies": {
     "@jest/globals": "^29.6.2",
     "@juggle/resize-observer": "^3.4.0",
-    "@lezer/generator": "^1.3.0",
+    "@lezer/generator": "^1.4.2",
     "@lezer/highlight": "^1.1.6",
-    "@lezer/lr": "^1.3.9",
+    "@lezer/lr": "^1.3.10",
     "@storybook/addon-actions": "^7.2.1",
     "@storybook/addon-docs": "^7.2.1",
     "@storybook/addon-essentials": "^7.2.1",

--- a/packages/components/src/components/CodeEditor.tsx
+++ b/packages/components/src/components/CodeEditor.tsx
@@ -347,6 +347,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
 
     const setViewDom = useCallback(
       (element: HTMLDivElement | null) => {
+        // TODO: this doesn't work on hot reloading in dev, investigate
         element?.replaceChildren(view.dom);
       },
       [view]

--- a/packages/components/src/components/CodeEditor.tsx
+++ b/packages/components/src/components/CodeEditor.tsx
@@ -347,7 +347,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
 
     const setViewDom = useCallback(
       (element: HTMLDivElement | null) => {
-        // TODO: this doesn't work on hot reloading in dev, investigate
+        // TODO: the editor breaks on hot reloading in storybook, investigate
         element?.replaceChildren(view.dom);
       },
       [view]

--- a/packages/components/src/components/CodeEditor.tsx
+++ b/packages/components/src/components/CodeEditor.tsx
@@ -3,8 +3,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
-  useRef,
   useState,
 } from "react";
 
@@ -13,7 +11,7 @@ import * as prettier from "prettier/standalone";
 import { defaultKeymap } from "@codemirror/commands";
 import { syntaxHighlighting } from "@codemirror/language";
 import { setDiagnostics } from "@codemirror/lint";
-import { Compartment, EditorState } from "@codemirror/state";
+import { Compartment, EditorState, Extension } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 // From basic setup
 import {
@@ -77,6 +75,7 @@ const compUpdateListener = new Compartment();
 const compSubmitListener = new Compartment();
 const compFormatListener = new Compartment();
 const compViewNodeListener = new Compartment();
+const compLineWrapping = new Compartment();
 
 export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
   function CodeEditor(
@@ -130,8 +129,8 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
         compGutter.of([]),
         compUpdateListener.of([]),
         compTheme.of([]),
+        compLineWrapping.of(lineWrapping ? [EditorView.lineWrapping] : []),
         languageSupport,
-        lineWrapping ? [EditorView.lineWrapping] : [],
       ];
 
       const state = EditorState.create({
@@ -225,6 +224,14 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
         ),
       });
     }, [width, height, view]);
+
+    useEffect(() => {
+      view.dispatch({
+        effects: compLineWrapping.reconfigure(
+          lineWrapping ? [EditorView.lineWrapping] : []
+        ),
+      });
+    }, [lineWrapping, view]);
 
     useEffect(() => {
       view.dispatch({

--- a/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
+++ b/packages/components/src/components/FunctionChart/NumericFunctionChart.tsx
@@ -3,6 +3,7 @@ import { FC, useCallback, useMemo } from "react";
 
 import { Env, SqNumericFnPlot } from "@quri/squiggle-lang";
 
+import { sqScaleToD3 } from "../../lib/d3/index.js";
 import {
   drawAxes,
   drawCursorLines,
@@ -14,9 +15,8 @@ import {
   useCanvasCursor,
 } from "../../lib/hooks/index.js";
 import { canvasClasses } from "../../lib/utility.js";
-import { getFunctionImage } from "./utils.js";
-import { sqScaleToD3 } from "../../lib/d3/index.js";
 import { ImageErrors } from "./ImageErrors.js";
+import { getFunctionImage } from "./utils.js";
 
 type Props = {
   plot: SqNumericFnPlot;
@@ -112,7 +112,7 @@ export const NumericFunctionChart: FC<Props> = ({
         },
       });
     },
-    [functionImage, height, cursor, plot]
+    [functionImage, height, cursor, plot, xScale]
   );
 
   const { ref } = useCanvas({ height, init: initCursor, draw });

--- a/packages/components/src/components/FunctionChart/utils.ts
+++ b/packages/components/src/components/FunctionChart/utils.ts
@@ -1,13 +1,14 @@
+import { ScaleContinuousNumeric } from "d3";
+
 import {
-  SqNumericFnPlot,
+  Env,
   SqDistFnPlot,
   SqDistribution,
   SqNumberValue,
-  Env,
-  SqScale,
+  SqNumericFnPlot,
 } from "@quri/squiggle-lang";
+
 import { sqScaleToD3 } from "../../lib/d3/index.js";
-import { ScaleContinuousNumeric } from "d3";
 
 export const functionChartDefaults = {
   min: 0,

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -35,7 +35,7 @@ import ReactMarkdown from "react-markdown";
 // We use an extra left margin for some elements to align them with parent variable name
 const leftMargin = "ml-1.5";
 
-const truncateStr = (str, maxLength) =>
+const truncateStr = (str: string, maxLength: number) =>
   str.substring(0, maxLength) + (str.length > maxLength ? "..." : "");
 
 // Distributions should be smaller than the other charts.

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -1,21 +1,19 @@
-import { FC, forwardRef, useEffect, memo, useMemo } from "react";
+import { forwardRef, memo, useImperativeHandle } from "react";
 
 import {
+  SqDictValue,
   SqError,
   SqValue,
-  SqDictValue,
   SqValuePath,
   result,
 } from "@quri/squiggle-lang";
-import { ErrorAlert } from "../Alert.js";
 import { ChevronRightIcon } from "@quri/ui";
-import { useImperativeHandle } from "react";
+
 import { MessageAlert } from "../Alert.js";
 import { CodeEditorHandle } from "../CodeEditor.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { ExpressionViewer } from "./ExpressionViewer.js";
-import { ErrorBoundary } from "react-error-boundary";
 import {
   ViewerProvider,
   useFocus,

--- a/packages/components/src/components/TableChart/index.tsx
+++ b/packages/components/src/components/TableChart/index.tsx
@@ -42,7 +42,10 @@ export const TableChart: FC<Props> = ({
     chartHeight,
   };
 
-  const showItem = (item: result<SqValue, SqError>, settings) => {
+  const showItem = (
+    item: result<SqValue, SqError>,
+    settings: PlaygroundSettings
+  ) => {
     if (item.ok) {
       const value = item.value;
       if (valueHasContext(value)) {

--- a/packages/components/src/languageSupport/squiggle.grammar
+++ b/packages/components/src/languageSupport/squiggle.grammar
@@ -15,66 +15,70 @@
 }
 
 @top Program {
-    (NonEmptyProgram)?
-}
-
-NonEmptyProgram {
     Import*
-    (expression | (
-        (     Binding
-            | FunDeclaration
-            | semicolon)
-        )*
-        (expression)
-    ) 
+    (
+        statement
+      | semicolon
+    )*
+    (expression)?
 }
 
-// Statement {
-//     expression
-// }
+blockContent {
+    (
+        statement
+      | semicolon
+    )*
+    (expression)
+}
+
 Import { import String as identifier }
 
 commaSep<content> {
-    () | content ("," content)*
+    "" | content ("," content)*
 }
 
 // when trailing comma is allowed
-commaSep1<content> { () | content ("," content?)* }
+commaSep1<content> { "" | content ("," content?)* }
 
 Binding { VariableName { identifier } "=" expression }
 
 LambdaParameter {
-    identifier (":" expression)?
+    LambdaParameterName { identifier } (":" expression)?
 }
 
 LambdaArgs {
     () | LambdaParameter ("," LambdaParameter)*
 }
 
-FunDeclaration { FunctionName[@dynamicPrecedence=0] { identifier }  ~fieldAmbig "(" LambdaArgs ")" "=" expression }
+FunDeclaration { FunctionName { identifier } ~callOrDeclaration "(" LambdaArgs ")" "=" expression }
 
-AccessIdentifier {
-    Field { identifier } (!deref "." Field { identifier })*
+statement[@isGroup="Statement"] {
+    Binding
+    | FunDeclaration
 }
 
 expression[@isGroup="Expression"] {
     String
     | Boolean
     | Number
-    | BlockExpr { "{" NonEmptyProgram "}" }
-    | DictExpr { "{" commaSep1<
-        Entry { Field[@dynamicPrecedence=1] { expression } ~inheritAmbig ":" expression } 
-        | InheritEntry { Field[@dynamicPrecedence=0] {identifier} ~inheritAmbig }
-        > "}" }
-    | LambdaExpr { "{" ArgsOpen { "|" } LambdaArgs "|" NonEmptyProgram "}" }
+    | BlockExpr { "{" blockContent "}" }
+    | DictExpr {
+        "{"
+            commaSep1<
+              Entry { Field[@dynamicPrecedence=1] { expression } ~inheritAmbig ":" expression } 
+            | InheritEntry { Field[@dynamicPrecedence=0] { identifier } ~inheritAmbig }
+            >
+        "}"
+    }
+    | LambdaExpr { "{" ArgsOpen { "|" } LambdaArgs "|" blockContent "}" }
     | IfExpr { if expression then expression !else else expression }
     | ParenExpr { "(" expression ")" }
-    | AccessExpr[@dynamicPrecedence=1] { AccessIdentifier ~fieldAmbig }
-    | CallExpr { expression !call ("(" commaSep<Argument { expression }> ")"| "()") }
+    | IdentifierExpr { identifier }
+    | AccessExpr { expression !deref "." Field { identifier } }
+    | CallExpr { expression ~callOrDeclaration !call "(" commaSep<Argument { expression }> ")" }
     | TernaryExpr { expression !logop LogicOp<"?"> expression LogicOp<":"> expression }
     | KVAccessExpr { expression !call ("[" Key { expression } "]") }
     | ArrayExpr { "[" commaSep1<expression> "]" }
-    | Void { !deref "()" }
     | UnaryExpr { !unary (ArithOp<"-"> | ArithOp<"!"> | DotArithOp<".-">) expression }
     | LogicExpr {
           expression !or     LogicOp<"||">  expression
@@ -86,7 +90,7 @@ expression[@isGroup="Expression"] {
         | expression !rel    LogicOp<"==">  expression
     }
     | ControlExpr {
-          expression !control  ControlOp<"|>">  expression
+          expression !control  ControlOp<"->">  expression
     }
     | ArithExpr {
           expression !times  ( ArithOp<"*"> | DotArithOp<".*"> )                expression
@@ -123,7 +127,6 @@ as { kw<"as"> }
 }
 
 @tokens {
-
     Comment { ( "#" | "//" ) ![\n]* }
     spaces[@export] { $[ ]+ }
     newline[@export] { $[\n] }

--- a/packages/components/src/languageSupport/squiggle.ts
+++ b/packages/components/src/languageSupport/squiggle.ts
@@ -13,71 +13,69 @@ import { parser } from "./generated/squiggle.js";
 import { SqProject } from "@quri/squiggle-lang";
 
 export function squiggleLanguageSupport(project: SqProject) {
+  const parserWithMetadata = parser.configure({
+    props: [
+      styleTags({
+        if: t.keyword,
+        then: t.keyword,
+        else: t.keyword,
+        import: t.keyword,
+        as: t.keyword,
+
+        Equals: t.definitionOperator,
+
+        ArithOp: t.arithmeticOperator,
+        LogicOp: t.logicOperator,
+        ControlOp: t.controlOperator,
+
+        "{ }": t.brace,
+        "[ ]": t.squareBracket,
+        "( )": t.paren,
+        "|": t.squareBracket,
+        ",": t.separator,
+
+        Syntax: t.annotation,
+        Boolean: t.bool,
+        Number: t.integer,
+        String: t.string,
+        Comment: t.comment,
+        Void: t.escape,
+        Escape: t.escape,
+
+        FunctionName: t.function(t.variableName),
+
+        LambdaSyntax: t.blockComment,
+
+        VariableName: t.constant(t.variableName),
+        Field: t.variableName,
+        LambdaParameter: t.variableName,
+      }),
+      foldNodeProp.add({
+        LambdaExpr: (context) => ({
+          from: context.getChild("NonEmptyProgram")?.from || 0,
+          to: context.getChild("NonEmptyProgram")?.to || 0,
+        }),
+        BlockExpr: foldInside,
+        DictExpr: foldInside,
+        ArrayExpr: foldInside,
+      }),
+      indentNodeProp.add({
+        DictExpr: (context) =>
+          context.baseIndent + (context.textAfter === "}" ? 0 : context.unit),
+        BlockExpr: (context) =>
+          context.baseIndent + (context.textAfter === "}" ? 0 : context.unit),
+        LambdaExpr: (context) =>
+          context.baseIndent + (context.textAfter === "}" ? 0 : context.unit),
+        ArrayExpr: (context) =>
+          context.baseIndent + (context.textAfter === "]" ? 0 : context.unit),
+      }),
+    ],
+  });
+
   return new LanguageSupport(
     LRLanguage.define({
       name: "squiggle",
-      parser: parser.configure({
-        props: [
-          styleTags({
-            if: t.keyword,
-            then: t.keyword,
-            else: t.keyword,
-            import: t.keyword,
-            as: t.keyword,
-
-            Equals: t.definitionOperator,
-
-            ArithOp: t.arithmeticOperator,
-            LogicOp: t.logicOperator,
-            ControlOp: t.controlOperator,
-
-            "{ }": t.brace,
-            "[ ]": t.squareBracket,
-            "( )": t.paren,
-            "|": t.squareBracket,
-            ",": t.separator,
-
-            Syntax: t.annotation,
-            Boolean: t.bool,
-            Number: t.integer,
-            String: t.string,
-            Comment: t.comment,
-            Void: t.escape,
-            Escape: t.escape,
-
-            FunctionName: t.function(t.variableName),
-
-            LambdaSyntax: t.blockComment,
-
-            VariableName: t.constant(t.variableName),
-            Field: t.variableName,
-            LambdaParameter: t.variableName,
-          }),
-          foldNodeProp.add({
-            LambdaExpr: (context) => ({
-              from: context.getChild("NonEmptyProgram")?.from || 0,
-              to: context.getChild("NonEmptyProgram")?.to || 0,
-            }),
-            BlockExpr: foldInside,
-            DictExpr: foldInside,
-            ArrayExpr: foldInside,
-          }),
-          indentNodeProp.add({
-            DictExpr: (context) =>
-              context.baseIndent +
-              (context.textAfter === "}" ? 0 : context.unit),
-            BlockExpr: (context) =>
-              context.baseIndent +
-              (context.textAfter === "}" ? 0 : context.unit),
-            LambdaExpr: (context) =>
-              context.baseIndent +
-              (context.textAfter === "}" ? 0 : context.unit),
-            ArrayExpr: (context) =>
-              context.baseIndent +
-              (context.textAfter === "]" ? 0 : context.unit),
-          }),
-        ],
-      }),
+      parser: parserWithMetadata,
       languageData: {
         commentTokens: {
           line: "//",

--- a/packages/components/src/languageSupport/squiggle.ts
+++ b/packages/components/src/languageSupport/squiggle.ts
@@ -8,13 +8,11 @@ import {
   syntaxTree,
 } from "@codemirror/language";
 import { styleTags, tags as t } from "@lezer/highlight";
-import { RefObject } from "react";
-
-import { SqProject } from "@quri/squiggle-lang";
 
 import { parser } from "./generated/squiggle.js";
+import { SqProject } from "@quri/squiggle-lang";
 
-export function squiggleLanguageSupport(projectRef: RefObject<SqProject>) {
+export function squiggleLanguageSupport(project: SqProject) {
   return new LanguageSupport(
     LRLanguage.define({
       name: "squiggle",
@@ -121,8 +119,8 @@ export function squiggleLanguageSupport(projectRef: RefObject<SqProject>) {
                 label: name,
                 type: "constant",
               })),
-              ...(projectRef.current
-                ?.getStdLib()
+              ...(project
+                .getStdLib()
                 .keySeq()
                 .toArray()
                 .map((name) => ({

--- a/packages/components/src/languageSupport/squiggle.ts
+++ b/packages/components/src/languageSupport/squiggle.ts
@@ -1,6 +1,5 @@
 import {
   Completion,
-  CompletionContext,
   CompletionSource,
   snippetCompletion,
 } from "@codemirror/autocomplete";
@@ -12,8 +11,8 @@ import {
   indentNodeProp,
   syntaxTree,
 } from "@codemirror/language";
+import { SyntaxNode, Tree } from "@lezer/common";
 import { styleTags, tags as t } from "@lezer/highlight";
-import { Tree, SyntaxNode } from "@lezer/common";
 
 import { SqProject } from "@quri/squiggle-lang";
 

--- a/packages/components/src/lib/hooks/useSquiggle.ts
+++ b/packages/components/src/lib/hooks/useSquiggle.ts
@@ -54,7 +54,7 @@ export type UseSquiggleOutput = [
 ];
 
 // this array's identity must be constant because it's used in useEffect below
-const defaultContinues = [];
+const defaultContinues: string[] = [];
 
 export function useSquiggle(args: SquiggleArgs): UseSquiggleOutput {
   // random; https://stackoverflow.com/a/12502559

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { SquigglePlayground as Component } from "../components/SquigglePlayground/index.js";
-import { Button } from "@quri/ui";
 import { sq } from "@quri/squiggle-lang";
-import { blockComment } from "@codemirror/commands";
+import { Button } from "@quri/ui";
+
+import { SquigglePlayground as Component } from "../components/SquigglePlayground/index.js";
 
 /**
  * A Squiggle playground is an environment where you can play around with all settings, including sampling settings, in Squiggle.

--- a/packages/components/test/autocompletion.test.ts
+++ b/packages/components/test/autocompletion.test.ts
@@ -1,0 +1,71 @@
+import { SyntaxNode } from "@lezer/common";
+import { parser } from "../src/languageSupport/generated/squiggle.js";
+import { getNameNodes } from "../src/languageSupport/squiggle.js";
+
+function getText(code: string, node: SyntaxNode) {
+  return code.slice(node.from, node.to);
+}
+
+describe("Autocompletion", () => {
+  test("Basic", () => {
+    const code = `
+foo = 5
+bar = 6
+1+`;
+    const tree = parser.parse(code);
+
+    const nodes = getNameNodes(tree, code.length);
+    expect(nodes.length).toBe(2);
+    expect(getText(code, nodes[0])).toBe("bar"); // code is traversed backwards
+    expect(getText(code, nodes[1])).toBe("foo");
+  });
+
+  test("Parameter names", () => {
+    const code = `
+myFun(arg1, arg2) = 1+`;
+    const tree = parser.parse(code);
+
+    const nodes = getNameNodes(tree, code.length);
+    expect(nodes.length).toBe(2);
+    expect(getText(code, nodes[0])).toBe("arg1");
+    expect(getText(code, nodes[1])).toBe("arg2");
+  });
+
+  test("Don't suggest current binding", () => {
+    const code = `
+foo = 5
+bar = {`;
+    const tree = parser.parse(code);
+
+    const nodes = getNameNodes(tree, code.length);
+    expect(nodes.length).toBe(1);
+    expect(getText(code, nodes[0])).toBe("foo");
+  });
+
+  test("Don't suggest parameters of sibling functions", () => {
+    const code = `
+fun1(arg1) = 1
+fun2(arg2) =`;
+    const tree = parser.parse(code);
+
+    const nodes = getNameNodes(tree, code.length);
+    expect(nodes.length).toBe(2);
+    expect(getText(code, nodes[0])).toBe("arg2");
+    expect(getText(code, nodes[1])).toBe("fun1");
+  });
+
+  test("Don't suggest bindings declared later", () => {
+    const code1 = `
+foo = 1
+x = f`;
+    const code2 = `
+bar = 2
+`;
+    const code = code1 + code2;
+    const tree = parser.parse(code);
+
+    const nodes = getNameNodes(tree, code1.length);
+    expect(nodes.length).toBe(1);
+    expect(getText(code, nodes[0])).toBe("foo");
+  });
+});

--- a/packages/components/test/autocompletion.test.ts
+++ b/packages/components/test/autocompletion.test.ts
@@ -31,6 +31,17 @@ myFun(arg1, arg2) = 1+`;
     expect(getText(code, nodes[1])).toBe("arg2");
   });
 
+  test("Parameter names at the start of function body", () => {
+    const code = `
+myFun(arg1, arg2) = `;
+    const tree = parser.parse(code);
+
+    const nodes = getNameNodes(tree, code.length);
+    expect(nodes.length).toBe(2);
+    expect(getText(code, nodes[0])).toBe("arg1");
+    expect(getText(code, nodes[1])).toBe("arg2");
+  });
+
   test("Don't suggest current binding", () => {
     const code = `
 foo = 5

--- a/packages/components/test/grammar.test.ts
+++ b/packages/components/test/grammar.test.ts
@@ -1,0 +1,49 @@
+import { parser } from "../src/languageSupport/generated/squiggle.js";
+
+describe("Lezer grammar", () => {
+  test("Basic", () => {
+    expect(parser.parse("2+2").toString()).toBe(
+      "Program(ArithExpr(Number,ArithOp,Number))"
+    );
+  });
+
+  test("Statements only", () => {
+    expect(
+      parser
+        .parse(
+          `foo = 5
+bar = 6`
+        )
+        .toString()
+    ).toBe(
+      "Program(Binding(VariableName,Equals,Number),Binding(VariableName,Equals,Number))"
+    );
+  });
+
+  test("Statements with trailing expression", () => {
+    expect(
+      parser
+        .parse(
+          `foo = 5
+bar = 6
+foo + bar`
+        )
+        .toString()
+    ).toBe(
+      "Program(Binding(VariableName,Equals,Number),Binding(VariableName,Equals,Number),ArithExpr(IdentifierExpr,ArithOp,IdentifierExpr))"
+    );
+  });
+
+  test("Function declarations and calls", () => {
+    expect(
+      parser
+        .parse(
+          `foo(x) = x
+foo(5)`
+        )
+        .toString()
+    ).toBe(
+      'Program(FunDeclaration(FunctionName,"(",LambdaArgs(LambdaParameter(LambdaParameterName)),")",Equals,IdentifierExpr),CallExpr(IdentifierExpr,"(",Argument(Number),")"))'
+    );
+  });
+});

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -15,7 +15,7 @@
     // type check settings
     "strict": true,
     "skipLibCheck": true,
-    "noImplicitAny": false
+    "noImplicitAny": false // waiting for https://github.com/lezer-parser/lezer/issues/41 to be fixed
   },
   "include": ["src/**/*"],
   "references": [

--- a/packages/prettier-plugin/.gitignore
+++ b/packages/prettier-plugin/.gitignore
@@ -1,1 +1,2 @@
 /dist
+/*.tsbuildinfo

--- a/packages/prettier-plugin/package.json
+++ b/packages/prettier-plugin/package.json
@@ -34,7 +34,17 @@
   "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",
   "exports": {
-    ".": "./dist/esm/src/index.js",
-    "./standalone": "./dist/esm/src/standalone.js"
+    ".": {
+      "import": {
+        "types": "./dist/esm/src/index.js",
+        "default": "./dist/types/src/index.d.ts"
+      }
+    },
+    "./standalone": {
+      "import": {
+        "types": "./dist/esm/src/standalone.js",
+        "default": "./dist/types/src/standalone.d.ts"
+      }
+    }
   }
 }

--- a/packages/prettier-plugin/package.json
+++ b/packages/prettier-plugin/package.json
@@ -31,20 +31,15 @@
   ],
   "type": "module",
   "source": "./src/index.ts",
-  "module": "./dist/esm/src/index.js",
   "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/esm/src/index.js",
-        "default": "./dist/types/src/index.d.ts"
-      }
+      "types": "./dist/esm/src/index.js",
+      "import": "./dist/types/src/index.d.ts"
     },
     "./standalone": {
-      "import": {
-        "types": "./dist/esm/src/standalone.js",
-        "default": "./dist/types/src/standalone.d.ts"
-      }
+      "types": "./dist/esm/src/standalone.js",
+      "import": "./dist/types/src/standalone.d.ts"
     }
   }
 }

--- a/packages/prettier-plugin/package.json
+++ b/packages/prettier-plugin/package.json
@@ -34,12 +34,12 @@
   "types": "./dist/types/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/esm/src/index.js",
-      "import": "./dist/types/src/index.d.ts"
+      "types": "./dist/types/src/index.d.ts",
+      "import": "./dist/esm/src/index.js"
     },
     "./standalone": {
-      "types": "./dist/esm/src/standalone.js",
-      "import": "./dist/types/src/standalone.d.ts"
+      "types": "./dist/types/src/standalone.d.ts",
+      "import": "./dist/esm/src/standalone.js"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
     dependencies:
       '@codemirror/autocomplete':
         specifier: ^6.9.0
-        version: 6.9.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.16.0)(@lezer/common@1.0.3)
+        version: 6.9.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.16.0)(@lezer/common@1.0.4)
       '@codemirror/commands':
         specifier: ^6.2.4
         version: 6.2.4
@@ -104,7 +104,7 @@ importers:
         version: 2.0.0
       codemirror:
         specifier: ^6.0.1
-        version: 6.0.1(@lezer/common@1.0.3)
+        version: 6.0.1(@lezer/common@1.0.4)
       d3:
         specifier: ^7.8.5
         version: 7.8.5
@@ -146,14 +146,14 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       '@lezer/generator':
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.4.2
+        version: 1.4.2
       '@lezer/highlight':
         specifier: ^1.1.6
         version: 1.1.6
       '@lezer/lr':
-        specifier: ^1.3.9
-        version: 1.3.9
+        specifier: ^1.3.10
+        version: 1.3.10
       '@storybook/addon-actions':
         specifier: ^7.2.1
         version: 7.2.1(@types/react-dom@18.2.7)(@types/react@18.2.18)(react-dom@18.2.0)(react@18.2.0)
@@ -474,7 +474,7 @@ importers:
     devDependencies:
       '@babel/preset-typescript':
         specifier: ^7.22.5
-        version: 7.22.5(@babel/core@7.22.9)
+        version: 7.22.5(@babel/core@7.22.10)
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.3
@@ -508,7 +508,7 @@ importers:
     devDependencies:
       '@babel/preset-typescript':
         specifier: ^7.22.5
-        version: 7.22.5(@babel/core@7.22.9)
+        version: 7.22.5(@babel/core@7.22.10)
       '@jest/globals':
         specifier: ^29.6.2
         version: 29.6.2
@@ -828,6 +828,14 @@ packages:
       default-browser-id: 3.0.0
     dev: true
 
+  /@babel/code-frame@7.22.10:
+    resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/highlight': 7.22.10
+      chalk: 2.4.2
+    dev: true
+
   /@babel/code-frame@7.22.5:
     resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
@@ -837,6 +845,29 @@ packages:
   /@babel/compat-data@7.22.9:
     resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/core@7.22.10:
+    resolution: {integrity: sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.10
+      '@babel/generator': 7.22.10
+      '@babel/helper-compilation-targets': 7.22.10
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.10)
+      '@babel/helpers': 7.22.10
+      '@babel/parser': 7.22.10
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.10
+      '@babel/types': 7.22.10
+      convert-source-map: 1.9.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/core@7.22.9:
@@ -860,6 +891,16 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/generator@7.22.10:
+    resolution: {integrity: sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.22.10
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.19
+      jsesc: 2.5.2
     dev: true
 
   /@babel/generator@7.22.9:
@@ -886,6 +927,17 @@ packages:
       '@babel/types': 7.22.5
     dev: true
 
+  /@babel/helper-compilation-targets@7.22.10:
+    resolution: {integrity: sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/compat-data': 7.22.9
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.10
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: true
+
   /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
     resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
     engines: {node: '>=6.9.0'}
@@ -898,6 +950,26 @@ packages:
       browserslist: 4.21.9
       lru-cache: 5.1.1
       semver: 6.3.1
+    dev: true
+
+  /@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.10):
+    resolution: {integrity: sha512-iwdzgtSiBxF6ni6mzVnZCF3xt5qE6cEA0J7nFt8QOAWZ0zjCFceEgpn3vtb2V7WFR6QzP2jmIFOHMTRo7eNJjQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.10
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@nicolo-ribaudo/semver-v6': 6.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/helper-create-class-features-plugin@7.22.6(@babel/core@7.22.9):
@@ -979,6 +1051,20 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.22.5
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.10):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.10
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: true
 
   /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
     resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
@@ -1075,6 +1161,17 @@ packages:
       '@babel/types': 7.22.5
     dev: true
 
+  /@babel/helpers@7.22.10:
+    resolution: {integrity: sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.10
+      '@babel/types': 7.22.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helpers@7.22.6:
     resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
     engines: {node: '>=6.9.0'}
@@ -1086,6 +1183,15 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/highlight@7.22.10:
+    resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.22.5
+      chalk: 2.4.2
+      js-tokens: 4.0.0
+    dev: true
+
   /@babel/highlight@7.22.5:
     resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
     engines: {node: '>=6.9.0'}
@@ -1093,6 +1199,14 @@ packages:
       '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
+
+  /@babel/parser@7.22.10:
+    resolution: {integrity: sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.10
+    dev: true
 
   /@babel/parser@7.22.7:
     resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
@@ -1283,6 +1397,16 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.10):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
     engines: {node: '>=6.9.0'}
@@ -1364,6 +1488,16 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.9
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.22.10):
+    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.10
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
@@ -1651,6 +1785,18 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.22.10):
+    resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.10
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.10)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+    dev: true
+
   /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==}
     engines: {node: '>=6.9.0'}
@@ -1920,6 +2066,21 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
+  /@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.10):
+    resolution: {integrity: sha512-SMubA9S7Cb5sGSFFUlqxyClTA9zWJ8qGQrppNUm05LtFuN1ELRFNndkix4zUJrC9F+YivWwa1dHMSyo0e0N9dA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.10
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.6(@babel/core@7.22.10)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.22.10)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-transform-typescript@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-SMubA9S7Cb5sGSFFUlqxyClTA9zWJ8qGQrppNUm05LtFuN1ELRFNndkix4zUJrC9F+YivWwa1dHMSyo0e0N9dA==}
     engines: {node: '>=6.9.0'}
@@ -2094,6 +2255,22 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /@babel/preset-typescript@7.22.5(@babel/core@7.22.10):
+    resolution: {integrity: sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.22.10
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.22.10)
+      '@babel/plugin-transform-modules-commonjs': 7.22.5(@babel/core@7.22.10)
+      '@babel/plugin-transform-typescript': 7.22.5(@babel/core@7.22.10)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/preset-typescript@7.22.5(@babel/core@7.22.9):
     resolution: {integrity: sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==}
     engines: {node: '>=6.9.0'}
@@ -2136,6 +2313,13 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
+  /@babel/runtime@7.22.10:
+    resolution: {integrity: sha512-21t/fkKLMZI4pqP2wlmsQAWnYW1PDyKyyUV4vCi+B25ydmdaYTKXPwCj0BzSUnZf4seIiYvSA3jcZ3gdsMFkLQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.0
+    dev: true
+
   /@babel/runtime@7.22.3:
     resolution: {integrity: sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==}
     engines: {node: '>=6.9.0'}
@@ -2157,6 +2341,24 @@ packages:
       '@babel/types': 7.22.5
     dev: true
 
+  /@babel/traverse@7.22.10:
+    resolution: {integrity: sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.10
+      '@babel/generator': 7.22.10
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.10
+      '@babel/types': 7.22.10
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/traverse@7.22.8:
     resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
     engines: {node: '>=6.9.0'}
@@ -2173,6 +2375,15 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@babel/types@7.22.10:
+    resolution: {integrity: sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
+      to-fast-properties: 2.0.0
     dev: true
 
   /@babel/types@7.22.5:
@@ -2379,7 +2590,7 @@ packages:
       prettier: 2.8.8
     dev: true
 
-  /@codemirror/autocomplete@6.9.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.16.0)(@lezer/common@1.0.3):
+  /@codemirror/autocomplete@6.9.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.16.0)(@lezer/common@1.0.4):
     resolution: {integrity: sha512-Fbwm0V/Wn3BkEJZRhr0hi5BhCo5a7eBL6LYaliPjOSwCyfOpnjXY59HruSxOUNV+1OYer0Tgx1zRNQttjXyDog==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
@@ -2390,7 +2601,7 @@ packages:
       '@codemirror/language': 6.8.0
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.16.0
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.0.4
     dev: false
 
   /@codemirror/commands@6.2.4:
@@ -2409,7 +2620,7 @@ packages:
       '@codemirror/view': 6.16.0
       '@lezer/common': 1.0.2
       '@lezer/highlight': 1.1.6
-      '@lezer/lr': 1.3.9
+      '@lezer/lr': 1.3.10
       style-mod: 4.0.2
     dev: false
 
@@ -3500,6 +3711,11 @@ packages:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
     engines: {node: '>=6.0.0'}
 
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
@@ -3523,6 +3739,13 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
 
+  /@jridgewell/trace-mapping@0.3.19:
+    resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
     dependencies:
@@ -3538,14 +3761,17 @@ packages:
 
   /@lezer/common@1.0.3:
     resolution: {integrity: sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA==}
+
+  /@lezer/common@1.0.4:
+    resolution: {integrity: sha512-lZHlk8p67x4aIDtJl6UQrXSOP6oi7dQR3W/geFVrENdA1JDaAJWldnVqVjPMJupbTKbzDfFcePfKttqVidS/dg==}
     dev: false
 
-  /@lezer/generator@1.3.0:
-    resolution: {integrity: sha512-7HfulDoOMOkskb97fnwgpC6StwPVSob4ptc0iuOH72rapNQBbp6lVj05y7vc5IM0E9pjFjiLmNQeiBiSbLpCtA==}
+  /@lezer/generator@1.4.2:
+    resolution: {integrity: sha512-6fRwiGnx6Sv2I25YKeC5Mw9LtIA3Yq4FmVdRk0NP+M8tCsLUHSJd4KzrEzYqW3SKqOR/ZRlGiw+HAXMRygyCZA==}
     hasBin: true
     dependencies:
       '@lezer/common': 1.0.2
-      '@lezer/lr': 1.3.9
+      '@lezer/lr': 1.3.10
     dev: true
 
   /@lezer/highlight@1.1.6:
@@ -3553,10 +3779,10 @@ packages:
     dependencies:
       '@lezer/common': 1.0.2
 
-  /@lezer/lr@1.3.9:
-    resolution: {integrity: sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==}
+  /@lezer/lr@1.3.10:
+    resolution: {integrity: sha512-BZfVvf7Re5BIwJHlZXbJn9L8lus5EonxQghyn+ih8Wl36XMFBPTXC0KM0IdUtj9w/diPHsKlXVgL+AlX2jYJ0Q==}
     dependencies:
-      '@lezer/common': 1.0.2
+      '@lezer/common': 1.0.3
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -5770,8 +5996,8 @@ packages:
     resolution: {integrity: sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/runtime': 7.22.6
+      '@babel/code-frame': 7.22.10
+      '@babel/runtime': 7.22.10
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
@@ -7574,6 +7800,17 @@ packages:
       pako: 0.2.9
     dev: true
 
+  /browserslist@4.21.10:
+    resolution: {integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001521
+      electron-to-chromium: 1.4.495
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.10)
+    dev: true
+
   /browserslist@4.21.5:
     resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -7734,6 +7971,10 @@ packages:
 
   /caniuse-lite@1.0.30001512:
     resolution: {integrity: sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==}
+
+  /caniuse-lite@1.0.30001521:
+    resolution: {integrity: sha512-fnx1grfpEOvDGH+V17eccmNjucGUnCbP6KL+l5KqBIerp26WK/+RQ7CIDE37KGJjaPyqWXXlFUyKiWmvdNNKmQ==}
+    dev: true
 
   /canvas@2.11.2:
     resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
@@ -7995,10 +8236,10 @@ packages:
       - supports-color
     dev: true
 
-  /codemirror@6.0.1(@lezer/common@1.0.3):
+  /codemirror@6.0.1(@lezer/common@1.0.4):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.9.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.16.0)(@lezer/common@1.0.3)
+      '@codemirror/autocomplete': 6.9.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.16.0)(@lezer/common@1.0.4)
       '@codemirror/commands': 6.2.4
       '@codemirror/language': 6.8.0
       '@codemirror/lint': 6.4.0
@@ -9103,6 +9344,10 @@ packages:
 
   /electron-to-chromium@1.4.451:
     resolution: {integrity: sha512-YYbXHIBxAHe3KWvGOJOuWa6f3tgow44rBW+QAuwVp2DvGqNZeE//K2MowNdWS7XE8li5cgQDrX1LdBr41LufkA==}
+    dev: true
+
+  /electron-to-chromium@1.4.495:
+    resolution: {integrity: sha512-mwknuemBZnoOCths4GtpU/SDuVMp3uQHKa2UNJT9/aVD6WVRjGpXOxRGX7lm6ILIenTdGXPSTCTDaWos5tEU8Q==}
     dev: true
 
   /elkjs@0.8.2:
@@ -13686,6 +13931,10 @@ packages:
     resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
     dev: true
 
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: true
+
   /nodemailer@6.9.3:
     resolution: {integrity: sha512-fy9v3NgTzBngrMFkDsKEj0r02U7jm6XfC3b52eoNV+GCrGj+s8pt5OqhiJdWKuw51zCTdiNR/IUD1z33LIIGpg==}
     engines: {node: '>=6.0.0'}
@@ -15178,6 +15427,10 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
+    dev: true
 
   /regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
@@ -17043,6 +17296,17 @@ packages:
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
     engines: {node: '>=8'}
+
+  /update-browserslist-db@1.0.11(browserslist@4.21.10):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.10
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.5):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.1.1
         version: 3.1.1(react-hook-form@7.45.2)
+      '@lezer/common':
+        specifier: ^1.0.4
+        version: 1.0.4
       '@quri/prettier-plugin-squiggle':
         specifier: workspace:*
         version: link:../prettier-plugin
@@ -2610,7 +2613,7 @@ packages:
       '@codemirror/language': 6.8.0
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.16.0
-      '@lezer/common': 1.0.2
+      '@lezer/common': 1.0.4
     dev: false
 
   /@codemirror/language@6.8.0:
@@ -2618,7 +2621,7 @@ packages:
     dependencies:
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.16.0
-      '@lezer/common': 1.0.2
+      '@lezer/common': 1.0.4
       '@lezer/highlight': 1.1.6
       '@lezer/lr': 1.3.10
       style-mod: 4.0.2
@@ -3756,33 +3759,26 @@ packages:
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
 
-  /@lezer/common@1.0.2:
-    resolution: {integrity: sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng==}
-
-  /@lezer/common@1.0.3:
-    resolution: {integrity: sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA==}
-
   /@lezer/common@1.0.4:
     resolution: {integrity: sha512-lZHlk8p67x4aIDtJl6UQrXSOP6oi7dQR3W/geFVrENdA1JDaAJWldnVqVjPMJupbTKbzDfFcePfKttqVidS/dg==}
-    dev: false
 
   /@lezer/generator@1.4.2:
     resolution: {integrity: sha512-6fRwiGnx6Sv2I25YKeC5Mw9LtIA3Yq4FmVdRk0NP+M8tCsLUHSJd4KzrEzYqW3SKqOR/ZRlGiw+HAXMRygyCZA==}
     hasBin: true
     dependencies:
-      '@lezer/common': 1.0.2
+      '@lezer/common': 1.0.4
       '@lezer/lr': 1.3.10
     dev: true
 
   /@lezer/highlight@1.1.6:
     resolution: {integrity: sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==}
     dependencies:
-      '@lezer/common': 1.0.2
+      '@lezer/common': 1.0.4
 
   /@lezer/lr@1.3.10:
     resolution: {integrity: sha512-BZfVvf7Re5BIwJHlZXbJn9L8lus5EonxQghyn+ih8Wl36XMFBPTXC0KM0IdUtj9w/diPHsKlXVgL+AlX2jYJ0Q==}
     dependencies:
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.0.4
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}


### PR DESCRIPTION
Autocompletion:
- suggest local function names
- suggest parameter names
- don't suggest unreachable vars (declared below or in unreachable local scopes)
- different icon for local functions

Grammar improvements:
- functions with 0 parameters don't break the parser
- trailing expressions are now really optional (they weren't, but Lezer recovered from it so it didn't matter)

Editor refactorings:
- create `view` and `state` only once and store them without React refs (this unfortunately broke hot reloading in Storybook, but it simplifies the implementation and is still worth it)
- `squiggleLanguageSupport` is a compartment and is properly reconfigured if `project` prop changes (this never happens in practice, though)

Other:
- fixed types in prettier-plugin-squiggle for standalone.js
- made some progress towards enabling `noImplicitAny`, which is still blocked by Lezer, but will be fixed when the patch for https://github.com/lezer-parser/lezer/issues/41 is releazed
- added basic tests for grammar and autocompletion