### PR TITLE
In Hub, optional button to save draft to clipboard

### DIFF
--- a/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
@@ -25,6 +25,33 @@ function localStorageExists() {
   return Boolean(typeof window !== "undefined" && window.localStorage);
 }
 
+const CopyToClipboardButton: FC<{ draftLocator: DraftLocator }> = ({
+  draftLocator,
+}) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopyClick = async () => {
+    const draft = draftUtils.load(draftLocator);
+    if (draft) {
+      try {
+        await navigator.clipboard.writeText(draft.formState.code);
+        setIsCopied(true);
+        setTimeout(() => setIsCopied(false), 2000); // Reset after 2 seconds
+      } catch (err) {
+        console.error("Failed to copy text: ", err);
+      }
+    } else {
+      console.error("Draft not found");
+    }
+  };
+
+  return (
+    <Button onClick={handleCopyClick}>
+      {isCopied ? "Copied!" : "Copy to Clipboard"}
+    </Button>
+  );
+};
+
 export const draftUtils = {
   exists(locator: DraftLocator): boolean {
     if (!localStorageExists()) {
@@ -123,6 +150,11 @@ export const SquiggleSnippetDraftDialog: FC<Props> = ({
           <TextTooltip text="Draft will be discarded.">
             <div>
               <Button onClick={discard}>Discard</Button>
+            </div>
+          </TextTooltip>
+          <TextTooltip text="Draft will be copied to clipboard.">
+            <div>
+              <CopyToClipboardButton draftLocator={draftLocator} />
             </div>
           </TextTooltip>
           <TextTooltip text="Code and version will be replaced by draft version. You'll still need to save it manually.">


### PR DESCRIPTION
<img width="789" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/67292ce4-6aa1-4d4a-b9f2-1cf043633dad">

<img width="755" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/dc4ebf2d-4358-4bc8-b09f-4ee3ae7bdc79">

It's a bit awkward (button becomes smaller when text changes, no error), but it works for now and is simple. 

Closes #2352 