### PR TITLE
squiggle parse --short flag

### DIFF
--- a/packages/squiggle-lang/src/cli/makeProgram.ts
+++ b/packages/squiggle-lang/src/cli/makeProgram.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import open from "open";
 import util from "util";
 
+import { nodeResultToString } from "../ast/parse.js";
 import { parse } from "../public/parse.js";
 import { red } from "./colors.js";
 import { OutputMode, run } from "./utils.js";
@@ -69,14 +70,19 @@ export function makeProgram() {
       "-e, --eval <code>",
       "parse a given squiggle code string instead of a file"
     )
+    .option("-s, --short", "output as an S-expression")
     .action((filename, options) => {
       const src = loadSrc({ filename, inline: options.eval });
 
       const parseResult = parse(src);
       if (parseResult.ok) {
-        console.log(
-          util.inspect(parseResult.value, { depth: Infinity, colors: true })
-        );
+        if (options.short) {
+          console.log(nodeResultToString(parseResult));
+        } else {
+          console.log(
+            util.inspect(parseResult.value, { depth: Infinity, colors: true })
+          );
+        }
       } else {
         console.log(red(parseResult.value.toString()));
       }


### PR DESCRIPTION
Tiny patch for debugging ASTs:

```
$ pnpm run cli parse -s -e 'foo -> foo -> foo'

> @quri/squiggle-lang@0.8.7-0 cli /Users/berekuk/coding/quri/squiggle/packages/squiggle-lang
> node ./dist/cli/index.js "parse" "-s" "-e" "foo -> foo -> foo"

(Program (Pipe (Pipe :foo :foo) :foo))
```

Previously `parse` command always printed JSON which was harder to read.