### PR TITLE
Prettier: don't quote new lines in strings

### DIFF
--- a/.changeset/weak-chicken-whisper.md
+++ b/.changeset/weak-chicken-whisper.md
@@ -1,0 +1,5 @@
+---
+"@quri/prettier-plugin-squiggle": patch
+---
+
+Don't quote new lines in strings

--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -306,7 +306,7 @@ export function createSquigglePrinter(
             "}",
           ]);
         case "String":
-          return [JSON.stringify(node.value)];
+          return [JSON.stringify(node.value).replace("\\n", "\n")];
         case "Ternary":
           return [
             node.kind === "C" ? [] : "if ",

--- a/packages/prettier-plugin/test/strings.test.ts
+++ b/packages/prettier-plugin/test/strings.test.ts
@@ -19,4 +19,15 @@ describe("strings", () => {
       `"This is something \\" ' \\" else"`
     );
   });
+
+  // https://github.com/quantified-uncertainty/squiggle/issues/2281
+  test("multiline string", async () => {
+    expect(
+      await format(`
+'foo\t"foo2"
+bar'
+`)
+    ).toBe(`"foo\\t\\"foo2\\"
+bar"`);
+  });
 });


### PR DESCRIPTION
Fixes #2281.

I unquote `\n` from `JSON.stringify`, but keep everything else quoted (e.g. `\t`).