### PR TITLE
Lambda.ts Refactor

### DIFF
--- a/.changeset/long-pugs-tease.md
+++ b/.changeset/long-pugs-tease.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Improved mixture() typing, but limited to 5 parameters maximum. Also adjusted SqLambda to output SqLamdaParameters.

--- a/packages/components/src/components/Calculator/calculatorReducer.ts
+++ b/packages/components/src/components/Calculator/calculatorReducer.ts
@@ -25,9 +25,6 @@ export type CalculatorState = {
   hash: string;
 };
 
-// This function is used to determine if a calculator has changed.
-// It's obviously not perfect - it doesn't capture changes within the calculator function, but this would be much more complicated.
-
 export function hasSameCalculator(state: CalculatorState, calc: SqCalculator) {
   return calc.hashString === state.hash;
 }

--- a/packages/components/src/components/Calculator/calculatorReducer.ts
+++ b/packages/components/src/components/Calculator/calculatorReducer.ts
@@ -27,14 +27,9 @@ export type CalculatorState = {
 
 // This function is used to determine if a calculator has changed.
 // It's obviously not perfect - it doesn't capture changes within the calculator function, but this would be much more complicated.
-export function calculatorHash(calc: SqCalculator): string {
-  const rowData = JSON.stringify(calc.fields);
-  const paramData = (calc.parameters || []).join(",");
-  return rowData + paramData + calc.description;
-}
 
 export function hasSameCalculator(state: CalculatorState, calc: SqCalculator) {
-  return calculatorHash(calc) === state.hash;
+  return calc.hashString === state.hash;
 }
 
 export function allFields(state: CalculatorState): FieldValue[] {
@@ -65,7 +60,7 @@ export function initialCalculatorState(
     fieldNames: calculator.fields.map((row) => row.name),
     fields,
     fn: {},
-    hash: calculatorHash(calculator),
+    hash: calculator.hashString,
   };
 }
 

--- a/packages/components/src/components/Calculator/index.tsx
+++ b/packages/components/src/components/Calculator/index.tsx
@@ -16,7 +16,6 @@ import { Action, useViewerContext } from "../SquiggleViewer/ViewerProvider.js";
 import {
   CalculatorAction,
   CalculatorState,
-  calculatorHash,
   calculatorReducer,
   hasSameCalculator,
   initialCalculatorState,
@@ -106,7 +105,7 @@ export const Calculator: FC<Props> = ({
   useEffect(() => {
     const calculatorChanged =
       prevCalculator !== null &&
-      calculatorHash(calculator) !== calculatorHash(prevCalculator);
+      calculator.hashString !== prevCalculator.hashString;
 
     if (calculatorChanged) {
       calculatorDispatch({

--- a/packages/components/src/components/FunctionChart/index.tsx
+++ b/packages/components/src/components/FunctionChart/index.tsx
@@ -52,7 +52,7 @@ export const FunctionChart: FC<FunctionChartProps> = ({
   height,
 }) => {
   const parameters = fn.paramCounts();
-  if (includes(parameters, 1)) {
+  if (!includes(parameters, 1)) {
     return (
       <MessageAlert heading="Function Display Not Supported">
         Only functions with one parameter are displayed.

--- a/packages/components/src/components/FunctionChart/index.tsx
+++ b/packages/components/src/components/FunctionChart/index.tsx
@@ -17,7 +17,6 @@ import {
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { DistFunctionChart } from "./DistFunctionChart.js";
 import { NumericFunctionChart } from "./NumericFunctionChart.js";
-import includes from "lodash/includes.js";
 
 type FunctionChartProps = {
   fn: SqLambda;
@@ -51,16 +50,16 @@ export const FunctionChart: FC<FunctionChartProps> = ({
   environment,
   height,
 }) => {
-  const parameters = fn.paramCounts();
-  if (!includes(parameters, 1)) {
+  const parameters = fn.parameterCounts();
+  if (!parameters.includes(1)) {
     return (
       <MessageAlert heading="Function Display Not Supported">
         Only functions with one parameter are displayed.
       </MessageAlert>
     );
   }
-  const definitions = fn.definitions();
-  const domain = definitions[0][0]?.domain;
+  const signatures = fn.signatures();
+  const domain = signatures[0][0]?.domain;
 
   const min = domain?.min ?? settings.functionChartSettings.start;
   const max = domain?.max ?? settings.functionChartSettings.stop;

--- a/packages/components/src/components/FunctionChart/index.tsx
+++ b/packages/components/src/components/FunctionChart/index.tsx
@@ -9,7 +9,6 @@ import {
   SqNumberValue,
   SqNumericFnPlot,
 } from "@quri/squiggle-lang";
-
 import { MessageAlert } from "../Alert.js";
 import {
   PlaygroundSettings,
@@ -18,6 +17,7 @@ import {
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { DistFunctionChart } from "./DistFunctionChart.js";
 import { NumericFunctionChart } from "./NumericFunctionChart.js";
+import includes from "lodash/includes.js";
 
 type FunctionChartProps = {
   fn: SqLambda;
@@ -51,8 +51,8 @@ export const FunctionChart: FC<FunctionChartProps> = ({
   environment,
   height,
 }) => {
-  const parameters = fn.parameters();
-  if (parameters.length !== 1) {
+  const parameters = fn.paramCounts();
+  if (includes(parameters, 1)) {
     return (
       <MessageAlert heading="Function Display Not Supported">
         Only functions with one parameter are displayed.

--- a/packages/components/src/components/FunctionChart/index.tsx
+++ b/packages/components/src/components/FunctionChart/index.tsx
@@ -59,7 +59,8 @@ export const FunctionChart: FC<FunctionChartProps> = ({
       </MessageAlert>
     );
   }
-  const domain = parameters[0].domain;
+  const definitions = fn.definitions();
+  const domain = definitions[0][0]?.domain;
 
   const min = domain?.min ?? settings.functionChartSettings.start;
   const max = domain?.max ?? settings.functionChartSettings.stop;

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -188,7 +188,7 @@ export const getBoxProps = (
           <div>
             fn(
             <span className="opacity-60">
-              {truncateStr(value.value.parameterNames().join(", "), 15)}
+              {truncateStr(value.value.parameterString(), 15)}
             </span>
             )
           </div>

--- a/packages/squiggle-lang/__tests__/helpers/reducerHelpers.ts
+++ b/packages/squiggle-lang/__tests__/helpers/reducerHelpers.ts
@@ -66,8 +66,12 @@ export async function expectEvalToMatch(
   expect(resultToString(await evaluateStringToResult(code))).toMatch(expected);
 }
 
-export function testEvalToBe(expr: string, answer: string) {
-  test(expr, async () => await expectEvalToBe(expr, answer));
+export function testEvalToBe(expr: string, answer: string, only = false) {
+  if (only) {
+    test.only(expr, async () => await expectEvalToBe(expr, answer));
+  } else {
+    test(expr, async () => await expectEvalToBe(expr, answer));
+  }
 }
 
 export function testEvalToMatch(expr: string, expected: string | RegExp) {

--- a/packages/squiggle-lang/__tests__/library/mixture_test.ts
+++ b/packages/squiggle-lang/__tests__/library/mixture_test.ts
@@ -2,6 +2,7 @@ import { testRun } from "../helpers/helpers.js";
 import { testEvalToBe } from "../helpers/reducerHelpers.js";
 
 describe("mixture", () => {
+  testEvalToBe("mx(Sym.normal(5,2))", "Point Set Distribution");
   testEvalToBe(
     "mx(Sym.normal(5,2), Sym.normal(10,1), Sym.normal(15, 1))",
     "Point Set Distribution"

--- a/packages/squiggle-lang/__tests__/library/plot_test.ts
+++ b/packages/squiggle-lang/__tests__/library/plot_test.ts
@@ -47,7 +47,7 @@ describe("Plot", () => {
       `Plot.numericFn({
         fn: {|x, y| x * y}
       })`,
-      "Error(Error: Plots only work with functions that have one parameter. This function only supports [2] parameters.)"
+      "Error(Error: Plots only work with functions that have one parameter. This function only supports 2 parameters.)"
     );
 
     testPlotResult(
@@ -129,7 +129,7 @@ describe("Plot", () => {
       `Plot.distFn({
         fn: {|x,y| x to x + y}
        })`,
-      "Error(Error: Plots only work with functions that have one parameter. This function only supports [2] parameters.)"
+      "Error(Error: Plots only work with functions that have one parameter. This function only supports 2 parameters.)"
     );
   });
 

--- a/packages/squiggle-lang/__tests__/library/plot_test.ts
+++ b/packages/squiggle-lang/__tests__/library/plot_test.ts
@@ -47,7 +47,7 @@ describe("Plot", () => {
       `Plot.numericFn({
         fn: {|x, y| x * y}
       })`,
-      "Plots only work with functions that have one parameter. This function has 2 parameters."
+      "Error(Error: Plots only work with functions that have one parameter. This function only supports [2] parameters.)"
     );
 
     testPlotResult(
@@ -129,7 +129,7 @@ describe("Plot", () => {
       `Plot.distFn({
         fn: {|x,y| x to x + y}
        })`,
-      "Plots only work with functions that have one parameter. This function has 2 parameters."
+      "Error(Error: Plots only work with functions that have one parameter. This function only supports [2] parameters.)"
     );
   });
 

--- a/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
@@ -115,7 +115,7 @@ describe("frArray", () => {
   });
 });
 
-test("frTuple", () => {
+describe("frTuple", () => {
   test("two elements", () => {
     const arr = [3, "foo"] as [number, string];
     const value = vArray([vNumber(arr[0]), vString(arr[1])]);

--- a/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
@@ -8,7 +8,7 @@ import {
   frString,
   frTimeDuration,
   frArray,
-  frTuple2,
+  frTuple,
   frDictWithArbitraryKeys,
   frDict,
   frOptional,
@@ -115,11 +115,27 @@ describe("frArray", () => {
   });
 });
 
-test("frTuple2", () => {
-  const arr = [3, "foo"] as [number, string];
-  const value = vArray([vNumber(arr[0]), vString(arr[1])]);
-  expect(frTuple2(frNumber, frString).unpack(value)).toEqual(arr);
-  expect(frTuple2(frNumber, frString).pack(arr)).toEqual(value);
+test("frTuple", () => {
+  test("two elements", () => {
+    const arr = [3, "foo"] as [number, string];
+    const value = vArray([vNumber(arr[0]), vString(arr[1])]);
+    expect(frTuple(frNumber, frString).unpack(value)).toEqual(arr);
+    expect(frTuple(frNumber, frString).pack(arr)).toEqual(value);
+  });
+
+  test("five elements", () => {
+    const arr = [3, "foo", 4, 5, 6] as [number, string, number, number, number];
+    const value = vArray([
+      vNumber(arr[0]),
+      vString(arr[1]),
+      vNumber(arr[2]),
+      vNumber(arr[3]),
+      vNumber(arr[4]),
+    ]);
+    const tuple = frTuple(frNumber, frString, frNumber, frNumber, frNumber);
+    expect(tuple.unpack(value)).toEqual(arr);
+    expect(tuple.pack(arr)).toEqual(value);
+  });
 });
 
 test("frDictWithArbitraryKeys", () => {

--- a/packages/squiggle-lang/src/fr/danger.ts
+++ b/packages/squiggle-lang/src/fr/danger.ts
@@ -18,7 +18,6 @@ import {
   frDist,
   frLambda,
   frNumber,
-  frTuple,
 } from "../library/registry/frTypes.js";
 import { FnFactory, unpackDistResult } from "../library/registry/helpers.js";
 import { ReducerContext } from "../reducer/context.js";

--- a/packages/squiggle-lang/src/fr/danger.ts
+++ b/packages/squiggle-lang/src/fr/danger.ts
@@ -18,6 +18,7 @@ import {
   frDist,
   frLambda,
   frNumber,
+  frTuple,
 } from "../library/registry/frTypes.js";
 import { FnFactory, unpackDistResult } from "../library/registry/helpers.js";
 import { ReducerContext } from "../reducer/context.js";

--- a/packages/squiggle-lang/src/fr/dict.ts
+++ b/packages/squiggle-lang/src/fr/dict.ts
@@ -6,7 +6,7 @@ import {
   frDictWithArbitraryKeys,
   frLambda,
   frString,
-  frTuple2,
+  frTuple,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
@@ -85,7 +85,7 @@ export const library = [
     output: "Dict",
     examples: [`Dict.fromList([["a", 1], ["b", 2]])`],
     definitions: [
-      makeDefinition([frArray(frTuple2(frString, frAny))], ([items]) =>
+      makeDefinition([frArray(frTuple(frString, frAny))], ([items]) =>
         vDict(ImmutableMap(items))
       ),
     ],

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -16,6 +16,7 @@ import { OtherOperationError } from "../operationError.js";
 import * as Result from "../utility/result.js";
 import { Value, vDist } from "../value/index.js";
 import { distResultToValue } from "./genericDist.js";
+import { mixtureDefinitions } from "./mixture.js";
 
 export const CI_CONFIG = [
   { lowKey: "p5", highKey: "p95", probability: 0.9 },
@@ -144,6 +145,16 @@ function makeOneArgDist(
 }
 
 export const library: FRFunction[] = [
+  maker.make({
+    name: "mx",
+    examples: ["mx(1,normal(5,2))"],
+    definitions: mixtureDefinitions,
+  }),
+  maker.make({
+    name: "mixture",
+    examples: ["mixture(1,normal(5,2))"],
+    definitions: mixtureDefinitions,
+  }),
   maker.make({
     name: "normal",
     examples: [

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -10,13 +10,11 @@ import {
   frDistOrNumber,
   frNumber,
   frDict,
-  frArray,
-  frAny,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 import { OtherOperationError } from "../operationError.js";
 import * as Result from "../utility/result.js";
-import { Value, vArray, vDist } from "../value/index.js";
+import { Value, vDist } from "../value/index.js";
 import { distResultToValue } from "./genericDist.js";
 
 export const CI_CONFIG = [

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -10,11 +10,13 @@ import {
   frDistOrNumber,
   frNumber,
   frDict,
+  frArray,
+  frAny,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 import { OtherOperationError } from "../operationError.js";
 import * as Result from "../utility/result.js";
-import { Value, vDist } from "../value/index.js";
+import { Value, vArray, vDist } from "../value/index.js";
 import { distResultToValue } from "./genericDist.js";
 
 export const CI_CONFIG = [

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -97,21 +97,21 @@ export const library = [
     definitions: [
       makeDefinition([frArray(frAny), frLambda], ([array, lambda], context) => {
         const mapped: Value[] = new Array(array.length);
-        const parameters = lambda.getParameterNames().length;
+        const counts = lambda.paramCounts();
 
         // this code is intentionally duplicated for performance reasons
-        if (parameters === 1) {
-          for (let i = 0; i < array.length; i++) {
-            mapped[i] = lambda.call([array[i]], context);
-          }
-        } else if (parameters === 2) {
+        if (includes(counts, 2)) {
           for (let i = 0; i < array.length; i++) {
             mapped[i] = lambda.call([array[i], vNumber(i)], context);
+          }
+        } else if (includes(counts, 1)) {
+          for (let i = 0; i < array.length; i++) {
+            mapped[i] = lambda.call([array[i]], context);
           }
         } else {
           throw new REExpectedType(
             "(number, number?) => ...",
-            `(${lambda.getParameterNames().join(",")}) => ...`
+            `(${lambda.parameterString()}) => ...`
           );
         }
         return vArray(mapped);

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -96,7 +96,7 @@ export const library = [
     definitions: [
       makeDefinition([frArray(frAny), frLambda], ([array, lambda], context) => {
         const mapped: Value[] = new Array(array.length);
-        const counts = lambda.paramCounts();
+        const counts = lambda.parameterCounts();
 
         // this code is intentionally duplicated for performance reasons
         if (counts.includes(2)) {

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -1,4 +1,3 @@
-import includes from "lodash/includes.js";
 import uniqBy from "lodash/uniqBy.js";
 import { REExpectedType, REOther } from "../errors/messages.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
@@ -100,11 +99,11 @@ export const library = [
         const counts = lambda.paramCounts();
 
         // this code is intentionally duplicated for performance reasons
-        if (includes(counts, 2)) {
+        if (counts.includes(2)) {
           for (let i = 0; i < array.length; i++) {
             mapped[i] = lambda.call([array[i], vNumber(i)], context);
           }
-        } else if (includes(counts, 1)) {
+        } else if (counts.includes(1)) {
           for (let i = 0; i < array.length; i++) {
             mapped[i] = lambda.call([array[i]], context);
           }
@@ -145,7 +144,7 @@ export const library = [
     definitions: [
       makeDefinition([frArray(frAny)], ([arr]) => {
         const isUniqableType = (t: Value) =>
-          includes(["String", "Bool", "Number"], t.type);
+          ["String", "Bool", "Number"].includes(t.type);
         //I'm not sure if the r.type concat is essential, but seems safe.
         const uniqueValueKey = (t: Value) => t.toString() + t.type;
 

--- a/packages/squiggle-lang/src/fr/mixture.ts
+++ b/packages/squiggle-lang/src/fr/mixture.ts
@@ -1,5 +1,5 @@
 import { BaseDist } from "../dist/BaseDist.js";
-import { DistError, argumentError } from "../dist/DistError.js";
+import { argumentError } from "../dist/DistError.js";
 import * as SymbolicDist from "../dist/SymbolicDist.js";
 import * as distOperations from "../dist/distOperations/index.js";
 import { Env } from "../dist/env.js";

--- a/packages/squiggle-lang/src/fr/mixture.ts
+++ b/packages/squiggle-lang/src/fr/mixture.ts
@@ -143,4 +143,4 @@ const defs = [
   ...oneToFiveDistsDefs,
 ];
 
-export const mxLambda = new BuiltinLambda("mx", defs);
+export const mxLambda = () => new BuiltinLambda("mx", defs);

--- a/packages/squiggle-lang/src/fr/mixture.ts
+++ b/packages/squiggle-lang/src/fr/mixture.ts
@@ -5,7 +5,6 @@ import * as distOperations from "../dist/distOperations/index.js";
 import { Env } from "../dist/env.js";
 import { unpackDistResult } from "../library/registry/helpers.js";
 import { REDistributionError } from "../errors/messages.js";
-import { BuiltinLambda } from "../reducer/lambda.js";
 import * as E_A from "../utility/E_A.js";
 import { Value, vDist } from "../value/index.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
@@ -135,11 +134,9 @@ const oneToFiveDistsDefs = Array.from({ length: 5 }, (_, i) => {
   );
 });
 
-const defs = [
+export const mixtureDefinitions = [
   singleArrayDef,
   twoArraysDef,
   ...twoToFiveDistsWithWeightsDefs,
   ...oneToFiveDistsDefs,
 ];
-
-export const mxLambda = (name: string) => new BuiltinLambda(name, defs);

--- a/packages/squiggle-lang/src/fr/mixture.ts
+++ b/packages/squiggle-lang/src/fr/mixture.ts
@@ -16,7 +16,7 @@ import {
   frTuple,
 } from "../library/registry/frTypes.js";
 
-function parseDistFromType(d: number | BaseDist): BaseDist {
+function parseDistFromDistOrNumber(d: number | BaseDist): BaseDist {
   if (d instanceof BaseDist) {
     return d;
   } else {
@@ -42,22 +42,10 @@ function mixtureWithDefaultWeights(distributions: BaseDist[], env: Env) {
   return mixtureWithGivenWeights(distributions, weights, env);
 }
 
-function mixtureWithWeightsAndMapping(
-  dists: (number | BaseDist)[],
-  weights: number[],
-  environment: any
-): Value {
-  return mixtureWithGivenWeights(
-    dists.map(parseDistFromType),
-    weights,
-    environment
-  );
-}
-
 const singleArrayDef = makeDefinition(
   [frArray(frDistOrNumber)],
   ([ar], { environment }) =>
-    mixtureWithDefaultWeights(ar.map(parseDistFromType), environment)
+    mixtureWithDefaultWeights(ar.map(parseDistFromDistOrNumber), environment)
 );
 
 const twoArraysDef = makeDefinition(
@@ -71,7 +59,7 @@ const twoArraysDef = makeDefinition(
       );
     }
     return mixtureWithGivenWeights(
-      dists.map(parseDistFromType),
+      dists.map(parseDistFromDistOrNumber),
       weights,
       environment
     );
@@ -82,7 +70,11 @@ const twoToFiveDistsWithWeightsDefs = [
   makeDefinition(
     [frDistOrNumber, frDistOrNumber, frTuple(frNumber, frNumber)],
     ([dist1, dist2, weights], { environment }) =>
-      mixtureWithWeightsAndMapping([dist1, dist2], weights, environment)
+      mixtureWithGivenWeights(
+        [dist1, dist2].map(parseDistFromDistOrNumber),
+        weights,
+        environment
+      )
   ),
   makeDefinition(
     [
@@ -92,7 +84,11 @@ const twoToFiveDistsWithWeightsDefs = [
       frTuple(frNumber, frNumber, frNumber),
     ],
     ([dist1, dist2, dist3, weights], { environment }) =>
-      mixtureWithWeightsAndMapping([dist1, dist2, dist3], weights, environment)
+      mixtureWithGivenWeights(
+        [dist1, dist2, dist3].map(parseDistFromDistOrNumber),
+        weights,
+        environment
+      )
   ),
   makeDefinition(
     [
@@ -103,8 +99,8 @@ const twoToFiveDistsWithWeightsDefs = [
       frTuple(frNumber, frNumber, frNumber, frNumber),
     ],
     ([dist1, dist2, dist3, dist4, weights], { environment }) =>
-      mixtureWithWeightsAndMapping(
-        [dist1, dist2, dist3, dist4],
+      mixtureWithGivenWeights(
+        [dist1, dist2, dist3, dist4].map(parseDistFromDistOrNumber),
         weights,
         environment
       )
@@ -119,8 +115,8 @@ const twoToFiveDistsWithWeightsDefs = [
       frTuple(frNumber, frNumber, frNumber, frNumber, frNumber),
     ],
     ([dist1, dist2, dist3, dist4, dist5, weights], { environment }) =>
-      mixtureWithWeightsAndMapping(
-        [dist1, dist2, dist3, dist4, dist5],
+      mixtureWithGivenWeights(
+        [dist1, dist2, dist3, dist4, dist5].map(parseDistFromDistOrNumber),
         weights,
         environment
       )
@@ -132,7 +128,10 @@ const oneToFiveDistsDefs = Array.from({ length: 5 }, (_, i) => {
   return makeDefinition(
     frArgs,
     (args: (number | BaseDist)[], { environment }) =>
-      mixtureWithDefaultWeights(args.map(parseDistFromType), environment)
+      mixtureWithDefaultWeights(
+        args.map(parseDistFromDistOrNumber),
+        environment
+      )
   );
 });
 
@@ -143,4 +142,4 @@ const defs = [
   ...oneToFiveDistsDefs,
 ];
 
-export const mxLambda = () => new BuiltinLambda("mx", defs);
+export const mxLambda = (name: string) => new BuiltinLambda(name, defs);

--- a/packages/squiggle-lang/src/fr/mixture.ts
+++ b/packages/squiggle-lang/src/fr/mixture.ts
@@ -9,6 +9,13 @@ import { BuiltinLambda } from "../reducer/lambda.js";
 import * as E_A from "../utility/E_A.js";
 import * as Result from "../utility/result.js";
 import { Value, vDist } from "../value/index.js";
+import { makeDefinition } from "../library/registry/fnDefinition.js";
+import {
+  frAny,
+  frArray,
+  frDistOrNumber,
+  frNumber,
+} from "../library/registry/frTypes.js";
 
 function raiseArgumentError(message: string): never {
   throw new REDistributionError(argumentError(message));
@@ -24,7 +31,7 @@ function parseNumber(arg: Value): number {
 
 const parseNumberArray = (args: Value[]): number[] => args.map(parseNumber);
 
-function parseDist(args: Value): BaseDist {
+function parseDistFromValue(args: Value): BaseDist {
   if (args.type === "Dist") {
     return args.value;
   } else if (args.type === "Number") {
@@ -34,7 +41,16 @@ function parseDist(args: Value): BaseDist {
   }
 }
 
-const parseDistributionArray = (ags: Value[]): BaseDist[] => ags.map(parseDist);
+function parseDistFromType(d: number | BaseDist): BaseDist {
+  if (d instanceof BaseDist) {
+    return d;
+  } else {
+    return new SymbolicDist.PointMass(d);
+  }
+}
+
+const parseDistributionArray = (ags: Value[]): BaseDist[] =>
+  ags.map(parseDistFromValue);
 
 function mixtureWithGivenWeights(
   distributions: BaseDist[],
@@ -56,38 +72,65 @@ function mixtureWithDefaultWeights(distributions: BaseDist[], env: Env) {
   return mixtureWithGivenWeights(distributions, weights, env);
 }
 
-function mixture(args: Value[], env: Env) {
-  if (args.length === 1 && args[0].type === "Array") {
-    return mixtureWithDefaultWeights(
-      parseDistributionArray(args[0].value),
-      env
+const defs = [
+  makeDefinition([frDistOrNumber], ([dist], { environment }) => {
+    return vDist(
+      unpackDistResult(
+        mixtureWithDefaultWeights([parseDistFromType(dist)], environment)
+      )
     );
-  } else if (
-    args.length === 2 &&
-    args[0].type === "Array" &&
-    args[1].type === "Array"
-  ) {
-    const distributions = args[0].value;
-    const weights = args[1].value;
-    const distrs = parseDistributionArray(distributions);
-    const wghts = parseNumberArray(weights);
-    return mixtureWithGivenWeights(distrs, wghts, env);
-  } else if (args.length > 0) {
-    const last = args[args.length - 1];
-    if (last.type === "Array") {
-      const weights = parseNumberArray(last.value);
-      const distributions = parseDistributionArray(
-        args.slice(0, args.length - 1)
-      );
-      return mixtureWithGivenWeights(distributions, weights, env);
-    } else if (last.type === "Number" || last.type === "Dist") {
-      return mixtureWithDefaultWeights(parseDistributionArray(args), env);
-    }
-  }
-  raiseArgumentError("Last argument of mx must be array or distribution");
-}
+  }),
+  makeDefinition([frArray(frDistOrNumber)], ([ar], { environment }) => {
+    return vDist(
+      unpackDistResult(
+        mixtureWithDefaultWeights(ar.map(parseDistFromType), environment)
+      )
+    );
+  }),
+  makeDefinition(
+    [frArray(frDistOrNumber), frArray(frNumber)],
+    ([dists, weights], { environment }) =>
+      vDist(
+        unpackDistResult(
+          mixtureWithGivenWeights(
+            dists.map(parseDistFromType),
+            weights,
+            environment
+          )
+        )
+      )
+  ),
+  ...Array.from({ length: 9 }, (_, i) => {
+    const frArgs = [frAny, ...new Array(i).fill(frAny)];
+    return makeDefinition(frArgs, (args: Value[], { environment }) => {
+      const last: Value = args[args.length - 1];
+
+      function getMixture() {
+        if (last.type === "Array") {
+          const weights = parseNumberArray(last.value);
+          const distributions = parseDistributionArray(
+            args.slice(0, args.length - 1)
+          );
+          return mixtureWithGivenWeights(distributions, weights, environment);
+        } else if (last.type === "Number" || last.type === "Dist") {
+          return mixtureWithDefaultWeights(
+            parseDistributionArray(args),
+            environment
+          );
+        } else {
+          raiseArgumentError(
+            "Last argument of mx must be array or distribution"
+          );
+        }
+      }
+      return vDist(unpackDistResult(getMixture()));
+    });
+  }),
+];
 
 // impossible to implement with FR due to arbitrary parameters length
-export const mxLambda = new BuiltinLambda("mx", (inputs, context) => {
-  return vDist(unpackDistResult(mixture(inputs, context.environment)));
-});
+// export const mxLambda = new BuiltinLambda("mx", [], (inputs, context) => {
+//   return vDist(unpackDistResult(mixture(inputs, context.environment)));
+// });
+
+export const mxLambda = new BuiltinLambda("mx", defs);

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -1,3 +1,4 @@
+import includes from "lodash/includes.js";
 import { PointMass } from "../dist/SymbolicDist.js";
 import { REOther } from "../errors/messages.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
@@ -69,15 +70,18 @@ function createScale(scale: Scale | null, domain: VDomain | undefined): Scale {
 
 // This function both extract the domain and checks that the function has only one parameter.
 function extractDomainFromOneArgFunction(fn: Lambda): VDomain | undefined {
-  const parameters = fn.getParameters();
-  if (parameters.length !== 1) {
+  const counts = fn.paramCounts();
+  if (!includes(counts, 1)) {
     throw new REOther(
-      `Plots only work with functions that have one parameter. This function has ${parameters.length} parameters.`
+      `Plots only work with functions that have one parameter. This function only supports [${counts.join(
+        ","
+      )}] parameters.`
     );
   }
+  const domain = fn.getParameters()[0]?.domain;
   // We could also verify a domain here, to be more confident that the function expects numeric args.
   // But we might get other numeric domains besides `NumericRange`, so checking domain type here would be risky.
-  return parameters[0].domain;
+  return domain;
 }
 
 export const library = [

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -69,7 +69,7 @@ function createScale(scale: Scale | null, domain: VDomain | undefined): Scale {
 
 // This function both extract the domain and checks that the function has only one parameter.
 function extractDomainFromOneArgFunction(fn: Lambda): VDomain | undefined {
-  const counts = fn.paramCounts();
+  const counts = fn.parameterCounts();
   if (!counts.includes(1)) {
     throw new REOther(
       `Plots only work with functions that have one parameter. This function only supports ${fn.parameterCountString()} parameters.`

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -1,4 +1,3 @@
-import includes from "lodash/includes.js";
 import { PointMass } from "../dist/SymbolicDist.js";
 import { REOther } from "../errors/messages.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
@@ -71,11 +70,9 @@ function createScale(scale: Scale | null, domain: VDomain | undefined): Scale {
 // This function both extract the domain and checks that the function has only one parameter.
 function extractDomainFromOneArgFunction(fn: Lambda): VDomain | undefined {
   const counts = fn.paramCounts();
-  if (!includes(counts, 1)) {
+  if (!counts.includes(1)) {
     throw new REOther(
-      `Plots only work with functions that have one parameter. This function only supports [${counts.join(
-        ","
-      )}] parameters.`
+      `Plots only work with functions that have one parameter. This function only supports ${fn.getParameterCountString()} parameters.`
     );
   }
 

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -15,7 +15,7 @@ import {
   frString,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
-import { Lambda } from "../reducer/lambda.js";
+import { Lambda, UserDefinedLambda } from "../reducer/lambda.js";
 import { LabeledDistribution, Scale, VDomain, vPlot } from "../value/index.js";
 
 const maker = new FnFactory({
@@ -78,7 +78,13 @@ function extractDomainFromOneArgFunction(fn: Lambda): VDomain | undefined {
       )}] parameters.`
     );
   }
-  const domain = fn.getParameters()[0]?.domain;
+
+  let domain;
+  if (fn instanceof UserDefinedLambda) {
+    domain = fn.parameters[0]?.domain;
+  } else {
+    domain = undefined;
+  }
   // We could also verify a domain here, to be more confident that the function expects numeric args.
   // But we might get other numeric domains besides `NumericRange`, so checking domain type here would be risky.
   return domain;

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -72,12 +72,12 @@ function extractDomainFromOneArgFunction(fn: Lambda): VDomain | undefined {
   const counts = fn.paramCounts();
   if (!counts.includes(1)) {
     throw new REOther(
-      `Plots only work with functions that have one parameter. This function only supports ${fn.getParameterCountString()} parameters.`
+      `Plots only work with functions that have one parameter. This function only supports ${fn.parameterCountString()} parameters.`
     );
   }
 
   let domain;
-  if (fn instanceof UserDefinedLambda) {
+  if (fn.type === "UserDefinedLambda") {
     domain = fn.parameters[0]?.domain;
   } else {
     domain = undefined;

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -28,7 +28,7 @@ export {
   type SqDistribution,
 } from "./public/SqValue/SqDistribution/index.js";
 export { type SqDomain } from "./public/SqValue/SqDomain.js";
-export { SqLambda } from "./public/SqValue/SqLambda.js";
+export { SqLambda, type SqLambdaParameter } from "./public/SqValue/SqLambda.js";
 export { SqDictValue } from "./public/SqValue/index.js";
 export {
   SqDistFnPlot,

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -40,7 +40,7 @@ function makeStdLib(): Bindings {
   res = res.set(INDEX_LOOKUP_FUNCTION, vLambda(makeLookupLambda()));
 
   // some lambdas can't be expressed in function registry (e.g. `mx` with its variadic number of parameters)
-  for (const [name, lambda] of nonRegistryLambdas) {
+  for (const [name, lambda] of nonRegistryLambdas()) {
     res = res.set(name, vLambda(lambda));
   }
 

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -6,11 +6,7 @@ import { vLambda } from "../value/index.js";
 import { Bindings } from "../reducer/stack.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { makeMathConstants } from "./math.js";
-import {
-  makeSquiggleBindings,
-  nonRegistryLambdas,
-  registry,
-} from "./registry/index.js";
+import { makeSquiggleBindings, registry } from "./registry/index.js";
 import { makeVersionConstant } from "./version.js";
 import { frAny } from "./registry/frTypes.js";
 import { makeDefinition } from "./registry/fnDefinition.js";
@@ -38,11 +34,6 @@ function makeStdLib(): Bindings {
 
   // field lookups
   res = res.set(INDEX_LOOKUP_FUNCTION, vLambda(makeLookupLambda()));
-
-  // some lambdas can't be expressed in function registry (e.g. `mx` with its variadic number of parameters)
-  for (const [name, lambda] of nonRegistryLambdas) {
-    res = res.set(name, vLambda(lambda));
-  }
 
   // bind the entire FunctionRegistry
   for (const name of registry.allNames()) {

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -40,7 +40,7 @@ function makeStdLib(): Bindings {
   res = res.set(INDEX_LOOKUP_FUNCTION, vLambda(makeLookupLambda()));
 
   // some lambdas can't be expressed in function registry (e.g. `mx` with its variadic number of parameters)
-  for (const [name, lambda] of nonRegistryLambdas()) {
+  for (const [name, lambda] of nonRegistryLambdas) {
     res = res.set(name, vLambda(lambda));
   }
 

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -12,21 +12,21 @@ import {
   registry,
 } from "./registry/index.js";
 import { makeVersionConstant } from "./version.js";
+import { frAny } from "./registry/frTypes.js";
+import { makeDefinition } from "./registry/fnDefinition.js";
 
-function makeLookupLambda(): Lambda {
-  return new BuiltinLambda(INDEX_LOOKUP_FUNCTION, (inputs) => {
-    if (inputs.length !== 2) {
-      // should never happen
-      throw new REOther("Index lookup internal error");
-    }
-
-    const [obj, key] = inputs;
+const definitions = [
+  makeDefinition([frAny, frAny], ([obj, key]) => {
     if ("get" in obj) {
       return obj.get(key).clone();
     } else {
       throw new REOther("Trying to access key on wrong value");
     }
-  });
+  }),
+];
+
+function makeLookupLambda(): Lambda {
+  return new BuiltinLambda(INDEX_LOOKUP_FUNCTION, definitions);
 }
 
 function makeStdLib(): Bindings {

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -66,6 +66,11 @@ export class Registry {
     if (!this.fnNameDict.has(fnName)) {
       throw new Error(`Function ${fnName} doesn't exist in registry`);
     }
-    return new BuiltinLambda(fnName, this.fnNameDict.get(fnName) || []);
+    const definitions = this.fnNameDict.get(fnName);
+    if (definitions === undefined) {
+      throw new Error(`Function ${fnName} has no definitions`);
+    } else {
+      return new BuiltinLambda(fnName, definitions);
+    }
   }
 }

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -94,10 +94,6 @@ export class Registry {
     if (!this.fnNameDict.has(fnName)) {
       throw new Error(`Function ${fnName} doesn't exist in registry`);
     }
-    return new BuiltinLambda(fnName, (args, context) => {
-      // Note: current bindings could be accidentally exposed here through context (compare with native lambda implementation above, where we override them with local bindings).
-      // But FunctionRegistry API is too limited for that to matter. Please take care not to violate that in the future by accident.
-      return this.call(fnName, args, context);
-    });
+    return new BuiltinLambda(fnName, this.fnNameDict.get(fnName) || []);
   }
 }

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -1,12 +1,6 @@
-import { REOther, RESymbolNotFound } from "../../errors/messages.js";
-import { ReducerContext } from "../../reducer/context.js";
 import { BuiltinLambda, Lambda } from "../../reducer/lambda.js";
 import { Value } from "../../value/index.js";
-import {
-  FnDefinition,
-  fnDefinitionToString,
-  tryCallFnDefinition,
-} from "./fnDefinition.js";
+import { FnDefinition } from "./fnDefinition.js";
 
 export type FRFunction = {
   name: string;
@@ -66,28 +60,6 @@ export class Registry {
 
   allNames(): string[] {
     return [...this.fnNameDict.keys()];
-  }
-
-  call(fnName: string, args: Value[], context: ReducerContext): Value {
-    const definitions = this.fnNameDict.get(fnName);
-    if (definitions === undefined) {
-      throw new RESymbolNotFound(fnName);
-    }
-    const showNameMatchDefinitions = () => {
-      const defsString = definitions
-        .map(fnDefinitionToString)
-        .map((def) => `  ${fnName}${def}\n`)
-        .join("");
-      return `There are function matches for ${fnName}(), but with different arguments:\n${defsString}`;
-    };
-
-    for (const definition of definitions) {
-      const callResult = tryCallFnDefinition(definition, args, context);
-      if (callResult !== undefined) {
-        return callResult;
-      }
-    }
-    throw new REOther(showNameMatchDefinitions());
   }
 
   makeLambda(fnName: string): Lambda {

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -28,27 +28,27 @@ export type FRType<T> = {
 
 export const frNumber: FRType<number> = {
   unpack: (v: Value) => (v.type === "Number" ? v.value : undefined),
-  pack: vNumber,
+  pack: (v) => vNumber(v),
   getName: () => "number",
 };
 export const frString: FRType<string> = {
   unpack: (v: Value) => (v.type === "String" ? v.value : undefined),
-  pack: vString,
+  pack: (v) => vString(v),
   getName: () => "string",
 };
 export const frBool: FRType<boolean> = {
   unpack: (v: Value) => (v.type === "Bool" ? v.value : undefined),
-  pack: vBool,
+  pack: (v) => vBool(v),
   getName: () => "bool",
 };
 export const frDate: FRType<Date> = {
   unpack: (v) => (v.type === "Date" ? v.value : undefined),
-  pack: vDate,
+  pack: (v) => vDate(v),
   getName: () => "date",
 };
 export const frTimeDuration: FRType<number> = {
   unpack: (v) => (v.type === "TimeDuration" ? v.value : undefined),
-  pack: vTimeDuration,
+  pack: (v) => vTimeDuration(v),
   getName: () => "duration",
 };
 export const frDistOrNumber: FRType<BaseDist | number> = {
@@ -59,17 +59,17 @@ export const frDistOrNumber: FRType<BaseDist | number> = {
 };
 export const frDist: FRType<BaseDist> = {
   unpack: (v) => (v.type === "Dist" ? v.value : undefined),
-  pack: vDist,
+  pack: (v) => vDist(v),
   getName: () => "distribution",
 };
 export const frLambda: FRType<Lambda> = {
   unpack: (v) => (v.type === "Lambda" ? v.value : undefined),
-  pack: vLambda,
+  pack: (v) => vLambda(v),
   getName: () => "lambda",
 };
 export const frScale: FRType<Scale> = {
   unpack: (v) => (v.type === "Scale" ? v.value : undefined),
-  pack: vScale,
+  pack: (v) => vScale(v),
   getName: () => "scale",
 };
 

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -123,6 +123,56 @@ export const frTuple2 = <T1, T2>(
   };
 };
 
+export function frTuple<T1, T2>(
+  type1: FRType<T1>,
+  type2: FRType<T2>
+): FRType<[T1, T2]>;
+
+export function frTuple<T1, T2, T3>(
+  type1: FRType<T1>,
+  type2: FRType<T2>,
+  type3: FRType<T3>
+): FRType<[T1, T2, T3]>;
+
+export function frTuple<T1, T2, T3, T4>(
+  type1: FRType<T1>,
+  type2: FRType<T2>,
+  type3: FRType<T3>,
+  type4: FRType<T4>
+): FRType<[T1, T2, T3, T4]>;
+
+export function frTuple<T1, T2, T3, T4, T5>(
+  type1: FRType<T1>,
+  type2: FRType<T2>,
+  type3: FRType<T3>,
+  type4: FRType<T4>,
+  type5: FRType<T5>
+): FRType<[T1, T2, T3, T4, T5]>;
+
+export function frTuple(...types: FRType<any>[]): any {
+  const numTypes = types.length;
+
+  return {
+    unpack: (v: Value) => {
+      if (v.type !== "Array" || v.value.length !== numTypes) {
+        return undefined;
+      }
+
+      const items = types.map((type, index) => type.unpack(v.value[index]));
+
+      if (items.some((item) => item === undefined)) {
+        return undefined;
+      }
+
+      return items as any;
+    },
+    pack: (values: any[]) => {
+      return vArray(values.map((val, index) => types[index].pack(val)));
+    },
+    getName: () => `tuple(${types.map((type) => type.getName()).join(", ")})`,
+  };
+}
+
 export const frDictWithArbitraryKeys = <T>(
   itemType: FRType<T>
 ): FRType<ImmutableMap<string, T>> => {

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -149,7 +149,7 @@ export function frTuple<T1, T2, T3, T4, T5>(
   type5: FRType<T5>
 ): FRType<[T1, T2, T3, T4, T5]>;
 
-export function frTuple(...types: FRType<any>[]): any {
+export function frTuple(...types: FRType<unknown>[]): FRType<any> {
   const numTypes = types.length;
 
   return {
@@ -164,9 +164,9 @@ export function frTuple(...types: FRType<any>[]): any {
         return undefined;
       }
 
-      return items as any;
+      return items;
     },
-    pack: (values: any[]) => {
+    pack: (values: unknown[]) => {
       return vArray(values.map((val, index) => types[index].pack(val)));
     },
     getName: () => `tuple(${types.map((type) => type.getName()).join(", ")})`,

--- a/packages/squiggle-lang/src/library/registry/index.ts
+++ b/packages/squiggle-lang/src/library/registry/index.ts
@@ -52,9 +52,9 @@ const fnList: FRFunction[] = [
 
 export const registry = Registry.make(fnList);
 
-export const nonRegistryLambdas: [string, Lambda][] = [
-  ["mx", mxLambda],
-  ["mixture", mxLambda],
+export const nonRegistryLambdas: () => [string, Lambda][] = () => [
+  ["mx", mxLambda()],
+  ["mixture", mxLambda()],
 ];
 
 export function makeSquiggleBindings(builtins: Bindings): Bindings {

--- a/packages/squiggle-lang/src/library/registry/index.ts
+++ b/packages/squiggle-lang/src/library/registry/index.ts
@@ -53,8 +53,8 @@ const fnList: FRFunction[] = [
 export const registry = Registry.make(fnList);
 
 export const nonRegistryLambdas: [string, Lambda][] = [
-  ["mx", mxLambda()],
-  ["mixture", mxLambda()],
+  ["mx", mxLambda("mx")],
+  ["mixture", mxLambda("mixture")],
 ];
 
 export function makeSquiggleBindings(builtins: Bindings): Bindings {

--- a/packages/squiggle-lang/src/library/registry/index.ts
+++ b/packages/squiggle-lang/src/library/registry/index.ts
@@ -52,7 +52,7 @@ const fnList: FRFunction[] = [
 
 export const registry = Registry.make(fnList);
 
-export const nonRegistryLambdas: () => [string, Lambda][] = () => [
+export const nonRegistryLambdas: [string, Lambda][] = [
   ["mx", mxLambda()],
   ["mixture", mxLambda()],
 ];

--- a/packages/squiggle-lang/src/library/registry/index.ts
+++ b/packages/squiggle-lang/src/library/registry/index.ts
@@ -1,4 +1,3 @@
-import { Lambda } from "../../reducer/lambda.js";
 import { FRFunction, Registry } from "./core.js";
 
 import { library as builtinLibrary } from "../../fr/builtin.js";

--- a/packages/squiggle-lang/src/library/registry/index.ts
+++ b/packages/squiggle-lang/src/library/registry/index.ts
@@ -24,7 +24,6 @@ import { library as scoringLibrary } from "../../fr/scoring.js";
 import { library as symLibrary } from "../../fr/sym.js";
 import { library as unitsLibrary } from "../../fr/units.js";
 
-import { mxLambda } from "../../fr/mixture.js";
 import { Bindings } from "../../reducer/stack.js";
 import { ImmutableMap } from "../../utility/immutableMap.js";
 
@@ -51,11 +50,6 @@ const fnList: FRFunction[] = [
 ];
 
 export const registry = Registry.make(fnList);
-
-export const nonRegistryLambdas: [string, Lambda][] = [
-  ["mx", mxLambda("mx")],
-  ["mixture", mxLambda("mixture")],
-];
 
 export function makeSquiggleBindings(builtins: Bindings): Bindings {
   let squiggleBindings: Bindings = ImmutableMap();

--- a/packages/squiggle-lang/src/public/SqValue/SqCalculator.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqCalculator.ts
@@ -34,6 +34,15 @@ export class SqCalculator {
     return this._value.description;
   }
 
+  // This function is used to determine if a calculator has changed.
+  // It's obviously not perfect - it doesn't capture changes within the calculator function, but this would be much more complicated.
+
+  get hashString(): string {
+    const rowData = JSON.stringify(this._value.fields);
+    const paramData = this._value.fn.toString() || "";
+    return rowData + paramData + this._value.description;
+  }
+
   get fields(): {
     name: string;
     default: string;

--- a/packages/squiggle-lang/src/public/SqValue/SqCalculator.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqCalculator.ts
@@ -34,10 +34,6 @@ export class SqCalculator {
     return this._value.description;
   }
 
-  get parameters(): string[] {
-    return this._value.fn.getParameterNames();
-  }
-
   get fields(): {
     name: string;
     default: string;

--- a/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
@@ -20,23 +20,24 @@ export type SqLambdaParameter = {
 type SqLambdaSignature = SqLambdaParameter[];
 
 function lambdaToSqLambdaSignatures(lambda: Lambda): SqLambdaSignature[] {
-  if (lambda.type === "UserDefinedLambda") {
-    return [
-      lambda.parameters.map((param) => {
-        return {
-          name: param.name,
-          domain: param.domain ? wrapDomain(param.domain.value) : undefined,
-        };
-      }),
-    ];
-  } else {
-    return lambda.signatures().map((def) =>
-      def.map((p, index) => ({
-        name: index.toString(),
-        domain: undefined,
-        typeName: p.getName(),
-      }))
-    );
+  switch (lambda.type) {
+    case "UserDefinedLambda":
+      return [
+        lambda.parameters.map((param) => {
+          return {
+            name: param.name,
+            domain: param.domain ? wrapDomain(param.domain.value) : undefined,
+          };
+        }),
+      ];
+    case "BuiltinLambda":
+      return lambda.signatures().map((def) =>
+        def.map((p, index) => ({
+          name: index.toString(),
+          domain: undefined,
+          typeName: p.getName(),
+        }))
+      );
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
@@ -2,11 +2,7 @@ import { Env } from "../../dist/env.js";
 import { IRuntimeError } from "../../errors/IError.js";
 import { getStdLib } from "../../library/index.js";
 import { createContext } from "../../reducer/context.js";
-import {
-  BuiltinLambda,
-  Lambda,
-  UserDefinedLambda,
-} from "../../reducer/lambda.js";
+import { Lambda } from "../../reducer/lambda.js";
 import * as Result from "../../utility/result.js";
 import { result } from "../../utility/result.js";
 
@@ -22,7 +18,7 @@ export type SqLambdaParameter = {
 };
 
 function lambdaToSqLambdaParameters(lambda: Lambda): SqLambdaParameter[][] {
-  if (lambda instanceof UserDefinedLambda) {
+  if (lambda.type === "UserDefinedLambda") {
     return [
       lambda.parameters.map((param) => {
         return {
@@ -31,16 +27,14 @@ function lambdaToSqLambdaParameters(lambda: Lambda): SqLambdaParameter[][] {
         };
       }),
     ];
-  } else if (lambda instanceof BuiltinLambda) {
-    return lambda.definitions().map((def) =>
+  } else {
+    return lambda.signatures().map((def) =>
       def.map((p, index) => ({
         name: index.toString(),
         domain: undefined,
         typeName: p.getName(),
       }))
     );
-  } else {
-    throw new Error("Unknown lambda type");
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
@@ -17,7 +17,9 @@ export type SqLambdaParameter = {
   typeName?: string;
 };
 
-function lambdaToSqLambdaParameters(lambda: Lambda): SqLambdaParameter[][] {
+type SqLambdaSignature = SqLambdaParameter[];
+
+function lambdaToSqLambdaSignatures(lambda: Lambda): SqLambdaSignature[] {
   if (lambda.type === "UserDefinedLambda") {
     return [
       lambda.parameters.map((param) => {
@@ -55,12 +57,12 @@ export class SqLambda {
     return new SqLambda(value.value);
   }
 
-  paramCounts() {
-    return this._value.paramCounts();
+  parameterCounts() {
+    return this._value.parameterCounts();
   }
 
-  definitions(): SqLambdaParameter[][] {
-    return lambdaToSqLambdaParameters(this._value);
+  signatures(): SqLambdaSignature[] {
+    return lambdaToSqLambdaSignatures(this._value);
   }
 
   call(args: SqValue[], env?: Env): result<SqValue, SqError> {

--- a/packages/squiggle-lang/src/reducer/context.ts
+++ b/packages/squiggle-lang/src/reducer/context.ts
@@ -2,14 +2,14 @@ import { Env } from "../dist/env.js";
 import { Stack } from "./stack.js";
 import { FrameStack, topFrameName } from "./frameStack.js";
 import { ReducerFn, evaluate } from "./index.js";
-import { Lambda } from "./lambda.js";
+import { BaseLambda } from "./lambda.js";
 
 export type ReducerContext = Readonly<{
   stack: Stack;
   environment: Env;
   frameStack: FrameStack;
   evaluate: ReducerFn;
-  inFunction: Lambda | undefined;
+  inFunction: BaseLambda | undefined;
 }>;
 
 export function createContext(environment: Env): ReducerContext {

--- a/packages/squiggle-lang/src/reducer/index.ts
+++ b/packages/squiggle-lang/src/reducer/index.ts
@@ -28,7 +28,7 @@ import {
   vVoid,
 } from "../value/index.js";
 import * as Context from "./context.js";
-import { LambdaParameter, SquiggleLambda } from "./lambda.js";
+import { UserDefinedLambdaParameter, UserDefinedLambda } from "./lambda.js";
 
 export type ReducerFn = (
   expression: Expression,
@@ -93,7 +93,7 @@ const evaluateBlock: SubReducerFn<"Block"> = (statements, context) => {
    * We could call `bindings.extend()` here, but we don't, since scopes are costly and bindings are immutable anyway.
    * So we just have to be careful to throw away block's bindings at the end of a block scope and return the original context.
    * Note: We'll have to remove this optimization if we add any kind of `locals()` (like in Python) function or debugging utilities.
-   * See also: similar note in `SquiggleLambda` constructor.
+   * See also: similar note in `UserDefinedLambda` constructor.
    */
   let currentContext = context;
   let currentValue: Value = vVoid();
@@ -207,7 +207,7 @@ const evaluateLambda: SubReducerFn<"Lambda"> = (
   context,
   ast
 ) => {
-  const parameters: LambdaParameter[] = [];
+  const parameters: UserDefinedLambdaParameter[] = [];
   for (const parameterExpression of expressionValue.parameters) {
     let domain: VDomain | undefined;
     // Processing annotations, e.g. f(x: [3, 5]) = { ... }
@@ -238,7 +238,7 @@ const evaluateLambda: SubReducerFn<"Lambda"> = (
     });
   }
   const value = vLambda(
-    new SquiggleLambda(
+    new UserDefinedLambda(
       expressionValue.name,
       parameters,
       context.stack,

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -31,7 +31,7 @@ export abstract class BaseLambda {
   abstract getName(): string;
   abstract toString(): string;
   abstract parameterString(): string;
-  abstract paramCounts(): number[];
+  abstract parameterCounts(): number[];
   abstract parameterCountString(): string;
 
   callFrom(
@@ -66,7 +66,7 @@ export abstract class BaseLambda {
 
 // User-defined functions, e.g. `add2 = {|x, y| x + y}`, are instances of this class.
 export class UserDefinedLambda extends BaseLambda {
-  public parameters: UserDefinedLambdaParameter[];
+  parameters: UserDefinedLambdaParameter[];
   location: LocationRange;
   name?: string;
   readonly type = "UserDefinedLambda";
@@ -129,7 +129,7 @@ export class UserDefinedLambda extends BaseLambda {
     return `lambda(${this._getParameterNames().join(",")}=>internal code)`;
   }
 
-  paramCounts() {
+  parameterCounts() {
     return [this.parameters.length];
   }
 
@@ -190,7 +190,7 @@ export class BuiltinLambda extends BaseLambda {
     throw new REOther(showNameMatchDefinitions());
   }
 
-  paramCounts() {
+  parameterCounts() {
     return sort(uniq(this._signatures.map((d) => d.inputs.length)));
   }
 }

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -32,6 +32,7 @@ export abstract class Lambda {
   abstract toString(): string;
   abstract parameterString(): string;
   abstract paramCounts(): number[];
+  abstract getParameterCountString(): string;
 
   callFrom(
     args: Value[],
@@ -131,6 +132,10 @@ export class UserDefinedLambda extends Lambda {
   paramCounts() {
     return [this.parameters.length];
   }
+
+  getParameterCountString() {
+    return this.parameters.length.toString();
+  }
 }
 
 // Stdlib functions (everything in FunctionRegistry) are instances of this class.
@@ -156,6 +161,10 @@ export class BuiltinLambda extends Lambda {
 
   parameterString() {
     return this._definitions.map(fnDefinitionToString).join(" | ");
+  }
+
+  getParameterCountString() {
+    return `[${this._definitions.map((d) => d.inputs.length).join(",")}]`;
   }
 
   definitions(): FRType<any>[][] {

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -167,7 +167,7 @@ export class BuiltinLambda extends BaseLambda {
     return `[${this._signatures.map((d) => d.inputs.length).join(",")}]`;
   }
 
-  signatures(): FRType<any>[][] {
+  signatures(): FRType<unknown>[][] {
     return this._signatures.map((d) => d.inputs);
   }
 

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -10,6 +10,7 @@ import { Lambda } from "../reducer/lambda.js";
 import * as DateTime from "../utility/DateTime.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { Domain } from "./domain.js";
+import includes from "lodash/includes.js";
 
 export type ValueMap = ImmutableMap<string, Value>;
 
@@ -284,11 +285,13 @@ class VCalculator extends BaseValue {
 
   constructor(public value: Calculator) {
     super();
-    if (value.fn.getParameters().length !== value.fields.length) {
+    if (!includes(value.fn.paramCounts(), value.fields.length)) {
       this.setError(
-        `Calculator function has ${
-          value.fn.getParameters().length
-        } parameters, but ${value.fields.length} fields were provided.`
+        `Calculator function has ${value.fn
+          .paramCounts()
+          .join(", ")} parameters, but ${
+          value.fields.length
+        } fields were provided.`
       );
     }
 

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -10,7 +10,6 @@ import { Lambda, UserDefinedLambda } from "../reducer/lambda.js";
 import * as DateTime from "../utility/DateTime.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { Domain } from "./domain.js";
-import includes from "lodash/includes.js";
 
 export type ValueMap = ImmutableMap<string, Value>;
 
@@ -144,9 +143,7 @@ class VLambda extends BaseValue implements Indexable {
           })
         );
       } else {
-        throw new REOther(
-          "VLambda: Can't access parameters on a builtin lambda"
-        );
+        throw new REOther("Can't access parameters on built in functions");
       }
     }
     throw new REOther("No such field");
@@ -292,9 +289,9 @@ class VCalculator extends BaseValue {
 
   constructor(public value: Calculator) {
     super();
-    if (!includes(value.fn.paramCounts(), value.fields.length)) {
+    if (!value.fn.paramCounts().includes(value.fields.length)) {
       this.setError(
-        `Calculator function has ${value.fn
+        `Calculator function needs ${value.fn
           .paramCounts()
           .join(", ")} parameters, but ${
           value.fields.length

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -6,7 +6,7 @@ import {
   REDictPropertyNotFound,
   REOther,
 } from "../errors/messages.js";
-import { Lambda, UserDefinedLambda } from "../reducer/lambda.js";
+import { Lambda } from "../reducer/lambda.js";
 import * as DateTime from "../utility/DateTime.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { Domain } from "./domain.js";
@@ -132,7 +132,7 @@ class VLambda extends BaseValue implements Indexable {
       //Note: If you try using instanceof here, it won't work because of circular dependencies.
       if (this.value.type === "UserDefinedLambda") {
         return vArray(
-          (this.value as UserDefinedLambda).parameters.map((parameter) => {
+          this.value.parameters.map((parameter) => {
             const fields: [string, Value][] = [
               ["name", vString(parameter.name)],
             ];

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -129,21 +129,21 @@ class VLambda extends BaseValue implements Indexable {
 
   get(key: Value) {
     if (key.type === "String" && key.value === "parameters") {
-      //Note: If you try using instanceof here, it won't work because of circular dependencies.
-      if (this.value.type === "UserDefinedLambda") {
-        return vArray(
-          this.value.parameters.map((parameter) => {
-            const fields: [string, Value][] = [
-              ["name", vString(parameter.name)],
-            ];
-            if (parameter.domain) {
-              fields.push(["domain", parameter.domain]);
-            }
-            return vDict(ImmutableMap(fields));
-          })
-        );
-      } else {
-        throw new REOther("Can't access parameters on built in functions");
+      switch (this.value.type) {
+        case "UserDefinedLambda":
+          return vArray(
+            this.value.parameters.map((parameter) => {
+              const fields: [string, Value][] = [
+                ["name", vString(parameter.name)],
+              ];
+              if (parameter.domain) {
+                fields.push(["domain", parameter.domain]);
+              }
+              return vDict(ImmutableMap(fields));
+            })
+          );
+        case "BuiltinLambda":
+          throw new REOther("Can't access parameters on built in functions");
       }
     }
     throw new REOther("No such field");
@@ -291,9 +291,7 @@ class VCalculator extends BaseValue {
     super();
     if (!value.fn.parameterCounts().includes(value.fields.length)) {
       this.setError(
-        `Calculator function needs ${value.fn
-          .parameterCounts()
-          .join(", ")} parameters, but ${
+        `Calculator function needs ${value.fn.parameterCountString()} parameters, but ${
           value.fields.length
         } fields were provided.`
       );

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -130,9 +130,10 @@ class VLambda extends BaseValue implements Indexable {
 
   get(key: Value) {
     if (key.type === "String" && key.value === "parameters") {
-      if (this.value instanceof UserDefinedLambda) {
+      //Note: If you try using instanceof here, it won't work because of circular dependencies.
+      if (this.value.type === "UserDefinedLambda") {
         return vArray(
-          this.value.parameters.map((parameter) => {
+          (this.value as UserDefinedLambda).parameters.map((parameter) => {
             const fields: [string, Value][] = [
               ["name", vString(parameter.name)],
             ];

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -6,7 +6,7 @@ import {
   REDictPropertyNotFound,
   REOther,
 } from "../errors/messages.js";
-import { Lambda } from "../reducer/lambda.js";
+import { Lambda, UserDefinedLambda } from "../reducer/lambda.js";
 import * as DateTime from "../utility/DateTime.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { Domain } from "./domain.js";
@@ -130,17 +130,23 @@ class VLambda extends BaseValue implements Indexable {
 
   get(key: Value) {
     if (key.type === "String" && key.value === "parameters") {
-      const parameters = this.value.getParameters();
-      return vArray(
-        parameters.map((parameter) => {
-          const fields: [string, Value][] = [["name", vString(parameter.name)]];
-          if (parameter.domain) {
-            fields.push(["domain", parameter.domain]);
-          }
-
-          return vDict(ImmutableMap(fields));
-        })
-      );
+      if (this.value instanceof UserDefinedLambda) {
+        return vArray(
+          this.value.parameters.map((parameter) => {
+            const fields: [string, Value][] = [
+              ["name", vString(parameter.name)],
+            ];
+            if (parameter.domain) {
+              fields.push(["domain", parameter.domain]);
+            }
+            return vDict(ImmutableMap(fields));
+          })
+        );
+      } else {
+        throw new REOther(
+          "VLambda: Can't access parameters on a builtin lambda"
+        );
+      }
     }
     throw new REOther("No such field");
   }

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -289,10 +289,10 @@ class VCalculator extends BaseValue {
 
   constructor(public value: Calculator) {
     super();
-    if (!value.fn.paramCounts().includes(value.fields.length)) {
+    if (!value.fn.parameterCounts().includes(value.fields.length)) {
       this.setError(
         `Calculator function needs ${value.fn
-          .paramCounts()
+          .parameterCounts()
           .join(", ")} parameters, but ${
           value.fields.length
         } fields were provided.`

--- a/packages/website/src/pages/docs/Api/Dist.mdx
+++ b/packages/website/src/pages/docs/Api/Dist.mdx
@@ -185,6 +185,8 @@ mixture: (...distributionLike, weights?:list<float>) => distribution
 mixture: (list<distributionLike>, weights?:list<float>) => distribution
 ```
 
+Note: If you want to pass in over 5 distributions, you must use the list syntax.
+
 **Examples**
 
 ```squiggle


### PR DESCRIPTION
Lambda has two distinct class instances, each with unique attributes. I did work here to more explicitly differentiate them.

I changed "SquiggleLambda" to "UserDefinedLambda", to differentiate if from "BuiltInLambda".

UserDefinedLambda has a public parameters() attribute, while BuiltInLambda has a definitions() function. 

Also:
1. BuiltInLambdas are a bit cleaner - they do most of the ``call`` work themselves now. 
2. Introduced frTuple() function that could take a tuple with up to 5 types. 
3. Use frTuple() to help clean up mixture.ts, so that it can be (fairly) cleanly typed. 
3. Export ``SqLambdaParameter``, a generalization of the params of the two different types, out of squiggle-lang. 