### PR TITLE
/admin page for upgrading models

### DIFF
--- a/packages/hub/schema.graphql
+++ b/packages/hub/schema.graphql
@@ -1,3 +1,7 @@
+type AdminUpdateModelVersionResult {
+  model: Model!
+}
+
 type BaseError implements Error {
   message: String!
 }
@@ -179,11 +183,20 @@ input ModelRevisionForRelativeValuesSlugOwnerInput {
   slug: String!
 }
 
+type ModelsByVersion {
+  count: Int!
+  models: [Model!]!
+  privateCount: Int!
+  version: String!
+}
+
 type MoveModelResult {
   model: Model!
 }
 
 type Mutation {
+  """Admin-only query for upgrading model versions"""
+  adminUpdateModelVersion(input: MutationAdminUpdateModelVersionInput!): MutationAdminUpdateModelVersionResult!
   buildRelativeValuesCache(input: MutationBuildRelativeValuesCacheInput!): MutationBuildRelativeValuesCacheResult!
   cancelGroupInvite(input: MutationCancelGroupInviteInput!): MutationCancelGroupInviteResult!
   clearRelativeValuesCache(input: MutationClearRelativeValuesCacheInput!): MutationClearRelativeValuesCacheResult!
@@ -204,6 +217,13 @@ type Mutation {
   updateRelativeValuesDefinition(input: MutationUpdateRelativeValuesDefinitionInput!): MutationUpdateRelativeValuesDefinitionResult!
   updateSquiggleSnippetModel(input: MutationUpdateSquiggleSnippetModelInput!): MutationUpdateSquiggleSnippetModelResult!
 }
+
+input MutationAdminUpdateModelVersionInput {
+  modelId: String!
+  version: String!
+}
+
+union MutationAdminUpdateModelVersionResult = AdminUpdateModelVersionResult | BaseError
 
 input MutationBuildRelativeValuesCacheInput {
   exportId: String!
@@ -383,6 +403,9 @@ type Query {
   me: Me!
   model(input: QueryModelInput!): QueryModelResult!
   models(after: String, before: String, first: Int, last: Int): ModelConnection!
+
+  """Admin-only query for listing models in /admin UI"""
+  modelsByVersion: [ModelsByVersion!]!
   node(id: ID!): Node
   nodes(ids: [ID!]!): [Node]!
   relativeValuesDefinition(input: QueryRelativeValuesDefinitionInput!): QueryRelativeValuesDefinitionResult!
@@ -559,6 +582,7 @@ type UpdateSquiggleSnippetResult {
 type User implements Node & Owner {
   groups(after: String, before: String, first: Int, last: Int): GroupConnection!
   id: ID!
+  isRoot: Boolean!
   models(after: String, before: String, first: Int, last: Int): ModelConnection!
   relativeValuesDefinitions(after: String, before: String, first: Int, last: Int): RelativeValuesDefinitionConnection!
   slug: String!

--- a/packages/hub/src/app/admin/AdminPage.tsx
+++ b/packages/hub/src/app/admin/AdminPage.tsx
@@ -117,7 +117,11 @@ export const AdminPage: FC<{
                       title={`Upgrade to ${defaultSquiggleVersion}`}
                     />
                   </div>
-                  <EditSquiggleSnippetModel key={model.id} modelRef={model} />
+                  <EditSquiggleSnippetModel
+                    key={model.id}
+                    modelRef={model}
+                    forceVersionPicker
+                  />
                 </div>
               ))}
             </section>

--- a/packages/hub/src/app/admin/AdminPage.tsx
+++ b/packages/hub/src/app/admin/AdminPage.tsx
@@ -1,36 +1,18 @@
 "use client";
 
 import { AdminPageQuery } from "@/__generated__/AdminPageQuery.graphql";
-import { AdminPage_updateMutation } from "@/__generated__/AdminPage_updateMutation.graphql";
-import { H1, H2 } from "@/components/ui/Headers";
-import { MutationButton } from "@/components/ui/MutationButton";
-import { StyledLink } from "@/components/ui/StyledLink";
+import { H1 } from "@/components/ui/Headers";
 import { SerializablePreloadedQuery } from "@/relay/loadPageQuery";
 import { usePageQuery } from "@/relay/usePageQuery";
-import { modelRoute } from "@/routes";
 import { LockIcon } from "@quri/ui";
-import { defaultSquiggleVersion } from "@quri/versioned-playground";
 import { useSession } from "next-auth/react";
 import { FC } from "react";
 import { graphql } from "relay-runtime";
-import { EditSquiggleSnippetModel } from "../models/[owner]/[slug]/EditSquiggleSnippetModel";
+import { UpgradeModels } from "./UpgradeModels";
 
 const Query = graphql`
   query AdminPageQuery {
-    modelsByVersion {
-      version
-      count
-      privateCount
-      models {
-        id
-        slug
-        owner {
-          id
-          slug
-        }
-        ...EditSquiggleSnippetModel
-      }
-    }
+    ...UpgradeModels
   }
 `;
 
@@ -39,7 +21,7 @@ export const AdminPage: FC<{
 }> = ({ query }) => {
   useSession({ required: true });
 
-  const [{ modelsByVersion }] = usePageQuery(Query, query);
+  const [queryRef] = usePageQuery(Query, query);
 
   return (
     <div>
@@ -49,85 +31,7 @@ export const AdminPage: FC<{
           <span>Admin console</span>
         </div>
       </H1>
-      <H2>Upgrade model versions</H2>
-      <p>
-        Check models with their current version and the new version, then press
-        the upgrade button if everything is ok.
-      </p>
-      <div className="space-y-8">
-        {modelsByVersion.map((entry) => {
-          if (
-            entry.version === "dev" ||
-            entry.version === defaultSquiggleVersion
-          ) {
-            return null;
-          }
-          return (
-            <section key={entry.version}>
-              <h3 className="font-medium text-lg text-slate-700">
-                {entry.version} ({entry.count} models, {entry.privateCount}{" "}
-                private models)
-              </h3>
-              {entry.models.map((model) => (
-                <div key={model.id}>
-                  <div className="flex gap-2 items-center">
-                    <div>
-                      Model:{" "}
-                      <StyledLink
-                        href={modelRoute({
-                          owner: model.owner.slug,
-                          slug: model.slug,
-                        })}
-                      >
-                        {model.owner.slug}/{model.slug}
-                      </StyledLink>
-                    </div>
-                    <MutationButton<
-                      AdminPage_updateMutation,
-                      "AdminUpdateModelVersionResult"
-                    >
-                      expectedTypename="AdminUpdateModelVersionResult"
-                      mutation={graphql`
-                        mutation AdminPage_updateMutation(
-                          $input: MutationAdminUpdateModelVersionInput!
-                        ) {
-                          result: adminUpdateModelVersion(input: $input) {
-                            __typename
-                            ... on BaseError {
-                              message
-                            }
-                            ... on AdminUpdateModelVersionResult {
-                              model {
-                                ...EditSquiggleSnippetModel
-                              }
-                            }
-                          }
-                        }
-                      `}
-                      updater={() => {
-                        // reload() from usePageQuery doesn't work for some reason
-                        window.location.reload();
-                      }}
-                      variables={{
-                        input: {
-                          modelId: model.id,
-                          version: defaultSquiggleVersion,
-                        },
-                      }}
-                      title={`Upgrade to ${defaultSquiggleVersion}`}
-                    />
-                  </div>
-                  <EditSquiggleSnippetModel
-                    key={model.id}
-                    modelRef={model}
-                    forceVersionPicker
-                  />
-                </div>
-              ))}
-            </section>
-          );
-        })}
-      </div>
+      <UpgradeModels queryRef={queryRef} />
     </div>
   );
 };

--- a/packages/hub/src/app/admin/AdminPage.tsx
+++ b/packages/hub/src/app/admin/AdminPage.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { AdminPageQuery } from "@/__generated__/AdminPageQuery.graphql";
+import { AdminPage_updateMutation } from "@/__generated__/AdminPage_updateMutation.graphql";
+import { H1, H2 } from "@/components/ui/Headers";
+import { MutationButton } from "@/components/ui/MutationButton";
+import { StyledLink } from "@/components/ui/StyledLink";
+import { SerializablePreloadedQuery } from "@/relay/loadPageQuery";
+import { usePageQuery } from "@/relay/usePageQuery";
+import { modelRoute } from "@/routes";
+import { LockIcon } from "@quri/ui";
+import { defaultSquiggleVersion } from "@quri/versioned-playground";
+import { useSession } from "next-auth/react";
+import { FC } from "react";
+import { graphql } from "relay-runtime";
+import { EditSquiggleSnippetModel } from "../models/[owner]/[slug]/EditSquiggleSnippetModel";
+
+const Query = graphql`
+  query AdminPageQuery {
+    modelsByVersion {
+      version
+      count
+      privateCount
+      models {
+        id
+        slug
+        owner {
+          id
+          slug
+        }
+        ...EditSquiggleSnippetModel
+      }
+    }
+  }
+`;
+
+export const AdminPage: FC<{
+  query: SerializablePreloadedQuery<AdminPageQuery>;
+}> = ({ query }) => {
+  useSession({ required: true });
+
+  const [{ modelsByVersion }] = usePageQuery(Query, query);
+
+  return (
+    <div>
+      <H1>
+        <div className="flex gap-1 items-center">
+          <LockIcon />
+          <span>Admin console</span>
+        </div>
+      </H1>
+      <H2>Upgrade model versions</H2>
+      <p>
+        Check models with their current version and the new version, then press
+        the upgrade button if everything is ok.
+      </p>
+      <div className="space-y-8">
+        {modelsByVersion.map((entry) => {
+          if (
+            entry.version === "dev" ||
+            entry.version === defaultSquiggleVersion
+          ) {
+            return null;
+          }
+          return (
+            <section key={entry.version}>
+              <h3 className="font-medium text-lg text-slate-700">
+                {entry.version} ({entry.count} models, {entry.privateCount}{" "}
+                private models)
+              </h3>
+              {entry.models.map((model) => (
+                <div key={model.id}>
+                  <div className="flex gap-2 items-center">
+                    <div>
+                      Model:{" "}
+                      <StyledLink
+                        href={modelRoute({
+                          owner: model.owner.slug,
+                          slug: model.slug,
+                        })}
+                      >
+                        {model.owner.slug}/{model.slug}
+                      </StyledLink>
+                    </div>
+                    <MutationButton<
+                      AdminPage_updateMutation,
+                      "AdminUpdateModelVersionResult"
+                    >
+                      expectedTypename="AdminUpdateModelVersionResult"
+                      mutation={graphql`
+                        mutation AdminPage_updateMutation(
+                          $input: MutationAdminUpdateModelVersionInput!
+                        ) {
+                          result: adminUpdateModelVersion(input: $input) {
+                            __typename
+                            ... on BaseError {
+                              message
+                            }
+                            ... on AdminUpdateModelVersionResult {
+                              model {
+                                ...EditSquiggleSnippetModel
+                              }
+                            }
+                          }
+                        }
+                      `}
+                      updater={() => {
+                        // reload() from usePageQuery doesn't work for some reason
+                        window.location.reload();
+                      }}
+                      variables={{
+                        input: {
+                          modelId: model.id,
+                          version: defaultSquiggleVersion,
+                        },
+                      }}
+                      title={`Upgrade to ${defaultSquiggleVersion}`}
+                    />
+                  </div>
+                  <EditSquiggleSnippetModel key={model.id} modelRef={model} />
+                </div>
+              ))}
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/hub/src/app/admin/UpgradeModels.tsx
+++ b/packages/hub/src/app/admin/UpgradeModels.tsx
@@ -131,6 +131,11 @@ export const UpgradeModels: FC<{
         Check models with their current version and the new version, then press
         the upgrade button if everything is ok.
       </p>
+      <p>
+        <strong>
+          {`Code edits won't be saved, "Upgrade" buttton bumps only the model's version.`}
+        </strong>
+      </p>
       <div className="space-y-8">
         {modelsByVersion.map((entry) => {
           if (

--- a/packages/hub/src/app/admin/UpgradeModels.tsx
+++ b/packages/hub/src/app/admin/UpgradeModels.tsx
@@ -84,6 +84,7 @@ const ModelList: FC<{ modelsRef: UpgradeModels_List$key }> = ({
             },
           }}
           title={`Upgrade to ${defaultSquiggleVersion}`}
+          theme="primary"
         />
         <Button onClick={() => setPos(usedPos - 1)} disabled={usedPos <= 0}>
           &larr; Prev

--- a/packages/hub/src/app/admin/UpgradeModels.tsx
+++ b/packages/hub/src/app/admin/UpgradeModels.tsx
@@ -1,0 +1,154 @@
+import { FC, useState } from "react";
+import { useFragment } from "react-relay";
+import { graphql } from "relay-runtime";
+
+import { UpgradeModels_updateMutation } from "@/__generated__/UpgradeModels_updateMutation.graphql";
+import { H2 } from "@/components/ui/Headers";
+import { MutationButton } from "@/components/ui/MutationButton";
+import { StyledLink } from "@/components/ui/StyledLink";
+import { modelRoute } from "@/routes";
+import { defaultSquiggleVersion } from "@quri/versioned-playground";
+import { EditSquiggleSnippetModel } from "../models/[owner]/[slug]/EditSquiggleSnippetModel";
+import { UpgradeModels$key } from "@/__generated__/UpgradeModels.graphql";
+import { UpgradeModels_List$key } from "@/__generated__/UpgradeModels_List.graphql";
+import { Button } from "@quri/ui";
+
+const ModelList: FC<{ modelsRef: UpgradeModels_List$key }> = ({
+  modelsRef,
+}) => {
+  const models = useFragment(
+    graphql`
+      fragment UpgradeModels_List on Model @relay(plural: true) {
+        id
+        slug
+        owner {
+          id
+          slug
+        }
+        ...EditSquiggleSnippetModel
+      }
+    `,
+    modelsRef
+  );
+
+  const [pos, setPos] = useState(0);
+
+  if (!models.length) return null;
+  const usedPos = Math.min(pos, models.length - 1);
+  const model = models[usedPos];
+
+  return (
+    <div>
+      <div className="flex gap-2 items-center">
+        <div>
+          Model:{" "}
+          <StyledLink
+            href={modelRoute({
+              owner: model.owner.slug,
+              slug: model.slug,
+            })}
+          >
+            {model.owner.slug}/{model.slug}
+          </StyledLink>
+        </div>
+        <MutationButton<
+          UpgradeModels_updateMutation,
+          "AdminUpdateModelVersionResult"
+        >
+          expectedTypename="AdminUpdateModelVersionResult"
+          mutation={graphql`
+            mutation UpgradeModels_updateMutation(
+              $input: MutationAdminUpdateModelVersionInput!
+            ) {
+              result: adminUpdateModelVersion(input: $input) {
+                __typename
+                ... on BaseError {
+                  message
+                }
+                ... on AdminUpdateModelVersionResult {
+                  model {
+                    ...EditSquiggleSnippetModel
+                  }
+                }
+              }
+            }
+          `}
+          updater={() => {
+            // reload() from usePageQuery doesn't work for some reason
+            window.location.reload();
+          }}
+          variables={{
+            input: {
+              modelId: model.id,
+              version: defaultSquiggleVersion,
+            },
+          }}
+          title={`Upgrade to ${defaultSquiggleVersion}`}
+        />
+        <Button onClick={() => setPos(usedPos - 1)} disabled={usedPos <= 0}>
+          &larr; Prev
+        </Button>
+        <Button
+          onClick={() => setPos(usedPos + 1)}
+          disabled={usedPos >= models.length - 1}
+        >
+          Next &rarr;
+        </Button>
+      </div>
+      <EditSquiggleSnippetModel
+        key={model.id}
+        modelRef={model}
+        forceVersionPicker
+      />
+    </div>
+  );
+};
+
+export const UpgradeModels: FC<{
+  queryRef: UpgradeModels$key;
+}> = ({ queryRef }) => {
+  const { modelsByVersion } = useFragment(
+    graphql`
+      fragment UpgradeModels on Query {
+        modelsByVersion {
+          version
+          count
+          privateCount
+          models {
+            ...UpgradeModels_List
+          }
+        }
+      }
+    `,
+    queryRef
+  );
+
+  return (
+    <div>
+      <H2>Upgrade model versions</H2>
+      <p>
+        Check models with their current version and the new version, then press
+        the upgrade button if everything is ok.
+      </p>
+      <div className="space-y-8">
+        {modelsByVersion.map((entry) => {
+          if (
+            entry.version === "dev" ||
+            entry.version === defaultSquiggleVersion
+          ) {
+            return null;
+          }
+          return (
+            <section key={entry.version}>
+              <h3 className="font-medium text-lg text-slate-700">
+                {entry.version} ({entry.count} models, {entry.privateCount}{" "}
+                private models)
+              </h3>
+              <ModelList modelsRef={entry.models} />
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/packages/hub/src/app/admin/page.tsx
+++ b/packages/hub/src/app/admin/page.tsx
@@ -1,0 +1,37 @@
+import { Metadata } from "next";
+import { getServerSession } from "next-auth";
+import { FC } from "react";
+
+import QueryNode, {
+  AdminPageQuery,
+} from "@/__generated__/AdminPageQuery.graphql";
+import { FullLayoutWithPadding } from "@/components/layout/FullLayoutWithPadding";
+import { NarrowPageLayout } from "@/components/layout/NarrowPageLayout";
+import { loadPageQuery } from "@/relay/loadPageQuery";
+import { authOptions } from "../api/auth/[...nextauth]/authOptions";
+import { AdminPage } from "./AdminPage";
+
+const OuterAdminPageAuthenticated: FC = async () => {
+  const query = await loadPageQuery<AdminPageQuery>(QueryNode, {});
+
+  return (
+    <FullLayoutWithPadding>
+      <AdminPage query={query} />
+    </FullLayoutWithPadding>
+  );
+};
+
+export default async function OuterAdminPage() {
+  const session = await getServerSession(authOptions);
+
+  const email = session?.user.email;
+  if (!email || !process.env.ROOT_EMAILS?.includes(email)) {
+    return <NarrowPageLayout>Access denied.</NarrowPageLayout>;
+  }
+
+  return <OuterAdminPageAuthenticated />;
+}
+
+export const metadata: Metadata = {
+  title: "Admin",
+};

--- a/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
@@ -46,9 +46,13 @@ type Props = {
   // We have to pass the entire model here and not just content;
   // it's too hard to split the editing form into "content-type-specific" part and "generic model fields" part.
   modelRef: EditSquiggleSnippetModel$key;
+  forceVersionPicker?: boolean;
 };
 
-export const EditSquiggleSnippetModel: FC<Props> = ({ modelRef }) => {
+export const EditSquiggleSnippetModel: FC<Props> = ({
+  modelRef,
+  forceVersionPicker,
+}) => {
   const model = useFragment(
     graphql`
       fragment EditSquiggleSnippetModel on Model {
@@ -231,7 +235,7 @@ export const EditSquiggleSnippetModel: FC<Props> = ({ modelRef }) => {
             }
             renderExtraControls={() => (
               <div className="h-full flex items-center justify-end gap-2">
-                {model.isEditable ? (
+                {model.isEditable || forceVersionPicker ? (
                   <SquigglePlaygroundVersionPicker
                     version={version}
                     onChange={handleVersionChange}

--- a/packages/hub/src/app/status/StatusPage.tsx
+++ b/packages/hub/src/app/status/StatusPage.tsx
@@ -32,7 +32,7 @@ export const StatusPage: FC<{
   return (
     <div>
       <H1>Global statistics</H1>
-      <table className="table-auto mt-8">
+      <table className="table-auto mt-8 bg-white">
         <tbody>
           <StatRow name="Users" value={stats.users} />
           <StatRow name="Models" value={stats.models} />

--- a/packages/hub/src/graphql/builder.ts
+++ b/packages/hub/src/graphql/builder.ts
@@ -30,11 +30,15 @@ export type HubSchemaTypes = {
   Context: Context;
   AuthScopes: {
     signedIn: boolean;
+    isRootUser: boolean;
     controlsOwnerId: string | null;
   };
   AuthContexts: {
     // https://pothos-graphql.dev/docs/plugins/scope-auth#change-context-types-based-on-scopes
     signedIn: Context & {
+      session: SignedInSession;
+    };
+    isRootUser: Context & {
       session: SignedInSession;
     };
   };
@@ -66,6 +70,12 @@ export const builder = new SchemaBuilder<HubSchemaTypes>({
   },
   authScopes: async (context) => ({
     signedIn: !!context.session?.user,
+    isRootUser: () => {
+      const email = context.session?.user.email;
+      // Note: there's no emailVerified field in session, is this a problem? Probably not.
+      // See also: `isRootUser` function in `types/User.ts`.
+      return !!(email && process.env.ROOT_EMAILS?.includes(email));
+    },
     controlsOwnerId: async (ownerId) => {
       if (!context.session) {
         return false;

--- a/packages/hub/src/graphql/mutations/adminUpdateModelVersion.ts
+++ b/packages/hub/src/graphql/mutations/adminUpdateModelVersion.ts
@@ -1,0 +1,94 @@
+import { prisma } from "@/prisma";
+import { builder } from "@/graphql/builder";
+
+import { Model } from "../types/Model";
+import { getSelf } from "../types/User";
+import { decodeGlobalIdWithTypename } from "../utils";
+
+builder.mutationField("adminUpdateModelVersion", (t) =>
+  t.withAuth({ signedIn: true }).fieldWithInput({
+    description: "Admin-only query for upgrading model versions",
+    type: builder.simpleObject("AdminUpdateModelVersionResult", {
+      fields: (t) => ({
+        model: t.field({ type: Model }),
+      }),
+    }),
+    errors: {},
+    authScopes: {
+      isRootUser: true,
+    },
+    input: {
+      modelId: t.input.string({ required: true }),
+      version: t.input.string({ required: true }),
+    },
+    resolve: async (_, { input }, { session }) => {
+      const decodedModelId = decodeGlobalIdWithTypename(input.modelId, "Model");
+      const self = await getSelf(session);
+
+      const model = await prisma.$transaction(async (tx) => {
+        let model = await prisma.model.findUniqueOrThrow({
+          where: { id: decodedModelId },
+          include: {
+            currentRevision: {
+              include: {
+                squiggleSnippet: true,
+                relativeValuesExports: true,
+              },
+            },
+          },
+        });
+        if (!model.currentRevision) {
+          throw new Error("currentRevision is missing");
+        }
+        if (
+          model.currentRevision.contentType !== "SquiggleSnippet" ||
+          !model.currentRevision.squiggleSnippet
+        ) {
+          throw new Error("Not a Squiggle model");
+        }
+
+        const revision = await tx.modelRevision.create({
+          data: {
+            squiggleSnippet: {
+              create: {
+                code: model.currentRevision.squiggleSnippet.code,
+                version: input.version,
+              },
+            },
+            contentType: "SquiggleSnippet",
+            model: {
+              connect: { id: model.id },
+            },
+            author: {
+              connect: { email: self.email! },
+            },
+            relativeValuesExports: {
+              createMany: {
+                data: model.currentRevision.relativeValuesExports,
+              },
+            },
+          },
+          include: {
+            model: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        });
+
+        return await tx.model.update({
+          where: {
+            id: revision.model.id,
+          },
+          data: {
+            currentRevisionId: revision.id,
+          },
+          // TODO - optimize with queryFromInfo, https://pothos-graphql.dev/docs/plugins/prisma#optimized-queries-without-tprismafield
+        });
+      });
+
+      return { model };
+    },
+  })
+);

--- a/packages/hub/src/graphql/queries/modelsByVersion.ts
+++ b/packages/hub/src/graphql/queries/modelsByVersion.ts
@@ -1,0 +1,64 @@
+import { builder } from "@/graphql/builder";
+import { prisma } from "@/prisma";
+import { Model } from "../types/Model";
+
+const ModelsByVersion = builder.simpleObject("ModelsByVersion", {
+  fields: (t) => ({
+    version: t.string(),
+    count: t.int(),
+    privateCount: t.int(),
+    models: t.field({
+      type: [Model],
+    }),
+  }),
+});
+
+builder.queryField("modelsByVersion", (t) =>
+  t.field({
+    description: "Admin-only query for listing models in /admin UI",
+    type: [ModelsByVersion],
+    authScopes: {
+      isRootUser: true,
+    },
+    resolve: async () => {
+      const models = await prisma.model.findMany({
+        include: {
+          currentRevision: {
+            where: {
+              contentType: "SquiggleSnippet",
+            },
+            include: {
+              squiggleSnippet: true,
+            },
+          },
+        },
+      });
+
+      const groupedModels: Record<string, typeof models> = {};
+      const privateStats: Record<string, number> = {};
+      const versions = new Set<string>();
+
+      for (const model of models) {
+        const version = model.currentRevision?.squiggleSnippet?.version;
+        if (!version) continue;
+
+        versions.add(version);
+
+        if (model.isPrivate) {
+          privateStats[version] ??= 0;
+          privateStats[version]++;
+        } else {
+          // don't expose private models, they won't be available through GraphQL anyway
+          groupedModels[version] ??= [];
+          groupedModels[version].push(model);
+        }
+      }
+      return [...versions.values()].map((version) => ({
+        version,
+        count: (groupedModels[version] ?? []).length,
+        privateCount: privateStats[version] ?? 0,
+        models: groupedModels[version] ?? [],
+      }));
+    },
+  })
+);

--- a/packages/hub/src/graphql/schema.ts
+++ b/packages/hub/src/graphql/schema.ts
@@ -15,6 +15,7 @@ import "./queries/relativeValuesDefinitions";
 import "./queries/runSquiggle";
 import "./queries/userByUsername";
 import "./queries/users";
+import "./queries/modelsByVersion";
 
 import "./mutations/buildRelativeValuesCache";
 import "./mutations/cancelGroupInvite";
@@ -35,5 +36,6 @@ import "./mutations/updateModelPrivacy";
 import "./mutations/updateModelSlug";
 import "./mutations/updateRelativeValuesDefinition";
 import "./mutations/updateSquiggleSnippetModel";
+import "./mutations/adminUpdateModelVersion";
 
 export const schema = builder.toSchema();


### PR DESCRIPTION
Running models on the server is too complicated for now, for several reasons:
- Vercel backend timeouts
- we'd need multiple Squiggle versions on the backend, versioned-playground is frontend-only
- duplicate linker config for the backend

And on the frontend, we don't have a way to run models with older versions without a playground component (versioned-playground exposes only a SquigglePlayground component).

So, instead, I show a playground for each (public, but not necessarily owned by the current user) model, along with "Upgrade" button:
<img width="900" alt="Captura de pantalla 2023-11-06 a la(s) 16 31 33" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/50f90932-5ba5-498f-b047-e96143d18158">

There's no pagination and the page reloads on each model, but it should be fine for now. Well, maybe a bit slow since we have 100+ models, but I _hope_ it won't crash the browser in production (actually, it might... we'll see).

Other things I had to implement for this:
- `isRootUser` auth scope, configured by `ROOT_EMAILS` env var
- two new routes for root scope, one for listing models and one for upgrading

- private models are not available for upgrades, but I'm listing their count in the /admin UI
- on upgrade, model gets a new revision authored by the admin; this might be a bit confusing for users because they'll see that someone else edited their model, but I think it's fine