### PR TITLE
Save model after export added or removed

### DIFF
--- a/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
@@ -249,8 +249,14 @@ export const EditSquiggleSnippetModel: FC<Props> = ({ modelRef }) => {
                   body: (
                     <div className="px-6 py-2">
                       <EditModelExports
-                        append={appendVariableWithDefinition}
-                        remove={removeVariableWithDefinition}
+                        append={(item) => {
+                          appendVariableWithDefinition(item);
+                          onSubmit();
+                        }}
+                        remove={(id) => {
+                          removeVariableWithDefinition(id);
+                          onSubmit();
+                        }}
                         items={variablesWithDefinitionsFields}
                         modelRef={model}
                       />


### PR DESCRIPTION
Closes https://github.com/quantified-uncertainty/squiggle/issues/2361

Very simple. I imagine we'll change this flow eventually, but for now, it seems decent, though there might be some flaw in this specific approach.. 