### PR TITLE
Boxed values - proof of concept

### DIFF
--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -257,3 +257,10 @@ Calculator.make(
     height: 800,
   },
 };
+
+export const Boxed: Story = {
+  name: "Boxed values",
+  args: {
+    defaultCode: `x = named(5, "X variable")`,
+  },
+};

--- a/packages/components/src/widgets/BoxedWidget.tsx
+++ b/packages/components/src/widgets/BoxedWidget.tsx
@@ -1,0 +1,19 @@
+import { SquiggleValueChart } from "../components/SquiggleViewer/SquiggleValueChart.js";
+import { valueHasContext } from "../lib/utility.js";
+import { widgetRegistry } from "./registry.js";
+
+widgetRegistry.register("Boxed", {
+  Chart: (value, settings) => {
+    const unboxedValue = value.value;
+    if (valueHasContext(unboxedValue)) {
+      return (
+        <div>
+          <div className="text-sm text-slate-600 ml-1.5">{value.title()}</div>
+          <SquiggleValueChart value={unboxedValue} settings={settings} />
+        </div>
+      );
+    } else {
+      return unboxedValue.toString();
+    }
+  },
+});

--- a/packages/components/src/widgets/index.ts
+++ b/packages/components/src/widgets/index.ts
@@ -10,3 +10,4 @@ import "./PlotWidget/index.js";
 import "./StringWidget.js";
 import "./TableChartWidget.js";
 import "./DurationWidget.js";
+import "./BoxedWidget.js";

--- a/packages/squiggle-lang/src/fr/builtin.ts
+++ b/packages/squiggle-lang/src/fr/builtin.ts
@@ -10,7 +10,7 @@ import {
   FnFactory,
   makeNumericComparisons,
 } from "../library/registry/helpers.js";
-import { vArray, vBool, vString, isEqual } from "../value/index.js";
+import { vArray, vBool, vString, isEqual, vBoxed } from "../value/index.js";
 
 const maker = new FnFactory({
   nameSpace: "", // no namespaced versions
@@ -90,6 +90,14 @@ export const library = [
     definitions: [
       makeDefinition([frAny], ([v]) => {
         return vString(v.publicName);
+      }),
+    ],
+  }),
+  maker.make({
+    name: "named",
+    definitions: [
+      makeDefinition([frAny, frString], ([v, name]) => {
+        return vBoxed(v, name);
       }),
     ],
   }),

--- a/packages/squiggle-lang/src/library/registry/fnDefinition.ts
+++ b/packages/squiggle-lang/src/library/registry/fnDefinition.ts
@@ -33,7 +33,11 @@ export function tryCallFnDefinition(
   }
   const unpackedArgs: any = []; // any, but that's ok, type safety is guaranteed by FnDefinition type
   for (let i = 0; i < args.length; i++) {
-    const unpackedArg = fn.inputs[i].unpack(args[i]);
+    let arg = args[i];
+    if (arg.type === "Boxed") {
+      arg = arg.value;
+    }
+    const unpackedArg = fn.inputs[i].unpack(arg);
     if (unpackedArg === undefined) {
       // type mismatch
       return;

--- a/packages/squiggle-lang/src/public/SqValue/index.ts
+++ b/packages/squiggle-lang/src/public/SqValue/index.ts
@@ -48,6 +48,8 @@ export function wrapValue(value: Value, context?: SqValueContext) {
       return new SqDomainValue(value, context);
     case "Input":
       return new SqInputValue(value, context);
+    case "Boxed":
+      return new SqBoxedValue(value, context);
     default:
       throw new Error(`Unknown value ${JSON.stringify(value satisfies never)}`);
   }
@@ -305,6 +307,22 @@ export class SqDomainValue extends SqAbstractValue<"Domain", SqDomain> {
 
   asJS() {
     return this.value;
+  }
+}
+
+export class SqBoxedValue extends SqAbstractValue<"Boxed", unknown> {
+  tag = "Boxed" as const;
+
+  get value() {
+    return wrapValue(this._value.value, this.context);
+  }
+
+  override title() {
+    return this._value.name;
+  }
+
+  asJS(): unknown {
+    return this.value.asJS();
   }
 }
 

--- a/packages/squiggle-lang/src/value/index.ts
+++ b/packages/squiggle-lang/src/value/index.ts
@@ -657,6 +657,23 @@ class VVoid extends BaseValue {
 }
 export const vVoid = () => new VVoid();
 
+class VBoxed extends BaseValue {
+  readonly type = "Boxed";
+  readonly publicName = "Boxed";
+
+  constructor(
+    public value: Value,
+    public name: string
+  ) {
+    super();
+  }
+
+  toString(): string {
+    return `${this.name}: ${this.value.toString()}`;
+  }
+}
+export const vBoxed = (value: Value, name: string) => new VBoxed(value, name);
+
 export type Value =
   | VArray
   | VBool
@@ -673,7 +690,8 @@ export type Value =
   | VScale
   | VInput
   | VDomain
-  | VVoid;
+  | VVoid
+  | VBoxed;
 
 export function isEqual(a: Value, b: Value): boolean {
   if (a.type !== b.type) {


### PR DESCRIPTION
`VBoxed` + `BoxedWidget` that renders `value.title()` + the underlying value.

Boxed values are created with `named(value, name)` builtin, so to give a variable a title, we can do `export foo = named(5, "Foo variable")`.

Values are unpacked very early, in `tryCallFnDefinition`. So all standard function calls are transparent.

Things to consider before we proceed with this:
1. Slight performance overhead; I can't think of a way to have overhead only on boxed values, all function definitions expect an unboxed value, so we have to check for `value.type === 'Boxed'` somewhere
  - benchmarks are imprecise but my impression is that this feature will cost us 3-4% on synthetic bench-map
2. Since values are unpacked early, it's not possible to access a name from a function (not possible to implement `getName(boxedVar)`. There are several ways to fix this: a "raw" flag on `FnDefinition`; or expose it through a pseudo-method with an impossible name, `boxedVar.@name`, as we discussed.
3. Assignment semantics: right now `y = boxedX` (or `y = ((((boxedX))))` is still boxed, but `z = boxedX + 1` is not.
  - I'd be more comfortable with unboxing even on assignment as a starting point, until we figure out what we really want to do here, because otherwise we're exposing accidental implementation details (e.g. that `+` is an operator while `()` is evaluated directly by the interpreter).