### PR TITLE
Improve package.json exports for prettier plugin

### DIFF
--- a/.changeset/stale-monkeys-confess.md
+++ b/.changeset/stale-monkeys-confess.md
@@ -1,0 +1,5 @@
+---
+"@quri/prettier-plugin-squiggle": patch
+---
+
+Improve package.json exports

--- a/packages/prettier-plugin/package.json
+++ b/packages/prettier-plugin/package.json
@@ -35,11 +35,11 @@
   "exports": {
     ".": {
       "types": "./dist/types/src/index.d.ts",
-      "import": "./dist/esm/src/index.js"
+      "default": "./dist/esm/src/index.js"
     },
     "./standalone": {
       "types": "./dist/types/src/standalone.d.ts",
-      "import": "./dist/esm/src/standalone.js"
+      "default": "./dist/esm/src/standalone.js"
     }
   }
 }


### PR DESCRIPTION
Attempt to fix #2295, trivial one-line change.

Should be safe (we export as `"default"` in components and it works fine)

But ultimately we'll see if it helped only when 0.8.6 is released.