### PR TITLE
Disable update messages for storybook and prisma

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -97,7 +97,7 @@
   },
   "scripts": {
     "start": "pnpm dev",
-    "dev": "storybook dev -p 6006",
+    "dev": "storybook dev -p 6006 --no-version-updates",
     "build:ts": "rm -rf dist/src dist/tsconfig.build.tsbuildinfo && tsc -b",
     "build:css": "postcss ./src/styles/full.css -o ./dist/full.css && postcss ./src/styles/common.css -o ./dist/common.css",
     "build:lezer": "cd ./src/languageSupport; mkdir -p generated; lezer-generator ./squiggle.grammar --output generated/squiggle.ts",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "db:generate": "prisma generate",
-    "db:migrate": "prisma migrate deploy",
+    "db:generate": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma generate",
+    "db:migrate": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma migrate deploy",
     "dev": "next dev -p 3001",
     "start": "__NEXT_PRIVATE_PREBUNDLED_REACT=next next start",
     "generate": "pnpm db:generate && pnpm print-schema && pnpm relay",


### PR DESCRIPTION
Both are spamming build logs or local logs with useless notifications.

There's also an option for turbo: https://turbo.build/repo/docs/reference/command-line-reference#--no-update-notifier, but there's no way to put it, only in my local ~/.bash_profile.