### PR TITLE
Added sampleCount field to Calculator.make

### DIFF
--- a/.changeset/hip-carrots-laugh.md
+++ b/.changeset/hip-carrots-laugh.md
@@ -1,0 +1,6 @@
+---
+"@quri/squiggle-lang": patch
+"@quri/squiggle-components": patch
+---
+
+Added sampleCount field to Calculator.make

--- a/packages/components/src/components/Calculator/index.tsx
+++ b/packages/components/src/components/Calculator/index.tsx
@@ -21,6 +21,8 @@ import {
   initialCalculatorState,
 } from "./calculatorReducer.js";
 import { CalculatorUI } from "./calculatorUI.js";
+import { ErrorAlert } from "../Alert.js";
+import { SAMPLE_COUNT_MAX, SAMPLE_COUNT_MIN } from "../../lib/constants.js";
 
 type Props = {
   value: SqCalculator;
@@ -161,5 +163,24 @@ export const Calculator: FC<Props> = ({
         }}
       />
     )
+  );
+};
+
+export const ShowErrorIfInvalid: React.FC<{
+  calculator: SqCalculator;
+  children: React.ReactNode;
+}> = ({ calculator, children }) => {
+  const { sampleCount } = calculator;
+
+  const sampleCountIsInvalid =
+    sampleCount &&
+    (sampleCount < SAMPLE_COUNT_MIN || sampleCount > SAMPLE_COUNT_MAX);
+
+  return sampleCountIsInvalid ? (
+    <ErrorAlert
+      heading={`Calculator sampleCount must be between ${SAMPLE_COUNT_MIN} and ${SAMPLE_COUNT_MAX}. It is set to ${sampleCount}.`}
+    />
+  ) : (
+    children
   );
 };

--- a/packages/components/src/components/PlaygroundSettings.tsx
+++ b/packages/components/src/components/PlaygroundSettings.tsx
@@ -12,9 +12,10 @@ import { CheckboxFormField, NumberFormField, RadioFormField } from "@quri/ui";
 import { functionChartDefaults } from "./FunctionChart/utils.js";
 import { FormComment } from "./ui/FormComment.js";
 import { FormSection } from "./ui/FormSection.js";
+import { SAMPLE_COUNT_MAX, SAMPLE_COUNT_MIN } from "../lib/constants.js";
 
 export const environmentSchema = z.object({
-  sampleCount: z.number().int().gte(10).lte(1000000),
+  sampleCount: z.number().int().gte(SAMPLE_COUNT_MIN).lte(SAMPLE_COUNT_MAX),
   xyPointLength: z.number().int().gte(10).lte(10000),
 });
 

--- a/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ExpressionViewer.tsx
@@ -32,7 +32,7 @@ import { TableChart } from "../TableChart/index.js";
 import { DistPreview } from "../DistributionsChart/DistPreview.js";
 import { TableCellsIcon } from "@quri/ui";
 import ReactMarkdown from "react-markdown";
-import { Calculator } from "../Calculator/index.js";
+import { Calculator, ShowErrorIfInvalid } from "../Calculator/index.js";
 
 // We use an extra left margin for some elements to align them with parent variable name
 const leftMargin = "ml-1.5";
@@ -143,15 +143,17 @@ export const getBoxProps = (
       const calculator: SqCalculator = value.value;
       return {
         children: (settings) => (
-          <Calculator
-            value={calculator}
-            valueWithContext={value}
-            environment={environment}
-            settings={settings}
-            renderValue={(value, settings) =>
-              getBoxProps(value).children(settings)
-            }
-          />
+          <ShowErrorIfInvalid calculator={calculator}>
+            <Calculator
+              value={calculator}
+              valueWithContext={value}
+              environment={environment}
+              settings={settings}
+              renderValue={(value, settings) =>
+                getBoxProps(value).children(settings)
+              }
+            />
+          </ShowErrorIfInvalid>
         ),
       };
     }

--- a/packages/components/src/lib/constants.ts
+++ b/packages/components/src/lib/constants.ts
@@ -1,0 +1,2 @@
+export const SAMPLE_COUNT_MAX = 1000000;
+export const SAMPLE_COUNT_MIN = 10;

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -242,6 +242,7 @@ Calculator.make(
   {
     fn: f,
     description: a,
+    sampleCount: 10000,
     fields: [
       {
         name: "Variable 1",

--- a/packages/squiggle-lang/src/fr/calculator.ts
+++ b/packages/squiggle-lang/src/fr/calculator.ts
@@ -6,6 +6,7 @@ import {
   frString,
   frOptional,
   frNumberOrString,
+  frNumber,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 import { vCalculator } from "../value/index.js";
@@ -37,6 +38,7 @@ export const library = [
             ["fn", frLambda],
             ["title", frOptional(frString)],
             ["description", frOptional(frString)],
+            ["sampleCount", frOptional(frNumber)],
             [
               "fields",
               frArray(
@@ -49,11 +51,12 @@ export const library = [
             ]
           ),
         ],
-        ([{ fn, title, description, fields }]) => {
+        ([{ fn, title, description, sampleCount, fields }]) => {
           const calc = vCalculator({
             fn,
             title: title || undefined,
             description: description || undefined,
+            sampleCount: sampleCount || undefined,
             fields: fields.map((vars) => ({
               name: vars.name,
               default: convertFieldDefault(vars.default),

--- a/packages/squiggle-lang/src/public/SqValue/SqCalculator.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqCalculator.ts
@@ -38,13 +38,23 @@ export class SqCalculator {
     return this._value.description;
   }
 
+  get sampleCount(): number | undefined {
+    return this._value.sampleCount;
+  }
+
   // This function is used to determine if a calculator has changed.
   // It's obviously not perfect - it doesn't capture changes within the calculator function, but this would be much more complicated.
 
   get hashString(): string {
     const rowData = JSON.stringify(this._value.fields);
     const paramData = this._value.fn.toString() || "";
-    return rowData + paramData + this._value.description;
+    return (
+      rowData +
+      paramData +
+      this._value.description +
+      this._value.title +
+      this._value.sampleCount
+    );
   }
 
   get fields(): {

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -439,6 +439,7 @@ export type Calculator = {
   fields: { name: string; default: string; description?: string }[];
   description?: string;
   title?: string;
+  sampleCount?: number;
 };
 
 class VCalculator extends BaseValue {

--- a/packages/website/src/pages/docs/Api/Calculator.mdx
+++ b/packages/website/src/pages/docs/Api/Calculator.mdx
@@ -17,6 +17,7 @@ Calculator.make: ({
   fn: ...arguments => any,
   title?: string,
   description?: string,
+  sampleCount?: number,
   fields: list<{
     name: string,
     default?: string | number,
@@ -35,6 +36,7 @@ Examples:
     fn: {|a, b|a + b},
     title: "Sum()"
     description: "This takes in two arguments, and outputs the sum of those two arguments.",
+    sampleCount: 1000,
     fields: [
       {
         name: "First Param",


### PR DESCRIPTION
This adds a simple ``sampleCount`` to calculators, so that their sample count could be easily modified.

We could trivially add ``pointLength``, but I'm hesitant to encourage much use of that now. 