### PR TITLE
Groups migration, step 2/5

### DIFF
--- a/packages/hub/prisma/migrations/20230914033258_groups_intermediate_schema/migration.sql
+++ b/packages/hub/prisma/migrations/20230914033258_groups_intermediate_schema/migration.sql
@@ -1,0 +1,127 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[slug,ownerId]` on the table `Model` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[slug,ownerId]` on the table `RelativeValuesDefinition` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[ownerId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateEnum
+CREATE TYPE "MembershipRole" AS ENUM ('Admin', 'Member');
+
+-- CreateEnum
+CREATE TYPE "GroupInviteStatus" AS ENUM ('Pending', 'Accepted', 'Declined', 'Canceled');
+
+-- AlterTable
+ALTER TABLE "Model" ADD COLUMN     "ownerId" TEXT;
+
+-- AlterTable
+ALTER TABLE "RelativeValuesDefinition" ADD COLUMN     "ownerId" TEXT;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "ownerId" TEXT;
+
+-- CreateTable
+CREATE TABLE "Group" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "ownerId" TEXT NOT NULL,
+
+    CONSTRAINT "Group_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Owner" (
+    "id" TEXT NOT NULL,
+    "slug" CITEXT NOT NULL,
+
+    CONSTRAINT "Owner_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "UserGroupMembership" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "role" "MembershipRole" NOT NULL,
+    "userId" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+
+    CONSTRAINT "UserGroupMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "GroupInvite" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "userId" TEXT,
+    "email" TEXT,
+    "role" "MembershipRole" NOT NULL,
+    "status" "GroupInviteStatus" NOT NULL DEFAULT 'Pending',
+    "processedAt" TIMESTAMP(3),
+    "groupId" TEXT NOT NULL,
+
+    CONSTRAINT "GroupInvite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Group_ownerId_key" ON "Group"("ownerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Owner_slug_key" ON "Owner"("slug");
+
+-- CreateIndex
+CREATE INDEX "UserGroupMembership_userId_idx" ON "UserGroupMembership"("userId");
+
+-- CreateIndex
+CREATE INDEX "UserGroupMembership_groupId_idx" ON "UserGroupMembership"("groupId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserGroupMembership_userId_groupId_key" ON "UserGroupMembership"("userId", "groupId");
+
+-- CreateIndex
+CREATE INDEX "GroupInvite_groupId_idx" ON "GroupInvite"("groupId");
+
+-- CreateIndex
+CREATE INDEX "GroupInvite_userId_idx" ON "GroupInvite"("userId");
+
+-- CreateIndex
+CREATE INDEX "Model_ownerId_idx" ON "Model"("ownerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Model_slug_ownerId_key" ON "Model"("slug", "ownerId");
+
+-- CreateIndex
+CREATE INDEX "RelativeValuesDefinition_ownerId_idx" ON "RelativeValuesDefinition"("ownerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelativeValuesDefinition_slug_ownerId_key" ON "RelativeValuesDefinition"("slug", "ownerId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_ownerId_key" ON "User"("ownerId");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Owner"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Group" ADD CONSTRAINT "Group_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Owner"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserGroupMembership" ADD CONSTRAINT "UserGroupMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "UserGroupMembership" ADD CONSTRAINT "UserGroupMembership_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupInvite" ADD CONSTRAINT "GroupInvite_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "GroupInvite" ADD CONSTRAINT "GroupInvite_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Model" ADD CONSTRAINT "Model_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Owner"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RelativeValuesDefinition" ADD CONSTRAINT "RelativeValuesDefinition_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "Owner"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/hub/prisma/schema.prisma
+++ b/packages/hub/prisma/schema.prisma
@@ -57,16 +57,28 @@ model Session {
 }
 
 model User {
-  id                        String                     @id @default(cuid())
-  name                      String?
-  email                     String?                    @unique
-  username                  String?                    @unique @db.Citext
-  emailVerified             DateTime?
-  image                     String?
-  accounts                  Account[]
-  sessions                  Session[]
+  id    String  @id @default(cuid())
+  name  String?
+  email String? @unique
+
+  emailVerified DateTime?
+  image         String?
+  accounts      Account[]
+  sessions      Session[]
+  memberships   UserGroupMembership[]
+  invites       GroupInvite[]
+
+  // Legacy, moved to Owner.slug, but necessary for migration
+  username String? @unique @db.Citext
+
+  // Legacy, will be moved under Owner
   models                    Model[]
   relativeValuesDefinitions RelativeValuesDefinition[]
+
+  // Usernames are stored through Owner table, because they share the same namespace with Groups.
+  // Users don't initially have an Owner entry, but are prompted to pick a slug and create one.
+  asOwner Owner?  @relation(fields: [ownerId], references: [id])
+  ownerId String? @unique
 }
 
 model VerificationToken {
@@ -75,6 +87,85 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
+}
+
+model Group {
+  id String @id @default(cuid())
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  memberships UserGroupMembership[]
+  invites     GroupInvite[]
+
+  asOwner Owner  @relation(fields: [ownerId], references: [id])
+  ownerId String @unique
+}
+
+model Owner {
+  id String @id @default(cuid())
+
+  slug String @unique @db.Citext
+
+  group Group?
+  user  User?
+
+  models                    Model[]
+  relativeValuesDefinitions RelativeValuesDefinition[]
+}
+
+enum MembershipRole {
+  Admin
+  Member
+}
+
+model UserGroupMembership {
+  id String @id @default(cuid())
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  role MembershipRole
+
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId  String
+  group   Group  @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId String
+
+  @@unique([userId, groupId])
+  @@index([userId])
+  @@index([groupId])
+}
+
+enum GroupInviteStatus {
+  Pending
+  Accepted
+  Declined
+  Canceled
+}
+
+model GroupInvite {
+  id String @id @default(cuid())
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Polymorphic, one and only one of `userId` and `email` must be set; type safety guaranteed by GraphQL code.
+  user   User?   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String?
+
+  email String?
+
+  role MembershipRole
+
+  status      GroupInviteStatus @default(Pending)
+  processedAt DateTime?
+
+  group   Group  @relation(fields: [groupId], references: [id], onDelete: Cascade)
+  groupId String
+
+  @@index([groupId])
+  @@index([userId])
 }
 
 // Models are polymorphic.
@@ -91,6 +182,9 @@ model Model {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  newOwner Owner?  @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+  ownerId  String?
+
   owner  User   @relation(fields: [userId], references: [id])
   userId String
 
@@ -103,8 +197,10 @@ model Model {
   currentRevisionId String?        @unique
 
   @@unique([slug, userId])
-  @@index([userId])
+  @@unique([slug, ownerId])
   @@index([createdAt])
+  @@index([userId])
+  @@index([ownerId])
 }
 
 model ModelRevision {
@@ -146,6 +242,9 @@ model RelativeValuesDefinition {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  newOwner Owner?  @relation(fields: [ownerId], references: [id])
+  ownerId  String?
+
   owner  User   @relation(fields: [userId], references: [id])
   userId String
 
@@ -158,8 +257,10 @@ model RelativeValuesDefinition {
   modelExports RelativeValuesExport[]
 
   @@unique([slug, userId])
+  @@unique([slug, ownerId])
   @@index([createdAt])
   @@index([userId])
+  @@index([ownerId])
 }
 
 model RelativeValuesDefinitionRevision {


### PR DESCRIPTION
Current plan:
1. <s>Rename `userId` to `ownerId` in main (prisma migration + code changes)</s> (done in previous PR)
2. **Migration to groups schema + optional `ownerId` on Model and RelativeValuesDefinition (prisma migration, backward-compatible)** <--- this PR
3. Fill `ownerId` with a custom script
4. Deploy groups code to prod (merge from main first, remove dev migrations, include migration that makes`ownerId` required and `userId` nullable)
5. Drop `userId` with final prisma migration, and also `User.username`

I'm doing separate PRs for each step for the sake of CI checks and clear history.

This step is relatively safe and backward-compatible, will merge after CI.