### PR TITLE
Calculators and viewer refactorings

### DIFF
--- a/packages/components/src/components/Calculator/CalculatorResult.tsx
+++ b/packages/components/src/components/Calculator/CalculatorResult.tsx
@@ -1,7 +1,8 @@
-import { FC, useEffect, useMemo, useState, useCallback } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 
 import { Env, SqValue } from "@quri/squiggle-lang";
 
+import { Button } from "@quri/ui";
 import { PlaygroundSettings } from "../PlaygroundSettings.js";
 import { ValueResultViewer } from "./ValueResultViewer.js";
 import {
@@ -10,7 +11,6 @@ import {
   SqValueResult,
 } from "./types.js";
 import { useSavedCalculatorState } from "./useSavedCalculatorState.js";
-import { Button } from "@quri/ui";
 
 type Props = {
   valueWithContext: SqCalculatorValueWithContext;

--- a/packages/components/src/components/Calculator/ValueResultViewer.tsx
+++ b/packages/components/src/components/Calculator/ValueResultViewer.tsx
@@ -1,4 +1,4 @@
-import { FC, memo } from "react";
+import { memo } from "react";
 
 import { valueHasContext } from "../../lib/utility.js";
 import { PlaygroundSettings } from "../PlaygroundSettings.js";
@@ -6,10 +6,13 @@ import { getSqValueWidget } from "../SquiggleViewer/getSqValueWidget.js";
 import { SqValueResult } from "./types.js";
 
 // Unlike ValueViewer/ValueWithContextViewer, this just renders the raw widget; TODO - better name?
-const ValueResultViewerBase: FC<{
+export const ValueResultViewer = memo(function ValueResultViewer({
+  result,
+  settings,
+}: {
   result: SqValueResult;
   settings: PlaygroundSettings;
-}> = ({ result, settings }) => {
+}) {
   if (result.ok) {
     const value = result.value;
     if (valueHasContext(value)) {
@@ -24,6 +27,4 @@ const ValueResultViewerBase: FC<{
       </div>
     );
   }
-};
-
-export const ValueResultViewer = memo(ValueResultViewerBase);
+});

--- a/packages/components/src/components/Calculator/index.tsx
+++ b/packages/components/src/components/Calculator/index.tsx
@@ -212,14 +212,17 @@ export const Calculator: FC<Props> = ({
   const { calculator, form, inputResults, processAllFieldCodes } =
     useCalculator(valueWithContext, _environment);
 
-  const inputResultSettings: PlaygroundSettings = {
-    ...settings,
-    distributionChartSettings: {
-      ...settings.distributionChartSettings,
-      showSummary: false,
-    },
-    chartHeight: 30,
-  };
+  const inputResultSettings: PlaygroundSettings = useMemo(
+    () => ({
+      ...settings,
+      distributionChartSettings: {
+        ...settings.distributionChartSettings,
+        showSummary: false,
+      },
+      chartHeight: 30,
+    }),
+    [settings]
+  );
 
   //This memoization is useful to make sure that CalculatorResult ResultViewer doesn't get updated too frequently.
   const calculatorResultSettings: PlaygroundSettings = useMemo(

--- a/packages/components/src/components/Calculator/index.tsx
+++ b/packages/components/src/components/Calculator/index.tsx
@@ -199,16 +199,6 @@ export const CalculatorSampleCountValidation: React.FC<{
   );
 };
 
-function useDeepCompareMemoize(value: PlaygroundSettings): PlaygroundSettings {
-  const ref = useRef<PlaygroundSettings | undefined>();
-
-  if (JSON.stringify(value) !== JSON.stringify(ref.current)) {
-    ref.current = value;
-  }
-
-  return ref.current as PlaygroundSettings;
-}
-
 export const Calculator: FC<Props> = ({
   environment,
   settings,
@@ -222,12 +212,10 @@ export const Calculator: FC<Props> = ({
   const { calculator, form, inputResults, processAllFieldCodes } =
     useCalculator(valueWithContext, _environment);
 
-  const _settings: PlaygroundSettings = useDeepCompareMemoize(settings);
-
   const inputResultSettings: PlaygroundSettings = {
-    ..._settings,
+    ...settings,
     distributionChartSettings: {
-      ..._settings.distributionChartSettings,
+      ...settings.distributionChartSettings,
       showSummary: false,
     },
     chartHeight: 30,
@@ -236,10 +224,10 @@ export const Calculator: FC<Props> = ({
   //This memoization is useful to make sure that CalculatorResult ResultViewer doesn't get updated too frequently.
   const calculatorResultSettings: PlaygroundSettings = useMemo(
     () => ({
-      ..._settings,
+      ...settings,
       chartHeight: 200,
     }),
-    [_settings]
+    [settings]
   );
 
   const hasTitleOrDescription = !!calculator.title || !!calculator.description;

--- a/packages/components/src/components/SquiggleViewer/ItemSettingsMenu.tsx
+++ b/packages/components/src/components/SquiggleViewer/ItemSettingsMenu.tsx
@@ -17,6 +17,7 @@ import {
   useSetLocalItemState,
   useViewerContext,
   useResetStateSettings,
+  useMergedSettings,
 } from "./ViewerProvider.js";
 import { pathAsString } from "./utils.js";
 
@@ -38,11 +39,11 @@ const ItemSettingsModal: React.FC<
   resetScroll,
 }) => {
   const setLocalItemState = useSetLocalItemState();
-  const { getLocalItemState, getMergedSettings } = useViewerContext();
+  const { getLocalItemState } = useViewerContext();
 
   const { path } = value.context;
 
-  const mergedSettings = getMergedSettings({ path });
+  const mergedSettings = useMergedSettings(path);
 
   const form = useForm({
     resolver: zodResolver(viewSettingsSchema),

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -14,11 +14,11 @@ import { SqValue, SqValuePath } from "@quri/squiggle-lang";
 
 import {
   PartialPlaygroundSettings,
+  PlaygroundSettings,
   defaultPlaygroundSettings,
 } from "../PlaygroundSettings.js";
 import {
   LocalItemState,
-  MergedItemSettings,
   getChildrenValues,
   pathAsString,
   topLevelBindingsName,
@@ -89,6 +89,7 @@ type ViewerContextShape = {
   // Note that we don't store localItemState themselves in the context (that would cause rerenders of the entire tree on each settings update).
   // Instead, we keep localItemState in local state and notify the global context via setLocalItemState to pass them down the component tree again if it got rebuilt from scratch.
   // See ./SquiggleViewer.tsx and ./ValueWithContextViewer.tsx for other implementation details on this.
+  globalSettings: PlaygroundSettings;
   getLocalItemState({
     path,
     defaults,
@@ -97,13 +98,6 @@ type ViewerContextShape = {
     defaults?: LocalItemState;
   }): LocalItemState;
   getCalculator({ path }: { path: SqValuePath }): CalculatorState | undefined;
-  getMergedSettings({
-    path,
-    defaults,
-  }: {
-    path: SqValuePath;
-    defaults?: LocalItemState;
-  }): MergedItemSettings;
   localSettingsEnabled: boolean; // show local settings icon in the UI
   focused?: SqValuePath;
   editor?: CodeEditorHandle;
@@ -111,9 +105,9 @@ type ViewerContextShape = {
 };
 
 export const ViewerContext = createContext<ViewerContextShape>({
+  globalSettings: defaultPlaygroundSettings,
   getLocalItemState: () => ({ collapsed: false, settings: {} }),
   getCalculator: () => undefined,
-  getMergedSettings: () => defaultPlaygroundSettings,
   localSettingsEnabled: false,
   focused: undefined,
   editor: undefined,
@@ -199,13 +193,25 @@ export function useCollapseChildren() {
   );
 }
 
-export function useIsFocused(location: SqValuePath) {
+export function useIsFocused(path: SqValuePath) {
   const { focused } = useViewerContext();
   if (!focused) {
     return false;
   } else {
-    return pathAsString(focused) === pathAsString(location);
+    return pathAsString(focused) === pathAsString(path);
   }
+}
+
+export function useMergedSettings(path: SqValuePath) {
+  const { getLocalItemState, globalSettings } = useViewerContext();
+
+  const localItemState = getLocalItemState({ path });
+
+  const result: PlaygroundSettings = useMemo(
+    () => merge({}, globalSettings, localItemState.settings),
+    [globalSettings, localItemState.settings]
+  );
+  return result;
 }
 
 type LocalItemStateStore = {
@@ -284,25 +290,6 @@ export const ViewerProvider: FC<
     [localItemStateStoreRef]
   );
 
-  const getMergedSettings = useCallback(
-    ({
-      path,
-      defaults = defaultLocalItemState,
-    }: {
-      path: SqValuePath;
-      defaults?: LocalItemState;
-    }) => {
-      const localItemState = getLocalItemState({ path, defaults });
-      const result: MergedItemSettings = merge(
-        {},
-        globalSettings,
-        localItemState.settings
-      );
-      return result;
-    },
-    [globalSettings, getLocalItemState]
-  );
-
   const setCollapsed = (path: SqValuePath, isCollapsed: boolean) => {
     setLocalItemState(path, (state) => ({
       ...state,
@@ -378,9 +365,9 @@ export const ViewerProvider: FC<
   return (
     <ViewerContext.Provider
       value={{
+        globalSettings,
         getLocalItemState,
         getCalculator,
-        getMergedSettings,
         localSettingsEnabled,
         editor,
         focused,

--- a/packages/components/src/components/SquiggleViewer/getSqValueWidget.tsx
+++ b/packages/components/src/components/SquiggleViewer/getSqValueWidget.tsx
@@ -22,14 +22,17 @@ import { DistFunctionChart } from "../FunctionChart/DistFunctionChart.js";
 import { NumericFunctionChart } from "../FunctionChart/NumericFunctionChart.js";
 import { FunctionChart } from "../FunctionChart/index.js";
 import { NumberShower } from "../NumberShower.js";
-import { generateDistributionPlotSettings } from "../PlaygroundSettings.js";
+import {
+  PlaygroundSettings,
+  generateDistributionPlotSettings,
+} from "../PlaygroundSettings.js";
 import { RelativeValuesGridChart } from "../RelativeValuesGridChart/index.js";
 import { ScatterChart } from "../ScatterChart/index.js";
 import { TableChart } from "../TableChart/index.js";
 import { ItemSettingsMenu } from "./ItemSettingsMenu.js";
 import { ValueViewer } from "./ValueViewer.js";
 import { SettingsMenuParams } from "./ValueWithContextViewer.js";
-import { MergedItemSettings, getChildrenValues } from "./utils.js";
+import { getChildrenValues } from "./utils.js";
 
 // Distributions should be smaller than the other charts.
 // Note that for distributions, this only applies to the internals, there's also extra margin and details.
@@ -55,7 +58,7 @@ export type ValueWidget = {
   heading?: string;
   renderPreview?: () => ReactNode;
   renderSettingsMenu?: (params: SettingsMenuParams) => ReactNode;
-  render: (settings: MergedItemSettings) => ReactNode;
+  render: (settings: PlaygroundSettings) => ReactNode;
 };
 
 export function getSqValueWidget(value: SqValueWithContext): ValueWidget {
@@ -294,7 +297,13 @@ export function getSqValueWidget(value: SqValueWithContext): ValueWidget {
         renderPreview: () => (
           <SqTypeWithCount type="{}" count={entries.length} />
         ),
-        render: () => entries.map((r, i) => <ValueViewer key={i} value={r} />),
+        render: () => (
+          <div className="space-y-2 pt-1 mt-1">
+            {entries.map((r, i) => (
+              <ValueViewer key={i} value={r} />
+            ))}
+          </div>
+        ),
       };
     }
     case "Array": {
@@ -303,7 +312,13 @@ export function getSqValueWidget(value: SqValueWithContext): ValueWidget {
       return {
         heading: `List(${length})`,
         renderPreview: () => <SqTypeWithCount type="[]" count={length} />,
-        render: () => entries.map((r, i) => <ValueViewer key={i} value={r} />),
+        render: () => (
+          <div className="space-y-2 pt-1 mt-1">
+            {entries.map((r, i) => (
+              <ValueViewer key={i} value={r} />
+            ))}
+          </div>
+        ),
       };
     }
 

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -1,9 +1,6 @@
 import { PathItem, SqValue, SqValuePath } from "@quri/squiggle-lang";
-import {
-  PartialPlaygroundSettings,
-  PlaygroundSettings,
-} from "../PlaygroundSettings.js";
 import { CalculatorState } from "../Calculator/types.js";
+import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 
 export type LocalItemState = {
   collapsed: boolean;
@@ -13,8 +10,6 @@ export type LocalItemState = {
     "distributionChartSettings" | "functionChartSettings"
   >;
 };
-
-export type MergedItemSettings = PlaygroundSettings;
 
 export const pathItemFormat = (item: PathItem): string => {
   if (item.type === "cellAddress") {

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -51,7 +51,7 @@ export function pathAsString(path: SqValuePath) {
   }
 }
 
-export function pathToShortName(path: SqValuePath): string | undefined {
+export function pathToShortName(path: SqValuePath): string {
   if (isTopLevel(path)) {
     return topLevelName(path);
   } else {


### PR DESCRIPTION
This PR is for #2525's branch.
1) Split `ValueWithContextViewer` in multiple components; most of the work is still done in `ValueWithContextViewer` but it's more manageable than before; there's a tradeoff in that we call `getSqValueWidget`, `useIsFocused` and some others a twice now, but all of these are cheap and shouldn't affect the performance
2) Replace `getMergedSettings` with `useMergedSettings` hook which keeps the settings identity stable; this allows us to remove `useDeepCompareMemoize` hook, as discussed in https://github.com/quantified-uncertainty/squiggle/pull/2525#discussion_r1393398447
3) Move `<div className="space-y-2 pt-1 mt-1">` wrapper to `getSqValueWidget` render; other minor refactorings