### PR TITLE
Change TypeScript target to ES2021

### DIFF
--- a/.changeset/famous-ties-hope.md
+++ b/.changeset/famous-ties-hope.md
@@ -1,0 +1,8 @@
+---
+"@quri/prettier-plugin-squiggle": patch
+"@quri/squiggle-lang": patch
+"@quri/squiggle-components": patch
+"@quri/ui": patch
+---
+
+Change Typescript target to ES2021

--- a/packages/components/tsconfig.build.json
+++ b/packages/components/tsconfig.build.json
@@ -3,7 +3,7 @@
     // build settings
     "module": "es2020",
     "moduleResolution": "node16",
-    "target": "es2022",
+    "target": "es2021",
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "composite": true,

--- a/packages/hub/tsconfig.json
+++ b/packages/hub/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "es2020",
     "moduleResolution": "node",
-    "target": "es2022",
+    "target": "es2021",
     "lib": ["dom", "dom.iterable", "esnext"],
     "esModuleInterop": true,
     "noEmit": true,

--- a/packages/ops/tsconfig.json
+++ b/packages/ops/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "es2020",
     "moduleResolution": "node16",
-    "target": "es2022",
+    "target": "es2021",
     "esModuleInterop": true,
     "rootDir": "scripts",
     "noEmit": true,

--- a/packages/prettier-plugin/tsconfig.build.json
+++ b/packages/prettier-plugin/tsconfig.build.json
@@ -3,7 +3,7 @@
     // build settings
     "module": "es2020",
     "moduleResolution": "node16",
-    "target": "es2022",
+    "target": "es2021",
     "esModuleInterop": true,
     "composite": true,
     "outDir": "./dist/esm",

--- a/packages/squiggle-lang/tsconfig.build.json
+++ b/packages/squiggle-lang/tsconfig.build.json
@@ -3,7 +3,7 @@
     // build settings
     "module": "es2020",
     "moduleResolution": "node16",
-    "target": "es2022",
+    "target": "es2021",
     "esModuleInterop": true,
     "allowJs": true, // necessary for peggy parser
     "composite": true,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,7 +3,7 @@
     // build settings
     "module": "es2020",
     "moduleResolution": "node16",
-    "target": "es2022",
+    "target": "es2021",
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "composite": true,


### PR DESCRIPTION
unpkg can't handle ES2022: https://unpkg.com/@quri/squiggle-components@0.8.4/dist/src/components/NumberShower.js?module

```
Cannot generate module for @quri/squiggle-components@0.8.4/dist/src/components/NumberShower.js

SyntaxError: unknown: Support for the experimental syntax 'classProperties' isn't currently enabled (14:11):

  12 | }
  13 | class NumberShowerBuilder {
> 14 |     number;
     |           ^
  15 |     precision;
  16 |     constructor(number, precision = 2) {
  17 |         this.number = number;

Add @babel/plugin-proposal-class-properties (https://git.io/vb4SL) to the 'plugins' section of your Babel config to enable transformation.

undefined
```

ES2021 should help.

It would be enough to change this setting in components, ui and squiggle-lang, but I updated all packages for consistency.