### PR TITLE
Improve empty group message; also rename `pnpm gen` target

### DIFF
--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -3,18 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "db:generate": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma generate",
     "db:migrate": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma migrate deploy",
     "dev": "next dev -p 3001",
     "start": "__NEXT_PRIVATE_PREBUNDLED_REACT=next next start",
-    "generate": "pnpm db:generate && pnpm print-schema && pnpm relay",
-    "build:ts": "pnpm generate && tsc",
-    "build": "pnpm generate && __NEXT_PRIVATE_PREBUNDLED_REACT=next next build",
+    "gen:prisma": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma generate",
+    "gen:relay": "relay-compiler",
+    "gen:schema": "tsx ./src/graphql/print-schema.ts",
+    "gen": "pnpm gen:prisma && pnpm gen:schema && pnpm gen:relay",
+    "build:ts": "pnpm gen && tsc",
+    "build": "pnpm gen && __NEXT_PRIVATE_PREBUNDLED_REACT=next next build",
     "lint": "prettier --check . && next lint",
     "format": "prettier --write .",
-    "relay": "relay-compiler",
-    "test:manual": "dotenv -e .env.test -- jest -i",
-    "print-schema": "tsx ./src/graphql/print-schema.ts"
+    "test:manual": "dotenv -e .env.test -- jest -i"
   },
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",

--- a/packages/hub/src/app/groups/[slug]/GroupModelList.tsx
+++ b/packages/hub/src/app/groups/[slug]/GroupModelList.tsx
@@ -1,8 +1,10 @@
-import { GroupModelList$key } from "@/__generated__/GroupModelList.graphql";
-import { ModelList } from "@/models/components/ModelList";
 import { FC } from "react";
 import { usePaginationFragment } from "react-relay";
 import { graphql } from "relay-runtime";
+
+import { GroupModelList$key } from "@/__generated__/GroupModelList.graphql";
+import { ModelList } from "@/models/components/ModelList";
+import { useIsGroupMember } from "./hooks";
 
 const Fragment = graphql`
   fragment GroupModelList on Group
@@ -11,6 +13,7 @@ const Fragment = graphql`
     count: { type: "Int", defaultValue: 20 }
   )
   @refetchable(queryName: "GroupModelListPaginationQuery") {
+    ...hooks_useIsGroupMember
     models(first: $count, after: $cursor)
       @connection(key: "GroupModelList_models") {
       edges {
@@ -26,10 +29,10 @@ type Props = {
 };
 
 export const GroupModelList: FC<Props> = ({ groupRef }) => {
-  const {
-    data: { models },
-    loadNext,
-  } = usePaginationFragment(Fragment, groupRef);
+  const { data: group, loadNext } = usePaginationFragment(Fragment, groupRef);
+
+  const { models } = group;
+  const isMember = useIsGroupMember(group);
 
   return (
     <div>
@@ -41,7 +44,9 @@ export const GroupModelList: FC<Props> = ({ groupRef }) => {
         />
       ) : (
         <div className="text-slate-500">
-          {"This group doesn't have any models yet."}
+          {isMember
+            ? "This group doesn't have any models."
+            : "This group does not have any public models."}
         </div>
       )}
     </div>

--- a/packages/hub/src/app/groups/[slug]/hooks.ts
+++ b/packages/hub/src/app/groups/[slug]/hooks.ts
@@ -1,4 +1,5 @@
 import { hooks_useIsGroupAdmin$key } from "@/__generated__/hooks_useIsGroupAdmin.graphql";
+import { hooks_useIsGroupMember$key } from "@/__generated__/hooks_useIsGroupMember.graphql";
 import { graphql, useFragment } from "react-relay";
 
 export function useIsGroupAdmin(groupRef: hooks_useIsGroupAdmin$key) {
@@ -16,7 +17,7 @@ export function useIsGroupAdmin(groupRef: hooks_useIsGroupAdmin$key) {
   return myMembership?.role === "Admin";
 }
 
-export function useIsGroupMember(groupRef: hooks_useIsGroupAdmin$key) {
+export function useIsGroupMember(groupRef: hooks_useIsGroupMember$key) {
   const { myMembership } = useFragment(
     graphql`
       fragment hooks_useIsGroupMember on Group {

--- a/packages/hub/vercel.json
+++ b/packages/hub/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "PLATFORM=vercel npx turbo build && pnpm run db:generate",
+  "buildCommand": "PLATFORM=vercel npx turbo build && pnpm run gen:prisma",
   "framework": "nextjs",
   "ignoreCommand": "npx turbo-ignore || ../../skip-dependabot.sh"
 }


### PR DESCRIPTION
Fixes #2502.

Also, I renamed `pnpm generate` to `pnpm gen`, because I'm typing it often and it's annoying to type a full word. (renamed some other scripts for consistency too)