### PR TITLE
Def improvements: frNaming, show builtIn documentation on function viewing

### DIFF
--- a/packages/components/src/components/ui/FnDocumentation.tsx
+++ b/packages/components/src/components/ui/FnDocumentation.tsx
@@ -16,6 +16,7 @@ export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
   const {
     name,
     nameSpace,
+    requiresNamespace,
     isUnit,
     shorthand,
     isExperimental,
@@ -43,7 +44,7 @@ export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
           </div>
         </div>
       </Section>
-      {(isUnit || shorthand || isExperimental) && (
+      {(isUnit || shorthand || isExperimental || !requiresNamespace) && (
         <Section>
           <div className="flex">
             {isUnit && (
@@ -62,6 +63,11 @@ export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
             {isExperimental && (
               <div className={clsx("bg-red-100 text-red-800", tagCss)}>
                 Experimental
+              </div>
+            )}
+            {!requiresNamespace && (
+              <div className={clsx("bg-purple-100 text-slate-800", tagCss)}>
+                {`Namespace optional`}
               </div>
             )}
           </div>

--- a/packages/components/src/components/ui/FnDocumentation.tsx
+++ b/packages/components/src/components/ui/FnDocumentation.tsx
@@ -2,13 +2,51 @@ import { clsx } from "clsx";
 import React, { FC, PropsWithChildren } from "react";
 import ReactMarkdown from "react-markdown";
 
-import { type FnDocumentation as FnDocumentationType } from "@quri/squiggle-lang";
+import {
+  FnDefinition,
+  type FnDocumentation as FnDocumentationType,
+} from "@quri/squiggle-lang";
 
 import { SQUIGGLE_DOCS_URL } from "../../lib/constants.js";
 
 const Section: FC<PropsWithChildren> = ({ children }) => (
   <div className={clsx("px-4 py-2")}>{children}</div>
 );
+
+const StyleDefinition: FC<{ fullName: string; def: FnDefinition }> = ({
+  fullName,
+  def,
+}) => {
+  const isOptional = (t) => (t.isOptional === undefined ? false : t.isOptional);
+  const annotation = "text-slate-400";
+  const primary = "text-slate-900";
+  const inputs = def.inputs.map((t, index) => (
+    <span key={index}>
+      <span className={primary}>{t.getName()}</span>
+      {isOptional(t) ? <span className={primary}>?</span> : ""}
+      {index !== def.inputs.length - 1 && (
+        <span className={annotation}>, </span>
+      )}
+    </span>
+  ));
+  const output = def.output.getName();
+  return (
+    <div>
+      <span className="text-slate-500">{fullName}</span>
+      <span className={annotation}>(</span>
+      <span className={clsx(primary, "ml-0.5 mr-0.5")}>{inputs}</span>
+      <span className={annotation}>)</span>
+      {output ? (
+        <>
+          <span className={annotation}>{" => "}</span>{" "}
+          <span className={primary}>{output}</span>
+        </>
+      ) : (
+        ""
+      )}
+    </div>
+  );
+};
 
 export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
   documentation,
@@ -21,7 +59,7 @@ export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
     shorthand,
     isExperimental,
     description,
-    signatures,
+    definitions,
     examples,
   } = documentation;
   const fullName = `${nameSpace ? nameSpace + "." : ""}${name}`;
@@ -81,16 +119,14 @@ export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
           </ReactMarkdown>
         </Section>
       ) : null}
-      {signatures.length ? (
+      {definitions ? (
         <Section>
           <header className="text-xs text-slate-600 font-medium mb-2">
             Signatures
           </header>
-          <div className="text-xs text-slate-600 font-mono p-2 bg-slate-100 rounded-md">
-            {signatures.map((sig, i) => (
-              <div className="pb-1" key={i}>
-                {fullName + sig}
-              </div>
+          <div className="text-xs text-slate-600 font-mono p-2 bg-slate-100 rounded-md space-y-2">
+            {definitions.map((def, id) => (
+              <StyleDefinition fullName={fullName} def={def} key={id} />
             ))}
           </div>
         </Section>

--- a/packages/components/src/components/ui/FnDocumentation.tsx
+++ b/packages/components/src/components/ui/FnDocumentation.tsx
@@ -19,14 +19,14 @@ const StyleDefinition: FC<{ fullName: string; def: FnDefinition }> = ({
   def,
 }) => {
   const isOptional = (t) => (t.isOptional === undefined ? false : t.isOptional);
-  const annotation = "text-slate-400";
-  const primary = "text-slate-900";
+  const primaryColor = "text-slate-900";
+  const secondaryColor = "text-slate-400";
   const inputs = def.inputs.map((t, index) => (
     <span key={index}>
-      <span className={primary}>{t.getName()}</span>
-      {isOptional(t) ? <span className={primary}>?</span> : ""}
+      <span className={primaryColor}>{t.getName()}</span>
+      {isOptional(t) ? <span className={primaryColor}>?</span> : ""}
       {index !== def.inputs.length - 1 && (
-        <span className={annotation}>, </span>
+        <span className={secondaryColor}>, </span>
       )}
     </span>
   ));
@@ -34,13 +34,13 @@ const StyleDefinition: FC<{ fullName: string; def: FnDefinition }> = ({
   return (
     <div>
       <span className="text-slate-500">{fullName}</span>
-      <span className={annotation}>(</span>
-      <span className={clsx(primary, "ml-0.5 mr-0.5")}>{inputs}</span>
-      <span className={annotation}>)</span>
+      <span className={secondaryColor}>(</span>
+      <span className={clsx(primaryColor, "ml-0.5 mr-0.5")}>{inputs}</span>
+      <span className={secondaryColor}>)</span>
       {output ? (
         <>
-          <span className={annotation}>{" => "}</span>{" "}
-          <span className={primary}>{output}</span>
+          <span className={secondaryColor}>{" => "}</span>{" "}
+          <span className={primaryColor}>{output}</span>
         </>
       ) : (
         ""

--- a/packages/components/src/components/ui/FnDocumentation.tsx
+++ b/packages/components/src/components/ui/FnDocumentation.tsx
@@ -13,6 +13,7 @@ const Section: FC<PropsWithChildren> = ({ children }) => (
   <div className={clsx("px-4 py-2")}>{children}</div>
 );
 
+//I'm not sure if this is worth it here. Much of the input data is hidden from us at this point. It might be better to just go back to strings, or to formally parse it after having it as a string.
 const StyleDefinition: FC<{ fullName: string; def: FnDefinition }> = ({
   fullName,
   def,

--- a/packages/components/src/components/ui/FnDocumentation.tsx
+++ b/packages/components/src/components/ui/FnDocumentation.tsx
@@ -32,6 +32,8 @@ export const FnDocumentation: FC<{ documentation: FnDocumentationType }> = ({
         <div className="flex flex-nowrap items-end justify-between gap-2 py-0.5">
           <a
             href={`${SQUIGGLE_DOCS_URL}/${nameSpace}#${name}`}
+            target="_blank"
+            rel="noreferrer"
             className="text-blue-500 hover:underline text-sm leading-none"
           >
             {fullName}

--- a/packages/components/src/stories/FnDocumentation.stories.tsx
+++ b/packages/components/src/stories/FnDocumentation.stories.tsx
@@ -47,6 +47,7 @@ const documentation: FnDocumentationType = {
   signatures: ["(number, number) => number"],
   examples: ["add(5,2)"],
   isExperimental: true,
+  definitions: [],
   isUnit: true,
   shorthand: { type: "unary", symbol: "-" },
   description: `**Lorem Ipsum**

--- a/packages/components/src/widgets/LambdaWidget/index.tsx
+++ b/packages/components/src/widgets/LambdaWidget/index.tsx
@@ -1,4 +1,7 @@
+import { getFunctionDocumentation } from "@quri/squiggle-lang";
+
 import { ItemSettingsMenuItems } from "../../components/SquiggleViewer/ItemSettingsMenuItems.js";
+import { FnDocumentation } from "../../components/ui/FnDocumentation.js";
 import { widgetRegistry } from "../registry.js";
 import { truncateStr } from "../utils.js";
 import { AutomaticFunctionChart } from "./FunctionChart/AutomaticFunctionChart.js";
@@ -18,6 +21,14 @@ widgetRegistry.register("Lambda", {
   },
   Chart: (value, settings) => {
     const environment = value.context.project.getEnvironment();
+    //It's kind of awkward that the documentation isn't connected to the function itself, but that's a greater effort.
+    if (value.value.type === "BuiltinLambda") {
+      const name = value.value._value.getName();
+      const documentation = getFunctionDocumentation(name);
+      if (documentation) {
+        return <FnDocumentation documentation={documentation} />;
+      }
+    }
     return (
       <AutomaticFunctionChart
         fn={value.value}

--- a/packages/squiggle-lang/__tests__/library/plot_test.ts
+++ b/packages/squiggle-lang/__tests__/library/plot_test.ts
@@ -115,7 +115,7 @@ Was given arguments: ((x,y) => internal code)`
     testEvalToMatch(
       `Plot.distFn({|x,y| x to x + y})`,
       `Error(Error: There are function matches for Plot.distFn(), but with different arguments:
-  Plot.distFn(fn: (number) => distribution, params?: {xScale?: scale, yScale?: scale, distXScale?: scale, title?: string, points?: number}) => plot
+  Plot.distFn(fn: (number) => dist, params?: {xScale?: scale, yScale?: scale, distXScale?: scale, title?: string, points?: number}) => plot
 Was given arguments: ((x,y) => internal code)`
     );
   });

--- a/packages/squiggle-lang/__tests__/reducer/various_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/various_test.ts
@@ -133,9 +133,9 @@ describe("stacktraces", () => {
   add(date, duration) => date
   add(duration, date) => date
   add(duration, duration) => duration
-  add(distribution, number) => distribution
-  add(number, distribution) => distribution
-  add(distribution, distribution) => distribution
+  add(dist, number) => dist
+  add(number, dist) => dist
+  add(dist, dist) => dist
 Was given arguments: (5,"a")
 Stack trace:
   f at line 4, column 5, file main

--- a/packages/squiggle-lang/src/fr/builtin.ts
+++ b/packages/squiggle-lang/src/fr/builtin.ts
@@ -4,6 +4,7 @@ import {
   frArray,
   frBool,
   frGeneric,
+  frNamed,
   frNumber,
   frOptional,
   frString,
@@ -103,7 +104,7 @@ export const library = [
     name: "inspect",
     definitions: [
       makeDefinition(
-        [frGeneric("A"), frOptional(frString)],
+        [frGeneric("A"), frNamed("message", frOptional(frString))],
         frGeneric("A"),
         ([value, message]) => {
           message ? console.log(message, value) : console.log(value);

--- a/packages/squiggle-lang/src/fr/danger.ts
+++ b/packages/squiggle-lang/src/fr/danger.ts
@@ -436,14 +436,21 @@ const mapYLibrary: FRFunction[] = [
     name: "binomialDist",
     examples: ["Danger.binomialDist(8, 0.5)"],
     definitions: [
-      makeTwoArgsSamplesetDist((n, p) => SymbolicDist.Binomial.make(n, p)),
+      makeTwoArgsSamplesetDist(
+        (n, p) => SymbolicDist.Binomial.make(n, p),
+        "numberOfTrials",
+        "probabilityOfSuccess"
+      ),
     ],
   }),
   maker.make({
     name: "poissonDist",
     examples: ["Danger.poissonDist(10)"],
     definitions: [
-      makeOneArgSamplesetDist((lambda) => SymbolicDist.Poisson.make(lambda)),
+      makeOneArgSamplesetDist(
+        (lambda) => SymbolicDist.Poisson.make(lambda),
+        "rate"
+      ),
     ],
   }),
 ];

--- a/packages/squiggle-lang/src/fr/date.ts
+++ b/packages/squiggle-lang/src/fr/date.ts
@@ -5,6 +5,7 @@ import {
   frDict,
   frDomain,
   frDuration,
+  frNamed,
   frNumber,
   frString,
 } from "../library/registry/frTypes.js";
@@ -51,7 +52,11 @@ export const library = [
       }),
 
       makeDefinition(
-        [frNumber, frNumber, frNumber],
+        [
+          frNamed("year", frNumber),
+          frNamed("month", frNumber),
+          frNamed("day", frNumber),
+        ],
         frDate,
         ([yr, month, date]) => {
           return SDate.fromYearMonthDay(yr, month, date);

--- a/packages/squiggle-lang/src/fr/dict.ts
+++ b/packages/squiggle-lang/src/fr/dict.ts
@@ -9,6 +9,7 @@ import {
   frDictWithArbitraryKeys,
   frGeneric,
   frLambdaTyped,
+  frNamed,
   frNumber,
   frString,
   frTuple,
@@ -29,7 +30,11 @@ export const library = [
     examples: [`Dict.set({a: 1, b: 2}, "c", 3)`],
     definitions: [
       makeDefinition(
-        [frDictWithArbitraryKeys(frGeneric("A")), frString, frGeneric("A")],
+        [
+          frDictWithArbitraryKeys(frGeneric("A")),
+          frNamed("key", frString),
+          frNamed("value", frGeneric("A")),
+        ],
         frDictWithArbitraryKeys(frGeneric("A")),
         ([dict, key, value]) => dict.set(key, value)
       ),
@@ -41,7 +46,7 @@ export const library = [
     examples: [`Dict.has({a: 1, b: 2}, "c")`],
     definitions: [
       makeDefinition(
-        [frDictWithArbitraryKeys(frAny), frString],
+        [frDictWithArbitraryKeys(frAny), frNamed("key", frString)],
         frBool,
         ([dict, key]) => dict.has(key)
       ),
@@ -65,7 +70,7 @@ export const library = [
     examples: [`Dict.delete({a: 1, b: 2}, "a")`],
     definitions: [
       makeDefinition(
-        [frDictWithArbitraryKeys(frGeneric("A")), frString],
+        [frDictWithArbitraryKeys(frGeneric("A")), frNamed("key", frString)],
         frDictWithArbitraryKeys(frGeneric("A")),
         ([dict, key]) => dict.delete(key)
       ),
@@ -151,7 +156,7 @@ export const library = [
       makeDefinition(
         [
           frDictWithArbitraryKeys(frGeneric("A")),
-          frLambdaTyped([frGeneric("A")], frGeneric("B")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frGeneric("B"))),
         ],
         frDictWithArbitraryKeys(frGeneric("B")),
         ([dict, lambda], context) => {
@@ -173,7 +178,7 @@ export const library = [
       makeDefinition(
         [
           frDictWithArbitraryKeys(frGeneric("A")),
-          frLambdaTyped([frString], frString),
+          frNamed("fn", frLambdaTyped([frString], frString)),
         ],
         frDictWithArbitraryKeys(frGeneric("A")),
         ([dict, lambda], context) => {
@@ -199,7 +204,7 @@ export const library = [
     definitions: [
       makeDefinition(
         [frDictWithArbitraryKeys(frGeneric("A")), frArray(frString)],
-        frDictWithArbitraryKeys(frGeneric("A")),
+        frNamed("keys", frDictWithArbitraryKeys(frGeneric("A"))),
         ([dict, keys]) => {
           const response: OrderedMap<string, Value> = OrderedMap<
             string,
@@ -224,7 +229,7 @@ export const library = [
     definitions: [
       makeDefinition(
         [frDictWithArbitraryKeys(frGeneric("A")), frArray(frString)],
-        frDictWithArbitraryKeys(frGeneric("A")),
+        frNamed("keys", frDictWithArbitraryKeys(frGeneric("A"))),
         ([dict, keys]) => {
           const response: OrderedMap<string, Value> = dict.withMutations(
             (result) => {

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -7,6 +7,7 @@ import {
   frDict,
   frDist,
   frDistSymbolic,
+  frNamed,
   frNumber,
   frSampleSetDist,
 } from "../library/registry/frTypes.js";
@@ -224,7 +225,11 @@ export const library: FRFunction[] = [
     examples: ["triangular(3, 5, 10)"],
     definitions: [
       makeDefinition(
-        [frNumber, frNumber, frNumber],
+        [
+          frNamed("min", frNumber),
+          frNamed("mode", frNumber),
+          frNamed("max", frNumber),
+        ],
         frSampleSetDist,
         ([low, medium, high], { environment }) => {
           const result = SymbolicDist.Triangular.make({ low, medium, high });

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -90,8 +90,10 @@ export const library: FRFunction[] = [
       "normal({mean: 5, stdev: 2})",
     ],
     definitions: [
-      makeTwoArgsSamplesetDist((mean, stdev) =>
-        SymbolicDist.Normal.make({ mean, stdev })
+      makeTwoArgsSamplesetDist(
+        (mean, stdev) => SymbolicDist.Normal.make({ mean, stdev }),
+        "mean",
+        "stdev"
       ),
       ...CI_CONFIG.map((entry) =>
         makeCIDist(entry.lowKey, entry.highKey, (low, high) =>
@@ -117,8 +119,10 @@ export const library: FRFunction[] = [
       "lognormal({mean: 5, stdev: 2})",
     ],
     definitions: [
-      makeTwoArgsSamplesetDist((mu, sigma) =>
-        SymbolicDist.Lognormal.make({ mu, sigma })
+      makeTwoArgsSamplesetDist(
+        (mu, sigma) => SymbolicDist.Lognormal.make({ mu, sigma }),
+        "mu",
+        "sigma"
       ),
       ...CI_CONFIG.map((entry) =>
         makeCIDist(entry.lowKey, entry.highKey, (low, high) =>
@@ -138,8 +142,10 @@ export const library: FRFunction[] = [
     name: "uniform",
     examples: ["uniform(10, 12)"],
     definitions: [
-      makeTwoArgsSamplesetDist((low, high) =>
-        SymbolicDist.Uniform.make({ low, high })
+      makeTwoArgsSamplesetDist(
+        (low, high) => SymbolicDist.Uniform.make({ low, high }),
+        "low",
+        "high"
       ),
     ],
   }),
@@ -147,8 +153,10 @@ export const library: FRFunction[] = [
     name: "beta",
     examples: ["beta(20, 25)", "beta({mean: 0.39, stdev: 0.1})"],
     definitions: [
-      makeTwoArgsSamplesetDist((alpha, beta) =>
-        SymbolicDist.Beta.make({ alpha, beta })
+      makeTwoArgsSamplesetDist(
+        (alpha, beta) => SymbolicDist.Beta.make({ alpha, beta }),
+        "alpha",
+        "beta"
       ),
       makeMeanStdevDist((mean, stdev) =>
         SymbolicDist.Beta.fromMeanAndStdev({ mean, stdev })
@@ -159,8 +167,10 @@ export const library: FRFunction[] = [
     name: "cauchy",
     examples: ["cauchy(5, 1)"],
     definitions: [
-      makeTwoArgsSamplesetDist((local, scale) =>
-        SymbolicDist.Cauchy.make({ local, scale })
+      makeTwoArgsSamplesetDist(
+        (local, scale) => SymbolicDist.Cauchy.make({ local, scale }),
+        "location",
+        "scale"
       ),
     ],
   }),
@@ -168,8 +178,10 @@ export const library: FRFunction[] = [
     name: "gamma",
     examples: ["gamma(5, 1)"],
     definitions: [
-      makeTwoArgsSamplesetDist((shape, scale) =>
-        SymbolicDist.Gamma.make({ shape, scale })
+      makeTwoArgsSamplesetDist(
+        (shape, scale) => SymbolicDist.Gamma.make({ shape, scale }),
+        "shape",
+        "scale"
       ),
     ],
   }),
@@ -177,8 +189,10 @@ export const library: FRFunction[] = [
     name: "logistic",
     examples: ["logistic(5, 1)"],
     definitions: [
-      makeTwoArgsSamplesetDist((location, scale) =>
-        SymbolicDist.Logistic.make({ location, scale })
+      makeTwoArgsSamplesetDist(
+        (location, scale) => SymbolicDist.Logistic.make({ location, scale }),
+        "location",
+        "scale"
       ),
     ],
   }),
@@ -186,38 +200,45 @@ export const library: FRFunction[] = [
     name: "to",
     examples: ["5 to 10", "to(5,10)"],
     definitions: [
-      makeTwoArgsSamplesetDist((low, high) => {
-        if (low >= high) {
-          throw new REDistributionError(
-            argumentError("Low value must be less than high value")
-          );
-        } else if (low <= 0 || high <= 0) {
-          throw new REDistributionError(
-            argumentError(
-              `The "to" function only accepts paramaters above 0. It's a shorthand for lognormal({p5:min, p95:max}), which is only valid with positive entries for then minimum and maximum. If you would like to use a normal distribution, which accepts values under 0, you can use it like this: normal({p5:${low}, p95:${high}}).`
-            )
-          );
-        }
-        return SymbolicDist.Lognormal.fromCredibleInterval({
-          low,
-          high,
-          probability: 0.9,
-        });
-      }),
+      makeTwoArgsSamplesetDist(
+        (low, high) => {
+          if (low >= high) {
+            throw new REDistributionError(
+              argumentError("Low value must be less than high value")
+            );
+          } else if (low <= 0 || high <= 0) {
+            throw new REDistributionError(
+              argumentError(
+                `The "to" function only accepts paramaters above 0. It's a shorthand for lognormal({p5:min, p95:max}), which is only valid with positive entries for then minimum and maximum. If you would like to use a normal distribution, which accepts values under 0, you can use it like this: normal({p5:${low}, p95:${high}}).`
+              )
+            );
+          }
+          return SymbolicDist.Lognormal.fromCredibleInterval({
+            low,
+            high,
+            probability: 0.9,
+          });
+        },
+        "p5",
+        "p95"
+      ),
     ],
   }),
   maker.make({
     name: "exponential",
     examples: ["exponential(2)"],
     definitions: [
-      makeOneArgSamplesetDist((rate) => SymbolicDist.Exponential.make(rate)),
+      makeOneArgSamplesetDist(
+        (rate) => SymbolicDist.Exponential.make(rate),
+        "rate"
+      ),
     ],
   }),
   maker.make({
     name: "bernoulli",
     examples: ["bernoulli(0.5)"],
     definitions: [
-      makeOneArgSamplesetDist((p) => SymbolicDist.Bernoulli.make(p)),
+      makeOneArgSamplesetDist((p) => SymbolicDist.Bernoulli.make(p), "p"),
     ],
   }),
   maker.make({

--- a/packages/squiggle-lang/src/fr/genericDist.ts
+++ b/packages/squiggle-lang/src/fr/genericDist.ts
@@ -16,6 +16,7 @@ import {
   frArray,
   frDist,
   frDistOrNumber,
+  frNamed,
   frNumber,
 } from "../library/registry/frTypes.js";
 import {
@@ -173,7 +174,7 @@ export const library: FRFunction[] = [
   maker.fromDefinition(
     "truncate",
     makeDefinition(
-      [frDist, frNumber, frNumber],
+      [frDist, frNamed("left", frNumber), frNamed("right", frNumber)],
       frDist,
       ([dist, left, right], { environment }) =>
         unwrapDistResult(dist.truncate(left, right, { env: environment }))

--- a/packages/squiggle-lang/src/fr/genericDist.ts
+++ b/packages/squiggle-lang/src/fr/genericDist.ts
@@ -115,9 +115,13 @@ export const library: FRFunction[] = [
   maker.d2n({ name: "integralSum", fn: (d) => d.integralSum() }),
   maker.fromDefinition(
     "sampleN",
-    makeDefinition([frDist, frNumber], frArray(frNumber), ([dist, n]) => {
-      return dist.sampleN(n | 0);
-    })
+    makeDefinition(
+      [frDist, frNamed("n", frNumber)],
+      frArray(frNumber),
+      ([dist, n]) => {
+        return dist.sampleN(n | 0);
+      }
+    )
   ),
   maker.d2d({
     name: "exp",

--- a/packages/squiggle-lang/src/fr/genericDist.ts
+++ b/packages/squiggle-lang/src/fr/genericDist.ts
@@ -27,7 +27,7 @@ import {
 import * as magicNumbers from "../magicNumbers.js";
 
 const maker = new FnFactory({
-  nameSpace: "",
+  nameSpace: "Dist",
   requiresNamespace: false,
 });
 

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -449,12 +449,12 @@ export const library = [
           frArray(frGeneric("B")),
           frNamed("initialValue", frGeneric("A")),
           frNamed(
-            "stepFn",
+            "callbackFn",
             frLambdaTyped(
               [
-                frNamed("acc", frGeneric("A")),
-                frNamed("curr", frGeneric("B")),
-                frNamed("index", frOptional(frNumber)),
+                frNamed("accumulator", frGeneric("A")),
+                frNamed("currentValue", frGeneric("B")),
+                frNamed("currentIndex", frOptional(frNumber)),
               ],
               frGeneric("A")
             )
@@ -484,9 +484,12 @@ export const library = [
           frArray(frGeneric("B")),
           frNamed("initialValue", frGeneric("A")),
           frNamed(
-            "stepFn",
+            "callbackFn",
             frLambdaTyped(
-              [frNamed("acc", frGeneric("A")), frNamed("curr", frGeneric("B"))],
+              [
+                frNamed("accumulator", frGeneric("A")),
+                frNamed("currentValue", frGeneric("B")),
+              ],
               frGeneric("A")
             )
           ),
@@ -513,9 +516,12 @@ export const library = [
           frArray(frGeneric("B")),
           frNamed("initialValue", frGeneric("A")),
           frNamed(
-            "stepFn",
+            "callbackFn",
             frLambdaTyped(
-              [frNamed("acc", frGeneric("A")), frNamed("curr", frGeneric("B"))],
+              [
+                frNamed("accumulator", frGeneric("A")),
+                frNamed("currentValue", frGeneric("B")),
+              ],
               frGeneric("A")
             )
           ),

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -622,7 +622,7 @@ export const library = [
       makeDefinition(
         [frArray(frString), frNamed("separator", frOptional(frString))],
         frString,
-        ([array, joinStr]) => array.join(joinStr || ",")
+        ([array, joinStr]) => array.join(joinStr ?? ",")
       ),
       makeDefinition([frArray(frString)], frString, ([array]) => array.join()),
     ],

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -158,10 +158,13 @@ export const library = [
       ),
       makeDefinition(
         [
-          frNumber,
-          frLambdaTyped(
-            [frNamed("index", frOptional(frNumber))],
-            frGeneric("A")
+          frNamed("count", frNumber),
+          frNamed(
+            "fn",
+            frLambdaTyped(
+              [frNamed("index", frOptional(frNumber))],
+              frGeneric("A")
+            )
           ),
         ],
         frArray(frGeneric("A")),
@@ -175,7 +178,7 @@ export const library = [
         }
       ),
       makeDefinition(
-        [frNumber, frGeneric("A")],
+        [frNamed("count", frNumber), frNamed("value", frGeneric("A"))],
         frArray(frGeneric("A")),
         ([number, value]) => {
           _assertValidArrayLength(number);
@@ -192,14 +195,18 @@ export const library = [
     output: "Array",
     examples: [`List.upTo(1,4)`],
     definitions: [
-      makeDefinition([frNumber, frNumber], frArray(frNumber), ([low, high]) => {
-        if (!Number.isInteger(low) || !Number.isInteger(high)) {
-          throw new REArgumentError(
-            "Low and high values must both be integers"
-          );
+      makeDefinition(
+        [frNamed("low", frNumber), frNamed("high", frNumber)],
+        frArray(frNumber),
+        ([low, high]) => {
+          if (!Number.isInteger(low) || !Number.isInteger(high)) {
+            throw new REArgumentError(
+              "Low and high values must both be integers"
+            );
+          }
+          return E_A_Floats.upTo(low, high);
         }
-        return E_A_Floats.upTo(low, high);
-      }),
+      ),
     ],
   }),
   maker.make({
@@ -293,7 +300,10 @@ export const library = [
     examples: [`List.sortBy([{a:3}, {a:1}], {|f| f.a})`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frNumber)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frNumber)),
+        ],
         frArray(frGeneric("A")),
         ([array, lambda], context) => {
           return sortBy(array, (e) =>
@@ -309,7 +319,10 @@ export const library = [
     examples: [`List.minBy([{a:3}, {a:1}], {|f| f.a})`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frNumber)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frNumber)),
+        ],
         frGeneric("A"),
         ([array, lambda], context) => {
           _assertUnemptyArray(array);
@@ -331,7 +344,10 @@ export const library = [
     examples: [`List.maxBy([{a:3}, {a:1}], {|f| f.a})`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frNumber)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frNumber)),
+        ],
         frGeneric("A"),
         ([array, lambda], context) => {
           _assertUnemptyArray(array);
@@ -369,8 +385,8 @@ export const library = [
       makeDefinition(
         [
           frArray(frGeneric("A")),
-          frNumber,
-          frNamed("index", frOptional(frNumber)),
+          frNamed("startIndex", frNumber),
+          frNamed("endIndex", frOptional(frNumber)),
         ],
         frArray(frGeneric("A")),
         ([array, start, end]) => {
@@ -425,20 +441,23 @@ export const library = [
     examples: [`List.reduce([1,4,5], 2, {|acc, el| acc+el})`],
     definitions: [
       makeAssertDefinition(
-        [frNumber, frLambdaNand([2, 3])],
+        [frNumber, frNamed("fn", frLambdaNand([2, 3]))],
         "Call with either 2 or 3 arguments, not both."
       ),
       makeDefinition(
         [
           frArray(frGeneric("B")),
-          frGeneric("A"),
-          frLambdaTyped(
-            [
-              frGeneric("A"),
-              frGeneric("B"),
-              frNamed("index", frOptional(frNumber)),
-            ],
-            frGeneric("A")
+          frNamed("initialValue", frGeneric("A")),
+          frNamed(
+            "stepFn",
+            frLambdaTyped(
+              [
+                frNamed("acc", frGeneric("A")),
+                frNamed("curr", frGeneric("B")),
+                frNamed("index", frOptional(frNumber)),
+              ],
+              frGeneric("A")
+            )
           ),
         ],
         frGeneric("A"),
@@ -463,8 +482,14 @@ export const library = [
       makeDefinition(
         [
           frArray(frGeneric("B")),
-          frGeneric("A"),
-          frLambdaTyped([frGeneric("A"), frGeneric("B")], frGeneric("A")),
+          frNamed("initialValue", frGeneric("A")),
+          frNamed(
+            "stepFn",
+            frLambdaTyped(
+              [frNamed("acc", frGeneric("A")), frNamed("curr", frGeneric("B"))],
+              frGeneric("A")
+            )
+          ),
         ],
         frGeneric("A"),
         ([array, initialValue, lambda], context) =>
@@ -486,9 +511,15 @@ export const library = [
       makeDefinition(
         [
           frArray(frGeneric("B")),
-          frGeneric("A"),
-          frLambdaTyped([frGeneric("A"), frGeneric("B")], frGeneric("A")),
-          frLambdaTyped([frGeneric("A")], frBool),
+          frNamed("initialValue", frGeneric("A")),
+          frNamed(
+            "stepFn",
+            frLambdaTyped(
+              [frNamed("acc", frGeneric("A")), frNamed("curr", frGeneric("B"))],
+              frGeneric("A")
+            )
+          ),
+          frNamed("conditionFn", frLambdaTyped([frGeneric("A")], frBool)),
         ],
         frGeneric("A"),
         ([array, initialValue, step, condition], context) =>
@@ -502,7 +533,10 @@ export const library = [
     examples: [`List.filter([1,4,5], {|x| x>3})`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frBool)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frBool)),
+        ],
         frArray(frGeneric("A")),
         ([array, lambda], context) =>
           array.filter(_binaryLambdaCheck1(lambda, context))
@@ -515,7 +549,10 @@ export const library = [
     examples: [`List.every([1,4,5], {|el| el>3 })`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frBool)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frBool)),
+        ],
         frBool,
         ([array, lambda], context) =>
           array.every(_binaryLambdaCheck1(lambda, context))
@@ -528,7 +565,10 @@ export const library = [
     examples: [`List.some([1,4,5], {|el| el>3 })`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frBool)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frBool)),
+        ],
         frBool,
         ([array, lambda], context) =>
           array.some(_binaryLambdaCheck1(lambda, context))
@@ -542,7 +582,10 @@ export const library = [
     examples: [`List.find([1,4,5], {|el| el>3 })`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frBool)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frBool)),
+        ],
         frGeneric("A"),
         ([array, lambda], context) => {
           const result = array.find(_binaryLambdaCheck1(lambda, context));
@@ -561,7 +604,10 @@ export const library = [
     examples: [`List.findIndex([1,4,5], {|el| el>3 })`],
     definitions: [
       makeDefinition(
-        [frArray(frGeneric("A")), frLambdaTyped([frGeneric("A")], frBool)],
+        [
+          frArray(frGeneric("A")),
+          frNamed("fn", frLambdaTyped([frGeneric("A")], frBool)),
+        ],
         frNumber,
         ([array, lambda], context) =>
           array.findIndex(_binaryLambdaCheck1(lambda, context))
@@ -574,9 +620,9 @@ export const library = [
     examples: [`List.join(["a", "b", "c"], ",")`],
     definitions: [
       makeDefinition(
-        [frArray(frString), frString],
+        [frArray(frString), frNamed("separator", frOptional(frString))],
         frString,
-        ([array, joinStr]) => array.join(joinStr)
+        ([array, joinStr]) => array.join(joinStr || ",")
       ),
       makeDefinition([frArray(frString)], frString, ([array]) => array.join()),
     ],

--- a/packages/squiggle-lang/src/fr/pointset.ts
+++ b/packages/squiggle-lang/src/fr/pointset.ts
@@ -9,6 +9,7 @@ import {
   frDist,
   frDistPointset,
   frLambdaTyped,
+  frNamed,
   frNumber,
 } from "../library/registry/frTypes.js";
 import {
@@ -73,7 +74,7 @@ export const library = [
     output: "Dist",
     definitions: [
       makeDefinition(
-        [frDistPointset, frNumber],
+        [frDistPointset, frNamed("newLength", frNumber)],
         frDistPointset,
         ([dist, number]) => {
           return dist.downsample(number);
@@ -87,7 +88,7 @@ export const library = [
     output: "Dist",
     definitions: [
       makeDefinition(
-        [frDistPointset, frLambdaTyped([frNumber], frNumber)],
+        [frDistPointset, frNamed("fn", frLambdaTyped([frNumber], frNumber))],
         frDistPointset,
         ([dist, lambda], context) => {
           return unwrapDistResult(

--- a/packages/squiggle-lang/src/fr/sampleset.ts
+++ b/packages/squiggle-lang/src/fr/sampleset.ts
@@ -115,7 +115,7 @@ const baseLibrary = [
     output: "Dist",
     definitions: [
       makeDefinition(
-        [frSampleSetDist, frLambdaTyped([frNumber], frNumber)],
+        [frSampleSetDist, frNamed("fn", frLambdaTyped([frNumber], frNumber))],
         frSampleSetDist,
         ([dist, lambda], context) => {
           return unwrapDistResult(
@@ -138,7 +138,7 @@ const baseLibrary = [
         [
           frSampleSetDist,
           frSampleSetDist,
-          frLambdaTyped([frNumber, frNumber], frNumber),
+          frNamed("fn", frLambdaTyped([frNumber, frNumber], frNumber)),
         ],
         frSampleSetDist,
         ([dist1, dist2, lambda], context) => {
@@ -168,7 +168,10 @@ const baseLibrary = [
           frSampleSetDist,
           frSampleSetDist,
           frSampleSetDist,
-          frLambdaTyped([frNumber, frNumber, frNumber], frNumber),
+          frNamed(
+            "fn",
+            frLambdaTyped([frNumber, frNumber, frNumber], frNumber)
+          ),
         ],
         frSampleSetDist,
         ([dist1, dist2, dist3, lambda], context) => {
@@ -201,7 +204,7 @@ const baseLibrary = [
       makeDefinition(
         [
           frArray(frSampleSetDist),
-          frLambdaTyped([frArray(frNumber)], frNumber),
+          frNamed("fn", frLambdaTyped([frArray(frNumber)], frNumber)),
         ],
         frSampleSetDist,
         ([dists, lambda], context) => {

--- a/packages/squiggle-lang/src/fr/scoring.ts
+++ b/packages/squiggle-lang/src/fr/scoring.ts
@@ -8,6 +8,7 @@ import {
   frDist,
   frDistOrNumber,
   frNumber,
+  frOptional,
 } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 
@@ -67,51 +68,46 @@ export const library = [
           frDict(
             ["estimate", frDist],
             ["answer", frDistOrNumber],
-            ["prior", frDist]
+            ["prior", frOptional(frDist)]
           ),
         ],
         frNumber,
         ([{ estimate, answer, prior }], context) => {
-          if (answer instanceof BaseDist) {
-            return runScoringDistAnswer(
-              estimate,
-              answer,
-              prior,
-              context.environment
-            );
-          } else if (typeof answer === "number") {
-            return runScoringScalarAnswer(
-              estimate,
-              answer,
-              prior,
-              context.environment
-            );
-          } else {
-            throw new REArgumentError("Impossible type");
+          if (prior !== null) {
+            if (answer instanceof BaseDist) {
+              return runScoringDistAnswer(
+                estimate,
+                answer,
+                prior,
+                context.environment
+              );
+            } else if (typeof answer === "number") {
+              return runScoringScalarAnswer(
+                estimate,
+                answer,
+                prior,
+                context.environment
+              );
+            }
           }
-        }
-      ),
-      makeDefinition(
-        [frDict(["estimate", frDist], ["answer", frDistOrNumber])],
-        frNumber,
-        ([{ estimate, answer }], context) => {
-          if (answer instanceof BaseDist) {
-            return runScoringDistAnswer(
-              estimate,
-              answer,
-              undefined,
-              context.environment
-            );
-          } else if (typeof answer === "number") {
-            return runScoringScalarAnswer(
-              estimate,
-              answer,
-              undefined,
-              context.environment
-            );
-          } else {
-            throw new REArgumentError("Impossible type");
+          if (prior === null) {
+            if (answer instanceof BaseDist) {
+              return runScoringDistAnswer(
+                estimate,
+                answer,
+                undefined,
+                context.environment
+              );
+            } else if (typeof answer === "number") {
+              return runScoringScalarAnswer(
+                estimate,
+                answer,
+                undefined,
+                context.environment
+              );
+            }
           }
+          throw new REArgumentError("Impossible type");
         }
       ),
     ],

--- a/packages/squiggle-lang/src/fr/string.ts
+++ b/packages/squiggle-lang/src/fr/string.ts
@@ -1,5 +1,10 @@
 import { makeDefinition } from "../library/registry/fnDefinition.js";
-import { frAny, frArray, frString } from "../library/registry/frTypes.js";
+import {
+  frAny,
+  frArray,
+  frNamed,
+  frString,
+} from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
 
 const maker = new FnFactory({
@@ -16,9 +21,13 @@ export const library = [
   maker.make({
     name: "split",
     definitions: [
-      makeDefinition([frString, frString], frArray(frString), ([str, mark]) => {
-        return str.split(mark);
-      }),
+      makeDefinition(
+        [frString, frNamed("separator", frString)],
+        frArray(frString),
+        ([str, mark]) => {
+          return str.split(mark);
+        }
+      ),
     ],
   }),
 ];

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -9,6 +9,8 @@ import {
   type SqValue,
 } from "./public/SqValue/index.js"; // TODO - reexport other values too
 
+export { FnDefinition } from "./library/registry/fnDefinition.js";
+
 export { type FnDocumentation } from "./library/registry/core.js";
 export {
   SqCheckboxInput,

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -9,7 +9,7 @@ import {
   type SqValue,
 } from "./public/SqValue/index.js"; // TODO - reexport other values too
 
-export { FnDefinition } from "./library/registry/fnDefinition.js";
+export { type FnDefinition } from "./library/registry/fnDefinition.js";
 
 export { type FnDocumentation } from "./library/registry/core.js";
 export {

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -32,6 +32,7 @@ export type FnDocumentation = Pick<
   | "description"
   | "requiresNamespace"
   | "nameSpace"
+  | "definitions"
   | "name"
   | "examples"
   | "isExperimental"
@@ -122,6 +123,7 @@ export class Registry {
       nameSpace: fn.nameSpace,
       requiresNamespace: fn.requiresNamespace,
       description: fn.description,
+      definitions: fn.definitions,
       examples: fn.examples,
       signatures: fn.definitions
         .filter((d) => showInDocumentation(d))

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -87,7 +87,7 @@ export const frDuration: FRType<SDuration> = {
 export const frDist: FRType<BaseDist> = {
   unpack: (v) => (v.type === "Dist" ? v.value : undefined),
   pack: (v) => vDist(v),
-  getName: () => "distribution",
+  getName: () => "dist",
 };
 export const frDistPointset: FRType<PointSetDist> = {
   unpack: (v) =>
@@ -230,7 +230,7 @@ export const frDistOrNumber: FRType<BaseDist | number> = {
   unpack: (v) =>
     v.type === "Dist" ? v.value : v.type === "Number" ? v.value : undefined,
   pack: (v) => (typeof v === "number" ? vNumber(v) : vDist(v)),
-  getName: () => "distribution|number",
+  getName: () => "dist|number",
 };
 
 export function frTuple<T1, T2>(

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -279,7 +279,7 @@ export function frTuple(...types: FRType<unknown>[]): FRType<any> {
     pack: (values: unknown[]) => {
       return vArray(values.map((val, index) => types[index].pack(val)));
     },
-    getName: () => `(${types.map((type) => type.getName()).join(", ")})`,
+    getName: () => `[${types.map((type) => type.getName()).join(", ")}]`,
   };
 }
 

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -279,7 +279,7 @@ export function frTuple(...types: FRType<unknown>[]): FRType<any> {
     pack: (values: unknown[]) => {
       return vArray(values.map((val, index) => types[index].pack(val)));
     },
-    getName: () => `tuple(${types.map((type) => type.getName()).join(", ")})`,
+    getName: () => `(${types.map((type) => type.getName()).join(", ")})`,
   };
 }
 

--- a/packages/squiggle-lang/src/library/registry/helpers.ts
+++ b/packages/squiggle-lang/src/library/registry/helpers.ts
@@ -27,6 +27,7 @@ import {
   frBool,
   frDist,
   frDistOrNumber,
+  frNamed,
   frNumber,
   frSampleSetDist,
   frString,
@@ -364,20 +365,23 @@ export function makeTwoArgsSamplesetDist(
   fn: (
     v1: number,
     v2: number
-  ) => Result.result<SymbolicDist.SymbolicDist, string>
+  ) => Result.result<SymbolicDist.SymbolicDist, string>,
+  name1: string,
+  name2: string
 ) {
   return makeDefinition(
-    [frDistOrNumber, frDistOrNumber],
+    [frNamed(name1, frDistOrNumber), frNamed(name2, frDistOrNumber)],
     frSampleSetDist,
     ([v1, v2], { environment }) => twoVarSample(v1, v2, environment, fn)
   );
 }
 
 export function makeOneArgSamplesetDist(
-  fn: (v: number) => Result.result<SymbolicDist.SymbolicDist, string>
+  fn: (v: number) => Result.result<SymbolicDist.SymbolicDist, string>,
+  name: string
 ) {
   return makeDefinition(
-    [frDistOrNumber],
+    [frNamed(name, frDistOrNumber)],
     frSampleSetDist,
     ([v], { environment }) => {
       const sampleFn = (a: number) =>

--- a/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqLambda.ts
@@ -57,6 +57,10 @@ export class SqLambda {
     return new SqLambda(value.value);
   }
 
+  get type() {
+    return this._value.type;
+  }
+
   parameterCounts() {
     return this._value.parameterCounts();
   }


### PR DESCRIPTION
Several minor improvements to in-language-documentation.

- Show definitions with limited HTML, instead of as strings
- New tag for "namespace optional"
- Show builtIn lambdas as their documentation.
- In the documentation:
  - Change "distribution" to "dist"
  - Add a bunch of ``frNamed``
  - Clean various definitions to use ``frOptional`` instead of multiple definitions. This cleans up the documentation signatures.

This closes https://github.com/quantified-uncertainty/squiggle/issues/2661