### PR TITLE
Remove unnecessary separator in version dropdown

### DIFF
--- a/packages/versioned-playground/src/SquigglePlaygroundVersionPicker.tsx
+++ b/packages/versioned-playground/src/SquigglePlaygroundVersionPicker.tsx
@@ -37,7 +37,6 @@ export const SquigglePlaygroundVersionPicker: FC<{
         render={({ close }) => (
           <DropdownMenu>
             <DropdownMenuHeader>Squiggle Version</DropdownMenuHeader>
-            <DropdownMenuSeparator />
             {squiggleVersions.map((version) => (
               <DropdownMenuActionItem
                 key={version}


### PR DESCRIPTION
Before:
<img width="247" alt="Captura de pantalla 2023-10-16 a la(s) 18 45 29" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/c33c58cc-f542-48c8-b965-306188cc4ce1">

After:
<img width="260" alt="Captura de pantalla 2023-10-16 a la(s) 18 44 45" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/62f78d0f-942c-460a-89cc-9741f39d54f1">

(we don't use separators after menu headers anymore since we added colored backgrounds in headers)