### PR TITLE
Tooltips on stdlib functions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -61,6 +61,7 @@
     "@types/lodash": "^4.14.200",
     "@types/node": "^20.8.10",
     "@types/react": "^18.2.34",
+    "@types/react-dom": "^18.2.14",
     "@types/react-resizable": "^3.0.6",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",

--- a/packages/components/src/components/CodeEditor/useSquiggleEditorView.ts
+++ b/packages/components/src/components/CodeEditor/useSquiggleEditorView.ts
@@ -42,6 +42,7 @@ import { useSquiggleLanguageExtension } from "./useSquiggleLanguageExtension.js"
 import { useSubmitExtension } from "./useSubmitExtension.js";
 import { useViewNodeExtension } from "./useViewNodeExtension.js";
 import { useWidthHeightExtension } from "./useWidthHeightExtension.js";
+import { useTooltipsExtension } from "./useTooltipsExtension.js";
 
 export function useSquiggleEditorExtensions(
   view: EditorView | undefined,
@@ -109,6 +110,8 @@ export function useSquiggleEditorExtensions(
   const formatExtension = useFormatSquiggleExtension();
   const errorsExtension = useErrorsExtension(view, params.errors);
 
+  const tooltipsExtension = useTooltipsExtension();
+
   const squiggleExtensions = [
     squiggleLanguageExtension,
     showGutterExtension,
@@ -119,6 +122,7 @@ export function useSquiggleEditorExtensions(
     viewNodeExtension,
     formatExtension,
     errorsExtension,
+    tooltipsExtension,
   ];
 
   return [builtinExtensions, squiggleExtensions];

--- a/packages/components/src/components/CodeEditor/useTooltipsExtension.tsx
+++ b/packages/components/src/components/CodeEditor/useTooltipsExtension.tsx
@@ -1,0 +1,95 @@
+import { EditorView, hoverTooltip, repositionTooltips } from "@codemirror/view";
+import { clsx } from "clsx";
+import { FC, PropsWithChildren, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+
+import { getFunctionDocumentation } from "@quri/squiggle-lang";
+
+type Hover = NonNullable<ReturnType<typeof getFunctionDocumentation>>;
+
+const TooltipSection: FC<PropsWithChildren<{ last?: boolean }>> = ({
+  children,
+  last,
+}) => <div className={clsx("px-4 py-2", last || "border-b")}>{children}</div>;
+
+const HoverTooltip: FC<{ hover: Hover; view: EditorView }> = ({
+  hover,
+  view,
+}) => {
+  useEffect(() => {
+    // https://codemirror.net/docs/ref/#view.repositionTooltips need to be called on each render.
+    repositionTooltips(view);
+  });
+
+  const fullName = `${hover.nameSpace}.${hover.name}`;
+
+  return (
+    <div className="border bg-slate-50 rounded-sm shadow-lg min-w-[200px]">
+      <TooltipSection>
+        <a
+          // TODO - move domain to constants
+          href={`https://www.squiggle-language.com/docs/Api/${hover.nameSpace}#${hover.name}`}
+          className="text-blue-500 hover:underline text-sm"
+        >
+          {fullName}
+        </a>
+      </TooltipSection>
+      {hover.description ? (
+        <TooltipSection>{hover.description}</TooltipSection>
+      ) : null}
+      {hover.examples?.length ? (
+        <TooltipSection>
+          <header className="text-sm text-slate-600 font-medium mb-1">
+            Examples
+          </header>
+          {hover.examples.map((example, i) => (
+            <div className="text-xs text-slate-800" key={i}>
+              {example}
+            </div>
+          ))}
+        </TooltipSection>
+      ) : null}
+    </div>
+  );
+};
+
+// Based on https://codemirror.net/examples/tooltip/#hover-tooltips
+// See also: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
+const wordHover = hoverTooltip((view, pos, side) => {
+  const { doc } = view.state;
+  const { from, to, text } = doc.lineAt(pos);
+  let start = pos,
+    end = pos;
+  while (start > from && /[\w.]/.test(text[start - from - 1])) start--;
+  while (end < to && /[\w.]/.test(text[end - from])) end++;
+  if ((start === pos && side < 0) || (end === pos && side > 0)) return null;
+
+  const token = text.slice(start - from, end - from);
+  const hover = getFunctionDocumentation(token);
+  if (!hover) {
+    return null;
+  }
+
+  return {
+    pos: start,
+    end,
+    above: true,
+    create() {
+      const dom = document.createElement("div");
+      const root = createRoot(dom);
+      root.render(<HoverTooltip hover={hover} view={view} />);
+      return { dom };
+    },
+  };
+});
+
+const tooltipTheme = EditorView.baseTheme({
+  ".cm-tooltip-hover": {
+    backgroundColor: "white !important",
+    border: "0 !important",
+  },
+});
+
+export function useTooltipsExtension() {
+  return [wordHover, tooltipTheme];
+}

--- a/packages/components/src/components/CodeEditor/useViewNodeExtension.ts
+++ b/packages/components/src/components/CodeEditor/useViewNodeExtension.ts
@@ -1,6 +1,8 @@
 import { EditorView, keymap } from "@codemirror/view";
 import { useCallback } from "react";
+
 import { SqProject, SqValuePath } from "@quri/squiggle-lang";
+
 import { useReactiveExtension } from "./codemirrorHooks.js";
 
 export function useViewNodeExtension(

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -1,4 +1,5 @@
 import { type Env } from "./dist/env.js";
+import { registry } from "./library/registry/index.js";
 import { SqProject } from "./public/SqProject/index.js";
 export {
   type SqInput,
@@ -95,4 +96,8 @@ export function sq(strings: TemplateStringsArray, ...rest: unknown[]) {
     throw new Error("Extrapolation in sq`` template literals is forbidden");
   }
   return strings.join("");
+}
+
+export function getFunctionDocumentation(name: string) {
+  return registry.getFunctionDocumentation(name);
 }

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -15,6 +15,11 @@ export type FRFunction = {
 
 type FnNameDict = Map<string, FnDefinition[]>;
 
+type FnDocumentation = Pick<
+  FRFunction,
+  "description" | "requiresNamespace" | "nameSpace" | "name" | "examples"
+>;
+
 export class Registry {
   private constructor(
     private functions: FRFunction[],
@@ -60,6 +65,30 @@ export class Registry {
 
   allNames(): string[] {
     return [...this.fnNameDict.keys()];
+  }
+
+  getFunctionDocumentation(fnName: string): FnDocumentation | undefined {
+    // Find the first function with a given name; there could be duplicates with different descriptions etc.
+    // FIXME - store `this.functions` as a `Map`.
+    const fn = this.functions.find((fn) => {
+      // FIXME - duplicates the logic from `make`
+      if (!fn.requiresNamespace && fnName === fn.name) {
+        return true;
+      }
+      if (`${fn.nameSpace}.${fn.name}` === fnName) {
+        return true;
+      }
+    });
+
+    if (!fn) return;
+
+    return {
+      name: fn.name,
+      nameSpace: fn.nameSpace,
+      requiresNamespace: fn.requiresNamespace,
+      description: fn.description,
+      examples: fn.examples,
+    };
   }
 
   makeLambda(fnName: string): Lambda {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       '@types/react':
         specifier: ^18.2.34
         version: 18.2.34
+      '@types/react-dom':
+        specifier: ^18.2.14
+        version: 18.2.14
       '@types/react-resizable':
         specifier: ^3.0.6
         version: 3.0.6


### PR DESCRIPTION
To improve:
- links to docs are generated so they're not always working
- description is rendered as a plain string, and we don't have many function descriptions in fr/* code yet
- it'd be useful to expose signatures, based on frTypes, maybe `getFunctionDocumentation` should expose `SqLambda`