### PR TITLE
@testing-library/user-event types are fixed, remove our workaround

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -57,7 +57,7 @@
     "@storybook/react-vite": "^7.2.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.4.3",
+    "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.3",
     "@types/lodash": "^4.14.196",
     "@types/node": "^20.4.7",

--- a/packages/components/test/autorun.test.tsx
+++ b/packages/components/test/autorun.test.tsx
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import { act, render, screen, waitFor } from "@testing-library/react";
-import { userEvent } from "./user-event.js";
+import { userEvent } from "@testing-library/user-event";
 
 import { SquigglePlayground } from "../src/index.js";
 
@@ -14,7 +14,7 @@ test("Autorun is default", async () => {
 });
 
 test("Autorun can be switched off", async () => {
-  const user = userEvent.setup(); // typescript issue is due to ESM mess
+  const user = userEvent.setup();
   act(() => render(<SquigglePlayground defaultCode="70*30" />));
 
   expect(screen.getByTestId("autorun-controls")).toHaveAttribute(
@@ -28,10 +28,9 @@ test("Autorun can be switched off", async () => {
     )
   );
 
-  await act(
-    async () =>
-      await user.click(screen.getByTestId("autorun-controls").firstChild) // disable
-  );
+  await act(async () => {
+    await user.click(screen.getByTestId("autorun-controls").firstElementChild!); // disable
+  });
 
   expect(screen.getByTestId("autorun-controls")).toHaveAttribute(
     "aria-checked",

--- a/packages/components/test/user-event.ts
+++ b/packages/components/test/user-event.ts
@@ -1,7 +1,0 @@
-import userEvent from "@testing-library/user-event";
-
-// Types are broken and hard to fix; https://github.com/testing-library/user-event/issues/1062
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const patchedUserEvent = userEvent as any;
-
-export { patchedUserEvent as userEvent };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
       '@testing-library/user-event':
-        specifier: ^14.4.3
-        version: 14.4.3(@testing-library/dom@9.3.1)
+        specifier: ^14.5.1
+        version: 14.5.1(@testing-library/dom@9.3.1)
       '@types/jest':
         specifier: ^29.5.3
         version: 29.5.3
@@ -7356,7 +7356,7 @@ packages:
     resolution: {integrity: sha512-Ff6jNnrsosmDshgCf0Eb5Cz7IA34p/1Ps5N3Kp3598kfXpBSccSkQQvVFUXC3kIHw/isIXWPqntZuKqnWUz7Gw==}
     dependencies:
       '@testing-library/dom': 9.0.0
-      '@testing-library/user-event': 14.4.3(@testing-library/dom@9.0.0)
+      '@testing-library/user-event': 14.5.1(@testing-library/dom@9.0.0)
       ts-dedent: 2.2.0
     dev: true
 
@@ -7500,8 +7500,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@testing-library/user-event@14.4.3(@testing-library/dom@9.0.0):
-    resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
+  /@testing-library/user-event@14.5.1(@testing-library/dom@9.0.0):
+    resolution: {integrity: sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -7509,8 +7509,8 @@ packages:
       '@testing-library/dom': 9.0.0
     dev: true
 
-  /@testing-library/user-event@14.4.3(@testing-library/dom@9.3.1):
-    resolution: {integrity: sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==}
+  /@testing-library/user-event@14.5.1(@testing-library/dom@9.3.1):
+    resolution: {integrity: sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'


### PR DESCRIPTION
https://github.com/testing-library/user-event/pull/1162

Minor fix for our tests.

PS: Fixed version of @testing-library/user-event was released 20 minutes ago, we're probably the first to adopt it :)