### PR TITLE
Adds Calculator.make(fn) call

### DIFF
--- a/.changeset/eleven-snakes-deliver.md
+++ b/.changeset/eleven-snakes-deliver.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Added Calculator.make(fn) shorthand

--- a/packages/squiggle-lang/src/fr/calculator.ts
+++ b/packages/squiggle-lang/src/fr/calculator.ts
@@ -10,12 +10,22 @@ import {
   frNumber,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
-import { vCalculator } from "../value/index.js";
+import { Calculator, Value, vCalculator } from "../value/index.js";
 
 const maker = new FnFactory({
   nameSpace: "Calculator",
   requiresNamespace: true,
 });
+
+const processCalc = (calc: Calculator): Value => {
+  const _calc = vCalculator(calc);
+  const error = _calc.getError();
+  if (error) {
+    throw error;
+  } else {
+    return _calc;
+  }
+};
 
 export const library = [
   maker.make({
@@ -34,23 +44,17 @@ export const library = [
             ["sampleCount", frOptional(frNumber)]
           ),
         ],
-        ([{ fn, title, description, inputs, autorun, sampleCount }]) => {
-          const calc = vCalculator({
+        ([{ fn, title, description, inputs, autorun, sampleCount }]) =>
+          processCalc({
             fn,
             title: title || undefined,
             description: description || undefined,
             inputs: inputs || [],
             autorun: autorun === null ? true : autorun,
             sampleCount: sampleCount || undefined,
-          });
-          const error = calc.getError();
-          if (error) {
-            throw error;
-          } else {
-            return calc;
-          }
-        }
+          })
       ),
+      makeDefinition([frLambda], ([fn]) => processCalc(fn.toCalculator())),
     ],
   }),
 ];

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -221,7 +221,6 @@ export class BuiltinLambda extends BaseLambda {
         name: `Input ${i + 1}`,
         type: sig.getName() === "Bool" ? "checkbox" : "text",
       })),
-      sampleCount: 10000,
       autorun,
     };
   }

--- a/packages/website/src/pages/docs/Api/Calculator.mdx
+++ b/packages/website/src/pages/docs/Api/Calculator.mdx
@@ -21,6 +21,7 @@ Calculator.make: ({
   autorun?: boolean = true,
   sampleCount?: number,
 }) => calculator
+Calculator.make(fn: ...arguments => any) => calculator
 ```
 
 ``Calculator.make`` takes in a function, a description, and a list of fields. The function should take in the same number of arguments as the number of fields, and the arguments should be of the same type as the default value of the field.


### PR DESCRIPTION
A quick way to turn functions into calculators, for testing. Will be more useful with Tags, soon. 