### PR TITLE
frOr support for falsy values

### DIFF
--- a/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/frTypes_test.ts
@@ -307,6 +307,12 @@ describe("frOr", () => {
       const unpacked = frNumberOrString.unpack(stringValue);
       expect(unpacked).toEqual({ tag: "2", value: "hello" });
     });
+
+    test("should correctly unpack falsy value", () => {
+      const numberValue = vNumber(0);
+      const unpacked = frNumberOrString.unpack(numberValue);
+      expect(unpacked).toEqual({ tag: "1", value: 0 });
+    });
   });
 
   describe("pack", () => {

--- a/packages/squiggle-lang/src/library/registry/frTypes.ts
+++ b/packages/squiggle-lang/src/library/registry/frTypes.ts
@@ -209,11 +209,11 @@ export function frOr<T1, T2>(
   return {
     unpack: (v) => {
       const unpacked1 = type1.unpack(v);
-      if (unpacked1) {
+      if (unpacked1 !== undefined) {
         return { tag: "1", value: unpacked1 };
       }
       const unpacked2 = type2.unpack(v);
-      if (unpacked2) {
+      if (unpacked2 !== undefined) {
         return { tag: "2", value: unpacked2 };
       }
       return undefined;


### PR DESCRIPTION
Fixes this bug: https://www.squiggle-language.com/playground?v=dev#code=eNqrVkpJTUsszSlxzk9JVbJSyk2s0DBSKMlXMNZRMNBUqgUAsUIJtg%3D%3D
<img width="966" alt="Captura de pantalla 2023-12-12 a la(s) 11 03 55" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/9161f210-c72a-4d11-b316-f2311d5f7df1">
