### PR TITLE
Rename drafts on model renames and moves; fix form submits

### DIFF
--- a/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState } from "react";
+import { BaseSyntheticEvent, FC, useMemo, useState } from "react";
 import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 import { graphql, useFragment } from "react-relay";
 
@@ -51,7 +51,10 @@ export type SquiggleSnippetFormShape = {
   exports: SquiggleModelExportInput[];
 };
 
-type OnSubmit = (extraData?: { comment: string }) => Promise<void>;
+type OnSubmit = (
+  event?: BaseSyntheticEvent,
+  extraData?: { comment: string }
+) => Promise<void>;
 
 const SaveDialog: FC<{ onSubmit: OnSubmit; close: () => void }> = ({
   onSubmit,
@@ -62,8 +65,8 @@ const SaveDialog: FC<{ onSubmit: OnSubmit; close: () => void }> = ({
   };
   const form = useForm<SaveFormShape>();
 
-  const handleSubmit = form.handleSubmit(async ({ comment }) => {
-    await onSubmit({ comment });
+  const handleSubmit = form.handleSubmit(async ({ comment }, event) => {
+    await onSubmit(event, { comment });
     close();
   });
 

--- a/packages/hub/src/app/models/[owner]/[slug]/FixModelUrlCasing.ts
+++ b/packages/hub/src/app/models/[owner]/[slug]/FixModelUrlCasing.ts
@@ -25,7 +25,14 @@ export function useFixModelUrlCasing(modelRef: FixModelUrlCasing$key) {
     slug: model.slug,
     owner: model.owner.slug,
   });
-  if (patchedPathname && patchedPathname !== pathname) {
-    router.replace(patchedPathname);
+  if (
+    patchedPathname &&
+    patchedPathname !== pathname &&
+    typeof window !== "undefined"
+  ) {
+    // delay to avoid React warnings
+    window.setTimeout(() => {
+      router.replace(patchedPathname);
+    }, 0);
   }
 }

--- a/packages/hub/src/app/models/[owner]/[slug]/ModelSettingsButton.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/ModelSettingsButton.tsx
@@ -14,12 +14,9 @@ export const ModelSettingsButton: FC<{
   const model = useFragment(
     graphql`
       fragment ModelSettingsButton on Model {
-        slug
+        ...UpdateModelSlugAction
         ...MoveModelAction
         ...DeleteModelAction
-        owner {
-          slug
-        }
       }
     `,
     modelKey
@@ -29,11 +26,7 @@ export const ModelSettingsButton: FC<{
     <Dropdown
       render={({ close }) => (
         <DropdownMenu>
-          <UpdateModelSlugAction
-            owner={model.owner.slug}
-            slug={model.slug}
-            close={close}
-          />
+          <UpdateModelSlugAction model={model} close={close} />
           <MoveModelAction model={model} close={close} />
           <DeleteModelAction model={model} close={close} />
         </DropdownMenu>

--- a/packages/hub/src/app/models/[owner]/[slug]/MoveModelAction.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/MoveModelAction.tsx
@@ -10,6 +10,7 @@ import { SelectOwner, SelectOwnerOption } from "@/components/SelectOwner";
 import { MutationModalAction } from "@/components/ui/MutationModalAction";
 import { modelRoute } from "@/routes";
 import { MoveModelAction$key } from "@/__generated__/MoveModelAction.graphql";
+import { draftUtils, modelToDraftLocator } from "./SquiggleSnippetDraftDialog";
 
 const Mutation = graphql`
   mutation MoveModelActionMutation($input: MutationMoveModelInput!) {
@@ -46,7 +47,6 @@ export const MoveModelAction: FC<Props> = ({ model: modelKey, close }) => {
       fragment MoveModelAction on Model {
         slug
         owner {
-          # TODO - fragment?
           __typename
           id
           slug
@@ -80,8 +80,14 @@ export const MoveModelAction: FC<Props> = ({ model: modelKey, close }) => {
       title="Change Owner"
       icon={RightArrowIcon}
       modalTitle={`Change owner for ${model.owner.slug}/${model.slug}`}
-      onCompleted={({ model }) => {
-        router.push(modelRoute({ owner: model.owner.slug, slug: model.slug }));
+      onCompleted={({ model: newModel }) => {
+        draftUtils.rename(
+          modelToDraftLocator(model),
+          modelToDraftLocator(newModel)
+        );
+        router.push(
+          modelRoute({ owner: newModel.owner.slug, slug: newModel.slug })
+        );
       }}
     >
       {() => (

--- a/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/SquiggleSnippetDraftDialog.tsx
@@ -73,6 +73,17 @@ export const draftUtils = {
     if (!value) return null;
     return JSON.parse(value); // TODO - validate
   },
+  rename(oldLocator: DraftLocator, newLocator: DraftLocator) {
+    if (!localStorageExists()) {
+      return;
+    }
+    const oldKey = draftKey(oldLocator);
+    const value = window.localStorage.getItem(oldKey);
+    if (!value) return null;
+    const newKey = draftKey(newLocator);
+    window.localStorage.setItem(newKey, value);
+    window.localStorage.removeItem(oldKey);
+  },
   discard(locator: DraftLocator) {
     if (!localStorageExists()) {
       return;
@@ -102,6 +113,20 @@ export function useDraftLocator(
     modelSlug: model.slug,
   };
   return draftLocator;
+}
+
+// In some contexts, we can't use useDraftLocator, because we can't use useFragment.
+// So we duck-type models instead.
+export function modelToDraftLocator(model: {
+  owner: {
+    slug: string;
+  };
+  slug: string;
+}): DraftLocator {
+  return {
+    ownerSlug: model.owner.slug,
+    modelSlug: model.slug,
+  };
 }
 
 type Props = {

--- a/packages/hub/src/app/new/group/NewGroup.tsx
+++ b/packages/hub/src/app/new/group/NewGroup.tsx
@@ -60,7 +60,7 @@ export const NewGroup: FC = () => {
   });
 
   return (
-    <form onSubmit={() => onSubmit()}>
+    <form onSubmit={onSubmit}>
       <FormProvider {...form}>
         <H1>New Group</H1>
         <div className="mb-4">

--- a/packages/hub/src/app/new/model/NewModel.tsx
+++ b/packages/hub/src/app/new/model/NewModel.tsx
@@ -114,7 +114,7 @@ export const NewModel: FC = () => {
   });
 
   return (
-    <form onSubmit={() => onSubmit()}>
+    <form onSubmit={onSubmit}>
       <FormProvider {...form}>
         <H1>New Model</H1>
         <div className="space-y-4 mb-4 mt-4">

--- a/packages/hub/src/app/settings/choose-username/ChooseUsername.tsx
+++ b/packages/hub/src/app/settings/choose-username/ChooseUsername.tsx
@@ -56,7 +56,7 @@ export const ChooseUsername: FC = () => {
   const disabled = inFlight || !form.formState.isValid;
 
   return (
-    <form onSubmit={() => onSubmit()}>
+    <form onSubmit={onSubmit}>
       <FormProvider {...form}>
         <div className="flex flex-col items-center mt-20">
           <div className="space-y-2">

--- a/packages/hub/src/components/ui/FormModal.tsx
+++ b/packages/hub/src/components/ui/FormModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Modal } from "@quri/ui";
-import { PropsWithChildren, useEffect } from "react";
+import { BaseSyntheticEvent, PropsWithChildren, useEffect } from "react";
 import {
   FieldPath,
   FieldValues,
@@ -8,7 +8,7 @@ import {
 } from "react-hook-form";
 
 type Props<TFieldValues extends FieldValues> = PropsWithChildren<{
-  onSubmit: () => void;
+  onSubmit: (event?: BaseSyntheticEvent) => void;
   close: () => void;
   submitText: string;
   title: string;

--- a/packages/hub/src/hooks/useMutationForm.ts
+++ b/packages/hub/src/hooks/useMutationForm.ts
@@ -2,7 +2,7 @@ import { FieldValues, UseFormProps, useForm } from "react-hook-form";
 import { VariablesOf } from "relay-runtime";
 
 import { CommonMutationParameters, useAsyncMutation } from "./useAsyncMutation";
-import { useCallback } from "react";
+import { BaseSyntheticEvent, useCallback } from "react";
 
 /**
  * This hook ties together `useForm` and `useAsyncMutation`, which is a very common pattern for forms that submit data to our backend through mutations.
@@ -67,13 +67,14 @@ export function useMutationForm<
   });
 
   const onSubmit = useCallback(
-    (extraData?: ExtraData) =>
+    (event?: BaseSyntheticEvent, extraData?: ExtraData) => {
       form.handleSubmit((formData) => {
         runMutation({
           variables: formDataToVariables(formData, extraData),
           onCompleted,
         });
-      })(),
+      })(event);
+    },
     [form, formDataToVariables, onCompleted, runMutation]
   );
 

--- a/packages/hub/src/hooks/useMutationForm.ts
+++ b/packages/hub/src/hooks/useMutationForm.ts
@@ -67,14 +67,13 @@ export function useMutationForm<
   });
 
   const onSubmit = useCallback(
-    (event?: BaseSyntheticEvent, extraData?: ExtraData) => {
+    (event?: BaseSyntheticEvent, extraData?: ExtraData) =>
       form.handleSubmit((formData) => {
         runMutation({
           variables: formDataToVariables(formData, extraData),
           onCompleted,
         });
-      })(event);
-    },
+      })(event),
     [form, formDataToVariables, onCompleted, runMutation]
   );
 

--- a/packages/ui/src/forms/fields/SelectFormField.tsx
+++ b/packages/ui/src/forms/fields/SelectFormField.tsx
@@ -177,7 +177,7 @@ export function SelectFormField<
 
           return (
             <SelectComponent<TOption>
-              instanceId={name}
+              instanceId={name} // important to avoid hydration errors
               name={name}
               components={{
                 Option: OptionComponent,

--- a/packages/ui/src/forms/fields/SelectFormField.tsx
+++ b/packages/ui/src/forms/fields/SelectFormField.tsx
@@ -159,7 +159,7 @@ export function SelectFormField<
         description={description}
         rules={{ required }}
       >
-        {({ value, onChange }) => {
+        {({ name, value, onChange }) => {
           /* `selectValue` can be null while `value` is not null.
            * This can happen if `fieldValueToOption` looks for an option in a fixed list, but value is not present there anymore.
            * This is bad: it means that the UI will show that nothing is selected, while the underlying form state still contains a value.
@@ -177,6 +177,8 @@ export function SelectFormField<
 
           return (
             <SelectComponent<TOption>
+              instanceId={name}
+              name={name}
               components={{
                 Option: OptionComponent,
                 SingleValue: SingleValueComponent,


### PR DESCRIPTION
1) Drafts are renamed together with slug or owner changes.

Because the page pretty much reloads on those actions, it means that if there were any unsaved edits then the draft dialog will be displayed. It could be improved by auto-saving on moves and renames, but that's harder to implement.

2) When I did #2498, I didn't realize that RHF's `form.handleSubmit` takes an event parameter and calls `event.preventDefault`. So several forms that we had started to redirect to `?field=value` instead of submitting.

Now I pass the `event` to RHF in `onSubmit` that's generated in `useMutationForm`.

3) Fix a few console warnings (one is hydration-related in SelectFormField, another in `useFixModelUrlCasing`).