### PR TITLE
Calculator field default can accept numbers

### DIFF
--- a/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
@@ -13,6 +13,7 @@ import {
   frDict,
   frOptional,
   frAny,
+  frNumberOrString,
 } from "../../src/library/registry/frTypes.js";
 import { ImmutableMap } from "../../src/utility/immutableMap.js";
 
@@ -77,6 +78,22 @@ describe("frDistOrNumber", () => {
     const value = vDist(dist);
     expect(frDistOrNumber.unpack(value)).toBe(dist);
     expect(frDistOrNumber.pack(dist)).toEqual(value);
+  });
+});
+
+describe("frNumberOrString", () => {
+  test("number", () => {
+    const number = 123;
+    const value = vNumber(number);
+    expect(frNumberOrString.unpack(value)).toBe(number);
+    expect(frNumberOrString.pack(number)).toEqual(value);
+  });
+
+  test("string", () => {
+    const string = "foo";
+    const value = vString(string);
+    expect(frNumberOrString.unpack(value)).toBe(string);
+    expect(frNumberOrString.pack(string)).toEqual(value);
   });
 });
 

--- a/packages/squiggle-lang/src/fr/calculator.ts
+++ b/packages/squiggle-lang/src/fr/calculator.ts
@@ -5,6 +5,7 @@ import {
   frArray,
   frString,
   frOptional,
+  frNumberOrString,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 import { vCalculator } from "../value/index.js";
@@ -13,6 +14,16 @@ const maker = new FnFactory({
   nameSpace: "Calculator",
   requiresNamespace: true,
 });
+
+const convertFieldDefault = (value: number | string | null): string => {
+  if (typeof value === "number") {
+    return value.toString();
+  } else if (typeof value === "string") {
+    return value;
+  } else {
+    return "";
+  }
+};
 
 export const library = [
   maker.make({
@@ -30,7 +41,7 @@ export const library = [
               frArray(
                 frDict(
                   ["name", frString],
-                  ["default", frOptional(frString)],
+                  ["default", frOptional(frNumberOrString)],
                   ["description", frOptional(frString)]
                 )
               ),
@@ -43,7 +54,7 @@ export const library = [
             description: description || undefined,
             fields: fields.map((vars) => ({
               name: vars.name,
-              default: vars.default || "",
+              default: convertFieldDefault(vars.default),
               description: vars.description || undefined,
             })),
           });

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -57,6 +57,12 @@ export const frDistOrNumber: FRType<BaseDist | number> = {
   pack: (v) => (typeof v === "number" ? vNumber(v) : vDist(v)),
   getName: () => "distribution|number",
 };
+export const frNumberOrString: FRType<string | number> = {
+  unpack: (v) =>
+    v.type === "String" ? v.value : v.type === "Number" ? v.value : undefined,
+  pack: (v) => (typeof v === "number" ? vNumber(v) : vString(v)),
+  getName: () => "number|string",
+};
 export const frDist: FRType<BaseDist> = {
   unpack: (v) => (v.type === "Dist" ? v.value : undefined),
   pack: (v) => vDist(v),

--- a/packages/website/src/pages/docs/Api/Calculator.mdx
+++ b/packages/website/src/pages/docs/Api/Calculator.mdx
@@ -18,7 +18,7 @@ Calculator.make: ({
   description: string,
   fields: list<{
     name: string,
-    default?: string,
+    default?: string | number,
     description?: string
   }>
 }) => calculator


### PR DESCRIPTION
Make sure that Calculator default fields can accept numbers.

It just uses the Javascript toString() method for converting numbers. This probably isn't optimal for Squiggle, but it works okay enough.

I think we can improve this more later if we want.

<img width="1235" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/28306586-d8f7-44b1-a51a-19d751a64835">

Basically closes https://github.com/quantified-uncertainty/squiggle/issues/2340
