### PR TITLE
Fixed calculator updating defaults bug

### DIFF
--- a/packages/components/src/components/Calculator/index.tsx
+++ b/packages/components/src/components/Calculator/index.tsx
@@ -87,10 +87,12 @@ export const Calculator: FC<Props> = ({
     calculatorStateOnFirstRender
   );
 
-  const _processAllFieldCodes = async () => {
+  const _processAllFieldCodes = async (
+    _calculatorState: CalculatorState = calculatorState
+  ) => {
     await processAllFieldCodes({
       dispatch: calculatorDispatch,
-      state: calculatorState,
+      state: _calculatorState,
       path,
       calculator,
       environment,
@@ -108,14 +110,15 @@ export const Calculator: FC<Props> = ({
       calculator.hashString !== prevCalculator.hashString;
 
     if (calculatorChanged) {
+      const newCalculatorState = initialCalculatorState(calculator);
       calculatorDispatch({
         type: "RESET",
         payload: {
           path: path,
-          state: initialCalculatorState(calculator),
+          state: newCalculatorState,
         },
       });
-      _processAllFieldCodes();
+      _processAllFieldCodes(newCalculatorState);
     } else {
       updateFnValue({
         path,


### PR DESCRIPTION
There was an annoying bug, where after updating a calculator default, the rendered calculator would show the result of the previous state. This fixes that. 