### PR TITLE
Save model drafts in localStorage

### DIFF
--- a/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
@@ -150,7 +150,9 @@ export const EditSquiggleSnippetModel: FC<Props> = ({ modelRef }) => {
 
   const onCodeChange = (code: string) => {
     form.setValue("code", code);
-    draftUtils.save(draftLocator, { formState: form.getValues(), version });
+    if (model.isEditable) {
+      draftUtils.save(draftLocator, { formState: form.getValues(), version });
+    }
   };
 
   // We don't want to control SquigglePlayground, it's uncontrolled by design.

--- a/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
@@ -132,6 +132,9 @@ export const EditSquiggleSnippetModel: FC<Props> = ({ modelRef }) => {
       },
     }),
     confirmation: "Saved",
+    onCompleted() {
+      draftUtils.discard(draftLocator);
+    },
   });
 
   // could version picker be part of the form?

--- a/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
@@ -5,8 +5,9 @@ import { Button, Modal, TextTooltip } from "@quri/ui";
 
 import { SquiggleSnippetDraftDialog_Model$key } from "@/__generated__/SquiggleSnippetDraftDialog_Model.graphql";
 import { SquiggleSnippetFormShape } from "./EditSquiggleSnippetModel";
+import { useClientOnlyRender } from "@/hooks/useClientOnlyRender";
 
-type Draft = {
+export type Draft = {
   formState: SquiggleSnippetFormShape;
   version: string;
 };
@@ -85,6 +86,7 @@ export const SquiggleSnippetDraftDialog: FC<Props> = ({
   draftLocator,
   restore,
 }) => {
+  const isClient = useClientOnlyRender();
   const [draftProcessed, setDraftProcessed] = useState(
     () => !draftUtils.exists(draftLocator)
   );
@@ -107,7 +109,7 @@ export const SquiggleSnippetDraftDialog: FC<Props> = ({
     setDraftProcessed(true);
   };
 
-  return draftProcessed ? null : (
+  return draftProcessed || !isClient ? null : (
     <Modal close={skip}>
       <Modal.Header>Unsaved Draft</Modal.Header>
       <Modal.Body>You have an unsaved draft for this model.</Modal.Body>

--- a/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
@@ -1,0 +1,137 @@
+import { FC, useState } from "react";
+import { graphql, useFragment } from "react-relay";
+
+import { Button, Modal, TextTooltip } from "@quri/ui";
+
+import { SquiggleSnippetDraftDialog_Model$key } from "@/__generated__/SquiggleSnippetDraftDialog_Model.graphql";
+import { SquiggleSnippetFormShape } from "./EditSquiggleSnippetModel";
+
+type Draft = {
+  formState: SquiggleSnippetFormShape;
+  version: string;
+};
+
+type DraftLocator = {
+  ownerSlug: string;
+  modelSlug: string;
+};
+
+function draftKey(key: DraftLocator) {
+  return `modelDraft:${key.ownerSlug}/${key.modelSlug}`;
+}
+
+function localStorageExists() {
+  return Boolean(typeof window !== "undefined" && window.localStorage);
+}
+
+export const draftUtils = {
+  exists(locator: DraftLocator): boolean {
+    if (!localStorageExists()) {
+      return false;
+    }
+    return Boolean(window.localStorage.getItem(draftKey(locator)));
+  },
+  save(locator: DraftLocator, draft: Draft) {
+    if (!localStorageExists()) {
+      return;
+    }
+    window.localStorage.setItem(draftKey(locator), JSON.stringify(draft));
+  },
+  load(locator: DraftLocator): Draft | null {
+    if (!localStorageExists()) {
+      throw new Error("Local storage not available");
+    }
+    const value = window.localStorage.getItem(draftKey(locator));
+    if (!value) return null;
+    return JSON.parse(value); // TODO - validate
+  },
+  discard(locator: DraftLocator) {
+    if (!localStorageExists()) {
+      return;
+    }
+    return window.localStorage.removeItem(draftKey(locator));
+  },
+};
+
+export function useDraftLocator(
+  modelRef: SquiggleSnippetDraftDialog_Model$key
+) {
+  const model = useFragment(
+    graphql`
+      fragment SquiggleSnippetDraftDialog_Model on Model {
+        id
+        slug
+        owner {
+          slug
+        }
+      }
+    `,
+    modelRef
+  );
+
+  const draftLocator: DraftLocator = {
+    ownerSlug: model.owner.slug,
+    modelSlug: model.slug,
+  };
+  return draftLocator;
+}
+
+type Props = {
+  draftLocator: DraftLocator;
+  restore: (draft: Draft) => void;
+};
+
+export const SquiggleSnippetDraftDialog: FC<Props> = ({
+  draftLocator,
+  restore,
+}) => {
+  const [draftProcessed, setDraftProcessed] = useState(
+    () => !draftUtils.exists(draftLocator)
+  );
+
+  const skip = () => {
+    setDraftProcessed(true);
+  };
+
+  const discard = () => {
+    draftUtils.discard(draftLocator);
+    setDraftProcessed(true);
+  };
+
+  const _restore = () => {
+    const draft = draftUtils.load(draftLocator);
+    if (!draft) {
+      throw new Error("Failed to restore draft");
+    }
+    restore(draft);
+    setDraftProcessed(true);
+  };
+
+  return draftProcessed ? null : (
+    <Modal close={skip}>
+      <Modal.Header>Unsaved Draft</Modal.Header>
+      <Modal.Body>You have an unsaved draft for this model.</Modal.Body>
+      <Modal.Footer>
+        <div className="flex items-center justify-end gap-2">
+          <TextTooltip text="Draft will be ignored but you'll see this prompt again on next load.">
+            <div>
+              <Button onClick={skip}>Ignore</Button>
+            </div>
+          </TextTooltip>
+          <TextTooltip text="Draft will be discarded.">
+            <div>
+              <Button onClick={discard}>Discard</Button>
+            </div>
+          </TextTooltip>
+          <TextTooltip text="Code and version will be replaced by draft version. You'll still need to save it manually.">
+            <div>
+              <Button theme="primary" onClick={_restore}>
+                Restore
+              </Button>
+            </div>
+          </TextTooltip>
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+};

--- a/packages/hub/src/hooks/useClientOnlyRender.ts
+++ b/packages/hub/src/hooks/useClientOnlyRender.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useClientOnlyRender() {
+  // https://react.dev/reference/react-dom/client/hydrateRoot#handling-different-client-and-server-content
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  return isClient;
+}


### PR DESCRIPTION
Fixes #1810 for the playground.

Turns out doing this feature with DB backups is quite hard, mostly on design decisions (when to save, when to discard a draft, what to do when user opened multiple tabs, etc.)

So I did a minimal localStorage-powered version instead:
- save to localStorage if model is editable, on each keystroke
- show a modal dialog if the draft exists
- discard a draft on save

Restore dialog:
<img width="914" alt="Captura de pantalla 2023-10-02 a la(s) 17 27 34" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/3a2c09d0-226f-4c88-84db-38a67e74027b">

Each button there has a tooltip with more details.

Implementation details:
- if the model is not editable, drafts are not saved; but if the model was editable before and the draft already exists, then the dialog is displayed anyway (it doesn't matter either way, unless the user was kicked out of a group)
- I'm saving the entire form state + version (which is currently not part of the form), so exported variables config is saved too
- I don't validate that the restored draft matches the form shape; security implications are not significant, and if we ever decide to make breaking changes to the stored format, we can just pick a different key, or provide a compatibility layer