### PR TITLE
Converts Dates Domains to use Dates as internal min/max format

### DIFF
--- a/packages/components/src/widgets/LambdaWidget/index.tsx
+++ b/packages/components/src/widgets/LambdaWidget/index.tsx
@@ -1,7 +1,7 @@
 import { ItemSettingsMenuItems } from "../../components/SquiggleViewer/ItemSettingsMenuItems.js";
 import { widgetRegistry } from "../registry.js";
 import { truncateStr } from "../utils.js";
-import { FunctionChart } from "./FunctionChart/index.js";
+import { AutomaticFunctionChart } from "./FunctionChart/AutomaticFunctionChart.js";
 
 widgetRegistry.register("Lambda", {
   Preview: (value) => (
@@ -19,7 +19,7 @@ widgetRegistry.register("Lambda", {
   Chart: (value, settings) => {
     const environment = value.context.project.getEnvironment();
     return (
-      <FunctionChart
+      <AutomaticFunctionChart
         fn={value.value}
         settings={settings}
         height={settings.chartHeight}

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -26,25 +26,25 @@ const maker = new FnFactory({
 
 const defaultScale = { type: "linear" } satisfies Scale;
 
+export function assertValidMinMax(scale: Scale) {
+  const hasMin = !scale.min;
+  const hasMax = !scale.max;
+
+  // Validate scale properties
+  if (hasMin !== hasMax) {
+    throw new REArgumentError(
+      `Scale ${hasMin ? "min" : "max"} set without ${
+        hasMin ? "max" : "min"
+      }. Must set either both or neither.`
+    );
+  } else if (hasMin && hasMax && scale.min! >= scale.max!) {
+    throw new REArgumentError(
+      `Scale min (${scale.min}) is greater or equal than than max (${scale.max})`
+    );
+  }
+}
+
 function createScale(scale: Scale | null, domain: VDomain | undefined): Scale {
-  if (scale && scale.min && scale.max) {
-    // complete scale, nothing to improve
-    return scale;
-  }
-
-  if (scale) {
-    if (scale.min === undefined && scale.max !== undefined) {
-      throw new REArgumentError(
-        "Scale max set without min. Must set either both or neither."
-      );
-    }
-    if (scale.min !== undefined && scale.max === undefined) {
-      throw new REArgumentError(
-        "Scale min set without max. Must set either both or neither."
-      );
-    }
-  }
-
   /*
    * There are several possible combinations here:
    * 1. Scale with min/max -> ignore domain, keep scale
@@ -52,34 +52,17 @@ function createScale(scale: Scale | null, domain: VDomain | undefined): Scale {
    * 3. Scale without min/max, no domain -> keep scale
    * 4. No scale and no domain -> default scale
    */
+  //TODO: It might be good to check if scale is outside the bounds of the domain, and throw an error then or something.
 
-  if (
-    !domain ||
-    (domain.value.type !== "NumericRange" && domain.value.type !== "DateRange")
-  ) {
-    // no domain, use explicit scale or default scale
-    return scale ?? defaultScale;
-  }
+  scale && assertValidMinMax(scale);
 
-  if (scale) {
-    return {
-      ...scale,
-      min: scale.min ?? domain.value.minAsNumber,
-      max: scale.max ?? domain.value.maxAsNumber,
-    };
-  } else if (domain.value.type === "DateRange") {
-    return {
-      type: "date",
-      min: domain.value.minAsNumber,
-      max: domain.value.maxAsNumber,
-    };
-  } else {
-    return {
-      type: "linear",
-      min: domain.value.min,
-      max: domain.value.max,
-    };
-  }
+  const _defaultScale = domain ? domain.value.toDefaultScale() : defaultScale;
+
+  // This gets min/max from domain, if it's not on scale.
+  return {
+    ..._defaultScale,
+    ...(scale || {}),
+  };
 }
 
 // This function both extract the domain and checks that the function has only one parameter.

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -64,14 +64,14 @@ function createScale(scale: Scale | null, domain: VDomain | undefined): Scale {
   if (scale) {
     return {
       ...scale,
-      min: scale.min ?? domain.value.min,
-      max: scale.max ?? domain.value.max,
+      min: scale.min ?? domain.value.minAsNumber,
+      max: scale.max ?? domain.value.maxAsNumber,
     };
   } else if (domain.value.type === "DateRange") {
     return {
       type: "date",
-      min: domain.value.min,
-      max: domain.value.max,
+      min: domain.value.minAsNumber,
+      max: domain.value.maxAsNumber,
     };
   } else {
     return {

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -8,7 +8,7 @@ import {
   frString,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
-import { dateFromMs, dateToMs, dateToString } from "../utility/DateTime.js";
+import { dateToMs, dateToString } from "../utility/DateTime.js";
 import { vScale } from "../value/index.js";
 
 const maker = new FnFactory({

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -37,7 +37,11 @@ export {
   SqSymbolicDistribution,
   type SqDistribution,
 } from "./public/SqValue/SqDistribution/index.js";
-export { type SqDomain } from "./public/SqValue/SqDomain.js";
+export {
+  type SqDomain,
+  SqNumericRangeDomain,
+  SqDateRangeDomain,
+} from "./public/SqValue/SqDomain.js";
 export { SqLambda, type SqLambdaParameter } from "./public/SqValue/SqLambda.js";
 export { SqDictValue } from "./public/SqValue/index.js";
 export {

--- a/packages/squiggle-lang/src/public/SqValue/SqDomain.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqDomain.ts
@@ -4,7 +4,7 @@ import {
   Domain,
   NumericRangeDomain,
 } from "../../value/domain.js";
-import { SqDateScale, SqLinearScale } from "./SqScale.js";
+import { SqDateScale, SqLinearScale, wrapScale } from "./SqScale.js";
 import { SqDateValue, SqNumberValue } from "./index.js";
 
 export function wrapDomain(value: Domain) {
@@ -52,11 +52,7 @@ export class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
   }
 
   toDefaultScale() {
-    return new SqLinearScale({
-      type: "linear",
-      min: this.min,
-      max: this.max,
-    });
+    return SqLinearScale.create(this._value.toDefaultScale());
   }
 }
 export class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
@@ -83,11 +79,7 @@ export class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
   }
 
   toDefaultScale() {
-    return new SqDateScale({
-      type: "date",
-      min: dateToMs(this.min),
-      max: dateToMs(this.max),
-    });
+    return SqDateScale.create(this._value.toDefaultScale());
   }
 }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqDomain.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqDomain.ts
@@ -1,4 +1,9 @@
-import { Domain } from "../../value/domain.js";
+import { dateToMs } from "../../utility/DateTime.js";
+import {
+  DateRangeDomain,
+  Domain,
+  NumericRangeDomain,
+} from "../../value/domain.js";
 import { SqDateScale, SqLinearScale } from "./SqScale.js";
 
 export function wrapDomain(value: Domain) {
@@ -15,16 +20,14 @@ export function wrapDomain(value: Domain) {
 // Domain internals are not exposed yet
 abstract class SqAbstractDomain<T extends Domain["type"]> {
   abstract tag: T;
-
-  constructor(public _value: Domain) {}
-
-  toString() {
-    return this._value.toString();
-  }
 }
 
 class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
   tag = "NumericRange" as const;
+
+  constructor(public _value: NumericRangeDomain) {
+    super();
+  }
 
   get min() {
     return this._value.min;
@@ -45,6 +48,10 @@ class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
 class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
   tag = "DateRange" as const;
 
+  constructor(public _value: DateRangeDomain) {
+    super();
+  }
+
   get min() {
     return this._value.min;
   }
@@ -56,8 +63,8 @@ class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
   toScale({ min, max }: { min?: number; max?: number }) {
     return new SqDateScale({
       type: "date",
-      min: min ? Math.max(min, this.min) : this.min,
-      max: max ? Math.min(max, this.max) : this.max,
+      min: min ? Math.max(min, dateToMs(this.min)) : dateToMs(this.min),
+      max: max ? Math.min(max, dateToMs(this.max)) : dateToMs(this.max),
     });
   }
 }

--- a/packages/squiggle-lang/src/public/SqValue/SqDomain.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqDomain.ts
@@ -5,6 +5,7 @@ import {
   NumericRangeDomain,
 } from "../../value/domain.js";
 import { SqDateScale, SqLinearScale } from "./SqScale.js";
+import { SqDateValue, SqNumberValue } from "./index.js";
 
 export function wrapDomain(value: Domain) {
   switch (value.type) {
@@ -22,11 +23,16 @@ abstract class SqAbstractDomain<T extends Domain["type"]> {
   abstract tag: T;
 }
 
-class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
+export class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
   tag = "NumericRange" as const;
 
   constructor(public _value: NumericRangeDomain) {
     super();
+  }
+
+  //A simple alternative to making a Domain object and pass that in.
+  static fromMinMax(min: number, max: number) {
+    return new this(new NumericRangeDomain(min, max));
   }
 
   get min() {
@@ -37,6 +43,14 @@ class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
     return this._value.max;
   }
 
+  get minValue() {
+    return SqNumberValue.create(this._value.min);
+  }
+
+  get maxValue() {
+    return SqNumberValue.create(this._value.max);
+  }
+
   toDefaultScale() {
     return new SqLinearScale({
       type: "linear",
@@ -45,7 +59,7 @@ class SqNumericRangeDomain extends SqAbstractDomain<"NumericRange"> {
     });
   }
 }
-class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
+export class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
   tag = "DateRange" as const;
 
   constructor(public _value: DateRangeDomain) {
@@ -58,6 +72,14 @@ class SqDateRangeDomain extends SqAbstractDomain<"DateRange"> {
 
   get max() {
     return this._value.max;
+  }
+
+  get minValue() {
+    return SqDateValue.create(this._value.min);
+  }
+
+  get maxValue() {
+    return SqDateValue.create(this._value.max);
   }
 
   toDefaultScale() {

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -118,7 +118,7 @@ export class SqDateScale extends SqAbstractScale<"date"> {
     return new SqDateScale({ type: "date", ...args });
   }
 
-  override numberToValue(v: number) {
+  override numberToValue(v: number): SqValue {
     return SqDateValue.create(dateFromMs(v));
   }
 }

--- a/packages/squiggle-lang/src/public/SqValue/SqScale.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqScale.ts
@@ -118,7 +118,7 @@ export class SqDateScale extends SqAbstractScale<"date"> {
     return new SqDateScale({ type: "date", ...args });
   }
 
-  override numberToValue(v: number): SqValue {
+  override numberToValue(v: number) {
     return SqDateValue.create(dateFromMs(v));
   }
 }

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -2,7 +2,7 @@ import { LocationRange } from "peggy";
 
 import { ASTNode } from "../ast/parse.js";
 import * as IError from "../errors/IError.js";
-import { REArityError, REDomainError, REOther } from "../errors/messages.js";
+import { REArityError, REOther } from "../errors/messages.js";
 import { Expression } from "../expression/index.js";
 import { VDomain, Value } from "../value/index.js";
 import * as Context from "./context.js";

--- a/packages/squiggle-lang/src/utility/DateTime.ts
+++ b/packages/squiggle-lang/src/utility/DateTime.ts
@@ -92,7 +92,6 @@ export function dateFromMsToString(ms: number): string {
 }
 
 export const date = {
-  //   //The Rescript/JS implementation of Date is pretty mediocre. It would be good to improve upon later.
   fmap(t: Date, fn: (v: number) => number): Date {
     return dateFromMs(fn(dateToMs(t)));
   },

--- a/packages/squiggle-lang/src/value/domain.ts
+++ b/packages/squiggle-lang/src/value/domain.ts
@@ -1,5 +1,5 @@
 import { REArgumentError, REDomainError } from "../errors/messages.js";
-import { dateFromMsToString, dateToMs } from "../utility/DateTime.js";
+import { dateToMs, dateToString } from "../utility/DateTime.js";
 import { Value } from "./index.js";
 
 abstract class BaseDomain {
@@ -9,6 +9,9 @@ abstract class BaseDomain {
   abstract toString(): string;
 
   abstract validateValue(value: Value): void;
+
+  abstract get minAsNumber(): number;
+  abstract get maxAsNumber(): number;
 }
 
 export class NumericRangeDomain extends BaseDomain {
@@ -40,41 +43,56 @@ export class NumericRangeDomain extends BaseDomain {
   isEqual(other: NumericRangeDomain) {
     return this.min === other.min && this.max === other.max;
   }
+
+  get minAsNumber() {
+    return this.min;
+  }
+
+  get maxAsNumber() {
+    return this.max;
+  }
 }
+
 export class DateRangeDomain extends BaseDomain {
   readonly type = "DateRange";
   readonly valueType = "Date";
-  public min;
-  public max;
 
-  constructor(_min: Date, _max: Date) {
+  constructor(
+    public min: Date,
+    public max: Date
+  ) {
     super();
-    this.min = dateToMs(_min);
-    this.max = dateToMs(_max);
   }
 
   toString() {
-    return `Date.rangeDomain({ min: ${dateFromMsToString(
+    return `Date.rangeDomain({ min: ${dateToString(
       this.min
-    )}, max: ${dateFromMsToString(this.max)} })`;
+    )}, max: ${dateToString(this.max)} })`;
   }
 
   validateValue(value: Value) {
     if (value.type !== "Date") {
       throw new REDomainError(`Value of type ${value.type} must be a date`);
     }
-    const valueTime = dateToMs(value.value);
-    if (valueTime < this.min || valueTime > this.max) {
+    if (value.value < this.min || value.value > this.max) {
       throw new REDomainError(
-        `Value ${value} must be within ${dateFromMsToString(
+        `Value ${value} must be within ${dateToString(
           this.min
-        )} and ${dateFromMsToString(this.max)}`
+        )} and ${dateToString(this.max)}`
       );
     }
   }
 
   isEqual(other: DateRangeDomain) {
     return this.min === other.min && this.max === other.max;
+  }
+
+  get minAsNumber() {
+    return dateToMs(this.min);
+  }
+
+  get maxAsNumber() {
+    return dateToMs(this.max);
   }
 }
 

--- a/packages/squiggle-lang/src/value/domain.ts
+++ b/packages/squiggle-lang/src/value/domain.ts
@@ -1,6 +1,7 @@
 import { REArgumentError, REDomainError } from "../errors/messages.js";
 import { dateToMs, dateToString } from "../utility/DateTime.js";
 import { Value } from "./index.js";
+import { Scale } from "./index.js";
 
 abstract class BaseDomain {
   abstract type: string;
@@ -51,6 +52,14 @@ export class NumericRangeDomain extends BaseDomain {
   get maxAsNumber() {
     return this.max;
   }
+
+  toDefaultScale(): Scale {
+    return {
+      type: "linear",
+      min: this.min,
+      max: this.max,
+    };
+  }
 }
 
 export class DateRangeDomain extends BaseDomain {
@@ -93,6 +102,14 @@ export class DateRangeDomain extends BaseDomain {
 
   get maxAsNumber() {
     return dateToMs(this.max);
+  }
+
+  toDefaultScale(): Scale {
+    return {
+      type: "date",
+      min: dateToMs(this.min),
+      max: dateToMs(this.max),
+    };
   }
 }
 

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -625,10 +625,9 @@ export class VDomain extends BaseValue implements Indexable {
   }
 
   get(key: Value): VNumber | VDate {
-    const mapValue = (value: number) =>
-      this.domainType === "DateRange"
-        ? vDate(dateFromMs(value))
-        : vNumber(value);
+    const mapValue = (value: number | Date) =>
+      typeof value === "number" ? vNumber(value) : vDate(value);
+
     if (key.type === "String") {
       if (key.value === "min") {
         return mapValue(this.value.min);

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -6,12 +6,7 @@ import {
   REOther,
 } from "../errors/messages.js";
 import { Lambda } from "../reducer/lambda.js";
-import {
-  date,
-  dateFromMs,
-  dateToString,
-  duration,
-} from "../utility/DateTime.js";
+import { dateToString, duration } from "../utility/DateTime.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { DateRangeDomain, Domain, NumericRangeDomain } from "./domain.js";
 import { shuffle } from "../utility/E_A.js";


### PR DESCRIPTION
A simple add-on to https://github.com/quantified-uncertainty/squiggle/pull/2572, that uses Dates inside Date Domains (both Domain and SqDomain). 

It would be neat to do this for the Date Scale too, but that would be much more work. 