### PR TITLE
Add data-first variants on Plot.dists

### DIFF
--- a/.changeset/hot-dancers-smoke.md
+++ b/.changeset/hot-dancers-smoke.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Add data-first variants on Plot.dists

--- a/packages/squiggle-lang/__tests__/library/plot_test.ts
+++ b/packages/squiggle-lang/__tests__/library/plot_test.ts
@@ -26,6 +26,14 @@ describe("Plot", () => {
       'Plot.dists({dists: [{name: "dist1", value: 2}, {name: "dist2", value: 2 to 5}]})',
       "Plot containing dist1, dist2"
     );
+    testEvalToBe(
+      'Plot.dists([{name: "dist1", value: 2}, {name: "dist2", value: 2 to 5}])',
+      "Plot containing dist1, dist2"
+    );
+    testEvalToBe(
+      "Plot.dists([(2), 2 to 10])",
+      "Plot containing dist 1, dist 2"
+    );
   });
 
   describe("Plot.numericFn", () => {

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -10,6 +10,7 @@ import {
   frNamed,
   frNumber,
   frOptional,
+  frOr,
   frPlot,
   frSampleSetDist,
   frScale,
@@ -185,6 +186,59 @@ export const library = [
     definitions: [
       makeDefinition(
         [
+          frNamed(
+            "dists",
+            frOr(
+              frArray(frDistOrNumber),
+              frArray(
+                frDict(
+                  ["name", frOptional(frString)],
+                  ["value", frDistOrNumber]
+                )
+              )
+            )
+          ),
+          frOptional(
+            frDict(
+              ["xScale", frOptional(frScale)],
+              ["yScale", frOptional(frScale)],
+              ["title", frOptional(frString)],
+              ["showSummary", frOptional(frBool)]
+            )
+          ),
+        ],
+        frPlot,
+        ([dists, params]) => {
+          const { xScale, yScale, title, showSummary } = params ?? {};
+          yScale && _assertYScaleNotDateScale(yScale);
+          const distributions: LabeledDistribution[] = [];
+          if (dists.tag === "2") {
+            dists.value.forEach(({ name, value }, index) => {
+              distributions.push({
+                name: name || `dist ${index + 1}`,
+                distribution: parseDistFromDistOrNumber(value),
+              });
+            });
+          } else {
+            dists.value.forEach((dist, index) => {
+              distributions.push({
+                name: `dist ${index + 1}`,
+                distribution: parseDistFromDistOrNumber(dist),
+              });
+            });
+          }
+          return {
+            type: "distributions",
+            distributions,
+            xScale: xScale ?? defaultScale,
+            yScale: yScale ?? defaultScale,
+            title: title ?? undefined,
+            showSummary: showSummary ?? true,
+          };
+        }
+      ),
+      makeDefinition(
+        [
           frDict(
             [
               "dists",
@@ -215,7 +269,8 @@ export const library = [
             title: title ?? undefined,
             showSummary: showSummary ?? true,
           };
-        }
+        },
+        { deprecated: "0.8.7" }
       ),
     ],
   }),


### PR DESCRIPTION
Once https://github.com/quantified-uncertainty/squiggle/pull/2667 is merged, it would be good to add boxed names to this. 