### PR TITLE
Adds 30ms throttle to useCanvas, to fix FF bug

### DIFF
--- a/packages/components/src/lib/hooks/useCanvas.ts
+++ b/packages/components/src/lib/hooks/useCanvas.ts
@@ -16,7 +16,7 @@ type DrawFunction = (context: DrawContext) => void;
 
 // We throttle to get around a Firefox bug.
 // See: https://github.com/quantified-uncertainty/squiggle/issues/2263
-const THROTTLE_AMOUNT = 30;
+const RESIZE_DELAY = 30;
 
 export function useCanvas({
   height,
@@ -37,7 +37,7 @@ export function useCanvas({
 
   const throttleTimeout = useRef<number | null>(null);
 
-  const handleResize = (entries: ResizeObserverEntry[]) => {
+  const handleResize = useCallback((entries: ResizeObserverEntry[]) => {
     if (!entries[0]) return;
 
     if (throttleTimeout.current) {
@@ -46,15 +46,15 @@ export function useCanvas({
 
     throttleTimeout.current = window.setTimeout(() => {
       setWidth(entries[0].contentRect.width);
-    }, THROTTLE_AMOUNT);
-  };
+    }, RESIZE_DELAY);
+  }, []);
 
   const observer = useMemo(() => {
     if (typeof window === "undefined") {
       return undefined;
     }
     return new window.ResizeObserver(handleResize);
-  }, []);
+  }, [handleResize]);
 
   useEffect(() => {
     return () => {

--- a/packages/components/src/lib/hooks/useCanvas.ts
+++ b/packages/components/src/lib/hooks/useCanvas.ts
@@ -14,6 +14,10 @@ export type DrawContext = {
 
 type DrawFunction = (context: DrawContext) => void;
 
+// We throttle to get around a Firefox bug.
+// See: https://github.com/quantified-uncertainty/squiggle/issues/2263
+const THROTTLE_AMOUNT = 30;
+
 export function useCanvas({
   height,
   init,
@@ -42,7 +46,7 @@ export function useCanvas({
 
     throttleTimeout.current = window.setTimeout(() => {
       setWidth(entries[0].contentRect.width);
-    }, 100); // Throttle for 100ms
+    }, THROTTLE_AMOUNT);
   };
 
   const observer = useMemo(() => {
@@ -60,6 +64,7 @@ export function useCanvas({
       observer?.disconnect();
     };
   }, [observer]);
+
   const ref = useCallback(
     (canvas: HTMLCanvasElement) => {
       if (!canvas) {


### PR DESCRIPTION
Closes https://github.com/quantified-uncertainty/squiggle/issues/2263

There might well be better solutions, but this does seem to decrease the issue a whole lot. (It still shows up under stress / tons of trials, but it takes far more now) 