### PR TITLE
Simple Exports Selection

### DIFF
--- a/packages/components/src/components/DynamicSquiggleViewer.tsx
+++ b/packages/components/src/components/DynamicSquiggleViewer.tsx
@@ -2,7 +2,11 @@ import { forwardRef } from "react";
 
 import { SquiggleViewer } from "../index.js";
 import { SquiggleOutput } from "../lib/hooks/useSquiggle.js";
-import { getResultVariables, getResultValue } from "../lib/utility.js";
+import {
+  getResultVariables,
+  getResultValue,
+  getExportVariables,
+} from "../lib/utility.js";
 import { CodeEditorHandle } from "./CodeEditor.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
 import { SquiggleViewerHandle } from "./SquiggleViewer/index.js";
@@ -40,6 +44,7 @@ export const DynamicSquiggleViewer = forwardRef<SquiggleViewerHandle, Props>(
           localSettingsEnabled={localSettingsEnabled}
           resultVariables={getResultVariables(squiggleOutput)}
           resultItem={getResultValue(squiggleOutput)}
+          resultExports={getExportVariables(squiggleOutput)}
           editor={editor}
         />
       </div>

--- a/packages/components/src/components/SquiggleViewer/VariableBox.tsx
+++ b/packages/components/src/components/SquiggleViewer/VariableBox.tsx
@@ -138,11 +138,15 @@ export const VariableBox: FC<VariableBoxProps> = ({
     </div>
   );
 
+  const isExport = path.root == "exports";
+
   const headerClasses = () => {
     if (isFocused) {
       return "text-md text-black font-bold ml-1";
     } else if (isRoot) {
       return "text-sm text-stone-600 font-semibold";
+    } else if (isExport) {
+      return "text-sm font-semibold text-purple-800 cursor-pointer hover:underline";
     } else {
       return "text-sm text-stone-800 cursor-pointer hover:underline";
     }
@@ -153,6 +157,7 @@ export const VariableBox: FC<VariableBoxProps> = ({
       {name}
     </div>
   );
+
   const headerPreview = () =>
     !!preview && (
       <div

--- a/packages/components/src/components/SquiggleViewer/VariableBox.tsx
+++ b/packages/components/src/components/SquiggleViewer/VariableBox.tsx
@@ -138,7 +138,7 @@ export const VariableBox: FC<VariableBoxProps> = ({
     </div>
   );
 
-  const isExport = path.root == "exports";
+  const isExport = path.root == "exports" && path.items.length == 1;
 
   const headerClasses = () => {
     if (isFocused) {
@@ -146,7 +146,7 @@ export const VariableBox: FC<VariableBoxProps> = ({
     } else if (isRoot) {
       return "text-sm text-stone-600 font-semibold";
     } else if (isExport) {
-      return "text-sm font-semibold text-purple-800 cursor-pointer hover:underline";
+      return "text-sm font-medium text-purple-700 cursor-pointer hover:underline";
     } else {
       return "text-sm text-stone-800 cursor-pointer hover:underline";
     }

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -38,6 +38,8 @@ function topLevelName(path: SqValuePath): string {
     return topLevelResultName;
   } else if (path.root === "bindings") {
     return topLevelBindingsName;
+  } else if (path.root === "exports") {
+    return "Exports";
   } else {
     return path.root;
   }

--- a/packages/components/src/lib/hooks/useSquiggle.ts
+++ b/packages/components/src/lib/hooks/useSquiggle.ts
@@ -36,6 +36,7 @@ export type SquiggleOutput = {
     {
       result: SqValue;
       bindings: SqDict;
+      exports: SqDict;
     },
     SqError
   >;

--- a/packages/components/src/lib/utility.ts
+++ b/packages/components/src/lib/utility.ts
@@ -48,6 +48,12 @@ export function getResultVariables({
   return resultMap(output, (value) => value.bindings.asValue());
 }
 
+export function getExportVariables({
+  output,
+}: SquiggleOutput): result<SqDictValue, SqError> {
+  return resultMap(output, (value) => value.exports.asValue());
+}
+
 export function getResultValue({
   output,
 }: SquiggleOutput): result<SqValue, SqError> | undefined {

--- a/packages/squiggle-lang/src/public/SqProject/index.ts
+++ b/packages/squiggle-lang/src/public/SqProject/index.ts
@@ -260,7 +260,7 @@ export class SqProject {
             valueAst: astR.value,
             valueAstIsPrecise: true,
             path: new SqValuePath({
-              root: "bindings",
+              root: field,
               items: [],
             }),
           })

--- a/packages/squiggle-lang/src/public/SqValuePath.ts
+++ b/packages/squiggle-lang/src/public/SqValuePath.ts
@@ -10,10 +10,13 @@ export type PathItem =
     };
 
 export class SqValuePath {
-  public root: "result" | "bindings";
+  public root: "result" | "bindings" | "exports";
   public items: PathItem[];
 
-  constructor(props: { root: "result" | "bindings"; items: PathItem[] }) {
+  constructor(props: {
+    root: "result" | "bindings" | "exports";
+    items: PathItem[];
+  }) {
     this.root = props.root;
     this.items = props.items;
   }


### PR DESCRIPTION
<img width="1509" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/f8f41c5f-b926-4c78-8c1e-f9c6f1b7c949">

One thing I'd like to do, but am not sure how best to, is to also highlight the export variables in the "Variables" list. As in, when a variable is exported, it should be shown in a different color, and should later have a clickable button to go to it's view page. 

I imagine I could do this either by saving the export data in the Viewer Context, or by it being part of the SqValueContext in Squiggle-language. 