### PR TITLE
Rename ownerId to userId for easier groups migration

### DIFF
--- a/.github/workflows/reset-preview-db.yml
+++ b/.github/workflows/reset-preview-db.yml
@@ -1,0 +1,26 @@
+name: Reset Preview DB
+
+on:
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: Preview
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Reset
+        working-directory: ./packages/hub
+        env:
+          DATABASE_URL: "${{ secrets.DATABASE_DIRECT_URL }}"
+        run: npx prisma migrate reset --force

--- a/packages/hub/prisma/migrations/20230914022115_rename_legacy_owner_id/migration.sql
+++ b/packages/hub/prisma/migrations/20230914022115_rename_legacy_owner_id/migration.sql
@@ -1,0 +1,17 @@
+-- Models
+
+ALTER TABLE "Model" RENAME CONSTRAINT "Model_ownerId_fkey" to "Model_userId_fkey";
+
+ALTER INDEX "Model_ownerId_idx" RENAME TO "Model_userId_idx";
+ALTER INDEX "Model_slug_ownerId_key" RENAME TO "Model_slug_userId_key";
+
+ALTER TABLE "Model" RENAME COLUMN "ownerId" TO "userId";
+
+-- RelativeValueDefinitions
+
+ALTER TABLE "RelativeValuesDefinition" RENAME CONSTRAINT "RelativeValuesDefinition_ownerId_fkey" to "RelativeValuesDefinition_userId_fkey";
+
+ALTER INDEX "RelativeValuesDefinition_ownerId_idx" RENAME TO "RelativeValuesDefinition_userId_idx";
+ALTER INDEX "RelativeValuesDefinition_slug_ownerId_key" RENAME TO "RelativeValuesDefinition_slug_userId_key";
+
+ALTER TABLE "RelativeValuesDefinition" RENAME COLUMN "ownerId" TO "userId";

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -91,8 +91,8 @@ model Model {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  owner   User   @relation(fields: [ownerId], references: [id])
-  ownerId String
+  owner  User   @relation(fields: [userId], references: [id])
+  userId String
 
   isPrivate Boolean @default(false)
 
@@ -102,8 +102,8 @@ model Model {
   currentRevision   ModelRevision? @relation("CurrentRevision", fields: [currentRevisionId], references: [id])
   currentRevisionId String?        @unique
 
-  @@unique([slug, ownerId])
-  @@index([ownerId])
+  @@unique([slug, userId])
+  @@index([userId])
   @@index([createdAt])
 }
 
@@ -146,8 +146,8 @@ model RelativeValuesDefinition {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  owner   User   @relation(fields: [ownerId], references: [id])
-  ownerId String
+  owner  User   @relation(fields: [userId], references: [id])
+  userId String
 
   // technically nullable, but won't ever be null in practice after the initial migration
   currentRevision   RelativeValuesDefinitionRevision? @relation("CurrentRevision", fields: [currentRevisionId], references: [id])
@@ -157,9 +157,9 @@ model RelativeValuesDefinition {
 
   modelExports RelativeValuesExport[]
 
-  @@unique([slug, ownerId])
+  @@unique([slug, userId])
   @@index([createdAt])
-  @@index([ownerId])
+  @@index([userId])
 }
 
 model RelativeValuesDefinitionRevision {

--- a/packages/hub/src/graphql/mutations/deleteModel.tsx
+++ b/packages/hub/src/graphql/mutations/deleteModel.tsx
@@ -24,9 +24,9 @@ builder.mutationField("deleteModel", (t) =>
 
       await prisma.model.delete({
         where: {
-          slug_ownerId: {
+          slug_userId: {
             slug,
-            ownerId: owner.id,
+            userId: owner.id,
           },
         },
       });

--- a/packages/hub/src/graphql/mutations/deleteRelativeValuesDefinition.tsx
+++ b/packages/hub/src/graphql/mutations/deleteRelativeValuesDefinition.tsx
@@ -24,9 +24,9 @@ builder.mutationField("deleteRelativeValuesDefinition", (t) =>
 
       await prisma.relativeValuesDefinition.delete({
         where: {
-          slug_ownerId: {
+          slug_userId: {
             slug,
-            ownerId: owner.id,
+            userId: owner.id,
           },
         },
       });

--- a/packages/hub/src/graphql/mutations/updateModelPrivacy.ts
+++ b/packages/hub/src/graphql/mutations/updateModelPrivacy.ts
@@ -29,7 +29,7 @@ builder.mutationField("updateModelPrivacy", (t) =>
       });
 
       const model = await prisma.model.update({
-        where: { slug_ownerId: { slug: input.slug, ownerId: owner.id } },
+        where: { slug_userId: { slug: input.slug, userId: owner.id } },
         data: { isPrivate: input.isPrivate },
         include: { owner: true },
       });

--- a/packages/hub/src/graphql/mutations/updateModelSlug.ts
+++ b/packages/hub/src/graphql/mutations/updateModelSlug.ts
@@ -37,9 +37,9 @@ builder.mutationField("updateModelSlug", (t) =>
 
       const model = await prisma.model.update({
         where: {
-          slug_ownerId: {
+          slug_userId: {
             slug: input.oldSlug,
-            ownerId: owner.id,
+            userId: owner.id,
           },
         },
         data: {

--- a/packages/hub/src/graphql/mutations/updateRelativeValuesDefinition.ts
+++ b/packages/hub/src/graphql/mutations/updateRelativeValuesDefinition.ts
@@ -63,9 +63,9 @@ builder.mutationField("updateRelativeValuesDefinition", (t) =>
             recommendedUnit: input.recommendedUnit,
             definition: {
               connect: {
-                slug_ownerId: {
+                slug_userId: {
                   slug: input.slug,
-                  ownerId: owner.id,
+                  userId: owner.id,
                 },
               },
             },

--- a/packages/hub/src/graphql/mutations/updateSquiggleSnippetModel.ts
+++ b/packages/hub/src/graphql/mutations/updateSquiggleSnippetModel.ts
@@ -144,9 +144,9 @@ builder.mutationField("updateSquiggleSnippetModel", (t) =>
             contentType: "SquiggleSnippet",
             model: {
               connect: {
-                slug_ownerId: {
+                slug_userId: {
                   slug: input.slug,
-                  ownerId: owner.id,
+                  userId: owner.id,
                 },
               },
             },


### PR DESCRIPTION
There is a naming collision where old `Model.ownerId` pointed to the `User` table, while after hubs group is's going to point at the `Owner` table.