### PR TITLE
Boxed format() for numbers, dists, dates, and durations

### DIFF
--- a/packages/components/src/components/NumberShower.tsx
+++ b/packages/components/src/components/NumberShower.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import { DurationUnitName, durationUnits } from "@quri/squiggle-lang";
+
 const orderOfMagnitudeNum = (n: number) => {
   return Math.pow(10, n);
 };
@@ -70,10 +72,11 @@ export function numberShow(number: number, precision = 2) {
   return ns.convert();
 }
 
+//At this point we only support duration units.
 export interface NumberShowerProps {
   number: number;
   precision?: number;
-  unitName?: string;
+  unitName?: DurationUnitName;
 }
 
 export const NumberShower: React.FC<NumberShowerProps> = ({
@@ -94,7 +97,7 @@ export const NumberShower: React.FC<NumberShowerProps> = ({
           </span>
         </span>
       ) : null}
-      {unitName && <span> {unitName + "s"}</span>}
+      {unitName && <span> {durationUnits[unitName].plural}</span>}
     </span>
   );
 };

--- a/packages/components/src/components/NumberShower.tsx
+++ b/packages/components/src/components/NumberShower.tsx
@@ -73,11 +73,13 @@ export function numberShow(number: number, precision = 2) {
 export interface NumberShowerProps {
   number: number;
   precision?: number;
+  unitName?: string;
 }
 
 export const NumberShower: React.FC<NumberShowerProps> = ({
   number,
   precision = 2,
+  unitName,
 }) => {
   const numberWithPresentation = numberShow(number, precision);
   return (
@@ -92,6 +94,7 @@ export const NumberShower: React.FC<NumberShowerProps> = ({
           </span>
         </span>
       ) : null}
+      {unitName && <span> {unitName + "s"}</span>}
     </span>
   );
 };

--- a/packages/components/src/components/PlaygroundSettings.tsx
+++ b/packages/components/src/components/PlaygroundSettings.tsx
@@ -40,7 +40,7 @@ type ScaleType = z.infer<typeof scaleSchema>;
 
 function scaleTypeToSqScale(
   scaleType: ScaleType,
-  args: { min?: number; max?: number } = {}
+  args: { min?: number; max?: number; tickFormat?: string } = {}
 ) {
   switch (scaleType) {
     case "linear":
@@ -108,11 +108,13 @@ export type PartialPlaygroundSettings = DeepPartial<PlaygroundSettings>;
 
 // partial params for SqDistributionsPlot.create; TODO - infer explicit type?
 export function generateDistributionPlotSettings(
-  settings: z.infer<typeof distributionSettingsSchema>
+  settings: z.infer<typeof distributionSettingsSchema>,
+  xTickFormat?: string
 ) {
   const xScale = scaleTypeToSqScale(settings.xScale, {
     min: settings.minX,
     max: settings.maxX,
+    tickFormat: xTickFormat,
   });
   const yScale = scaleTypeToSqScale(settings.yScale);
   return {

--- a/packages/components/src/components/SquiggleViewer/SquiggleValueChart.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValueChart.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 
+import { SqBoxedValue } from "../../../../squiggle-lang/src/public/SqValue/index.js";
 import { SqValueWithContext } from "../../lib/utility.js";
 import { widgetRegistry } from "../../widgets/registry.js";
 import { PlaygroundSettings } from "../PlaygroundSettings.js";
@@ -7,11 +8,12 @@ import { PlaygroundSettings } from "../PlaygroundSettings.js";
 export const SquiggleValueChart = memo<{
   value: SqValueWithContext;
   settings: PlaygroundSettings;
-}>(function SquiggleValueChart({ value, settings }) {
+  boxed: SqBoxedValue | undefined;
+}>(function SquiggleValueChart({ value, settings, boxed }) {
   const widget = widgetRegistry.widgets.get(value.tag);
   if (!widget) {
     return value.toString();
   }
 
-  return <widget.Chart value={value} settings={settings} />;
+  return <widget.Chart value={value} settings={settings} boxed={boxed} />;
 });

--- a/packages/components/src/components/SquiggleViewer/SquiggleValueChart.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValueChart.tsx
@@ -8,7 +8,7 @@ import { PlaygroundSettings } from "../PlaygroundSettings.js";
 export const SquiggleValueChart = memo<{
   value: SqValueWithContext;
   settings: PlaygroundSettings;
-  boxed: SqBoxedValue | undefined;
+  boxed?: SqBoxedValue;
 }>(function SquiggleValueChart({ value, settings, boxed }) {
   const widget = widgetRegistry.widgets.get(value.tag);
   if (!widget) {

--- a/packages/components/src/components/SquiggleViewer/SquiggleValueChart.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValueChart.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 
-import { SqBoxedValue } from "../../../../squiggle-lang/src/public/SqValue/index.js";
+import { SqBoxedValue } from "@quri/squiggle-lang";
+
 import { SqValueWithContext } from "../../lib/utility.js";
 import { widgetRegistry } from "../../widgets/registry.js";
 import { PlaygroundSettings } from "../PlaygroundSettings.js";

--- a/packages/components/src/components/SquiggleViewer/SquiggleValuePreview.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValuePreview.tsx
@@ -1,15 +1,17 @@
 import { FC } from "react";
 
+import { SqBoxedValue } from "../../../../squiggle-lang/src/public/SqValue/index.js";
 import { SqValueWithContext } from "../../lib/utility.js";
 import { widgetRegistry } from "../../widgets/registry.js";
 
 export const SquiggleValuePreview: FC<{
   value: SqValueWithContext;
-}> = ({ value }) => {
+  boxed: SqBoxedValue | undefined;
+}> = ({ value, boxed }) => {
   const widget = widgetRegistry.widgets.get(value.tag);
   if (!widget?.Preview) {
     return null;
   }
 
-  return <widget.Preview value={value} />;
+  return <widget.Preview value={value} boxed={boxed} />;
 };

--- a/packages/components/src/components/SquiggleViewer/SquiggleValuePreview.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValuePreview.tsx
@@ -6,7 +6,7 @@ import { widgetRegistry } from "../../widgets/registry.js";
 
 export const SquiggleValuePreview: FC<{
   value: SqValueWithContext;
-  boxed: SqBoxedValue | undefined;
+  boxed?: SqBoxedValue;
 }> = ({ value, boxed }) => {
   const widget = widgetRegistry.widgets.get(value.tag);
   if (!widget?.Preview) {

--- a/packages/components/src/components/SquiggleViewer/SquiggleValuePreview.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValuePreview.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 
-import { SqBoxedValue } from "../../../../squiggle-lang/src/public/SqValue/index.js";
+import { SqBoxedValue } from "@quri/squiggle-lang";
+
 import { SqValueWithContext } from "../../lib/utility.js";
 import { widgetRegistry } from "../../widgets/registry.js";
 

--- a/packages/components/src/components/SquiggleViewer/SquiggleValueResultViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValueResultViewer.tsx
@@ -19,7 +19,13 @@ export const SquiggleValueResultChart = memo(function ValueResultViewer({
   if (result.ok) {
     const value = result.value;
     if (valueHasContext(value)) {
-      return <SquiggleValueChart value={value} settings={settings} />;
+      return (
+        <SquiggleValueChart
+          value={value}
+          settings={settings}
+          boxed={undefined}
+        />
+      );
     } else {
       return value.toString();
     }

--- a/packages/components/src/lib/d3/index.ts
+++ b/packages/components/src/lib/d3/index.ts
@@ -2,6 +2,7 @@ import * as d3 from "d3";
 
 import { SqScale } from "@quri/squiggle-lang";
 
+import { DEFAULT_DATE_FORMAT } from "../constants.js";
 import {
   scaleDate,
   scaleLinear,
@@ -35,4 +36,8 @@ export function sqScaleToD3(
 
 export function formatNumber(format: string, num: number) {
   return d3.format(format)(num);
+}
+
+export function formatDate(date: Date, format?: string) {
+  return d3.timeFormat(format || DEFAULT_DATE_FORMAT)(date);
 }

--- a/packages/components/src/lib/d3/index.ts
+++ b/packages/components/src/lib/d3/index.ts
@@ -32,3 +32,7 @@ export function sqScaleToD3(
       throw new Error(`Unknown scale: ${scale satisfies never}`);
   }
 }
+
+export function formatNumber(format: string, num: number) {
+  return d3.format(format)(num);
+}

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -263,14 +263,14 @@ export const Boxed: Story = {
   args: {
     defaultCode: `
 z = 34 -> Tag.format(".1f")
-// x = Tag.name(5 to 10, "My favorite Dist")
-//     -> Tag.description(
-//       "This is a long description"
-//     )
-//     -> Tag.format(
-//       "%2f"
-//     )
-//   y = x -> Tag.all
+x = Tag.name(5 to 10, "My favorite Dist")
+    -> Tag.description(
+      "This is a long description"
+    )
+    -> Tag.format(
+      "$.1f"
+    )
+  y = x -> Tag.all
    `,
   },
 };

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -261,14 +261,16 @@ Calculator.make(
 export const Boxed: Story = {
   name: "Boxed values",
   args: {
-    defaultCode: `x = Tag.name(5 to 10, "My favorite Dist") ->
-    Tag.description(
-      "This is a long description"
-    ) ->
-    Tag.showAs(
-      Plot.dist
-    )
-    y = x -> Tag.all
-    `,
+    defaultCode: `
+z = 34 -> Tag.format(".1f")
+// x = Tag.name(5 to 10, "My favorite Dist")
+//     -> Tag.description(
+//       "This is a long description"
+//     )
+//     -> Tag.format(
+//       "%2f"
+//     )
+//   y = x -> Tag.all
+   `,
   },
 };

--- a/packages/components/src/widgets/BoxedWidget.tsx
+++ b/packages/components/src/widgets/BoxedWidget.tsx
@@ -15,18 +15,26 @@ widgetRegistry.register("Boxed", {
   Preview: (value) => {
     const unboxedValue = value.value.value;
     if (valueHasContext(unboxedValue)) {
-      return <SquiggleValuePreview value={unboxedValue} />;
+      return <SquiggleValuePreview value={unboxedValue} boxed={value} />;
     }
   },
   Chart: (value, settings) => {
     const showAs = value.value.showAs();
     if (showAs && valueHasContext(showAs)) {
-      return <SquiggleValueChart value={showAs} settings={settings} />;
+      return (
+        <SquiggleValueChart value={showAs} settings={settings} boxed={value} />
+      );
     }
 
     const unboxedValue = value.value.value;
     if (valueHasContext(unboxedValue)) {
-      return <SquiggleValueChart value={unboxedValue} settings={settings} />;
+      return (
+        <SquiggleValueChart
+          value={unboxedValue}
+          settings={settings}
+          boxed={value}
+        />
+      );
     } else {
       return unboxedValue.toString();
     }

--- a/packages/components/src/widgets/DateWidget.tsx
+++ b/packages/components/src/widgets/DateWidget.tsx
@@ -1,8 +1,12 @@
+import {
+  SqBoxedValue,
+  SqDateValue,
+} from "../../../squiggle-lang/src/public/SqValue/index.js";
 import { formatDate } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 
-const showDate = (value, boxed) => {
-  const dateFormat = boxed && boxed.value.dateFormat();
+const showDate = (value: SqDateValue, boxed: SqBoxedValue | undefined) => {
+  const dateFormat = boxed?.value?.dateFormat();
   if (dateFormat) {
     return formatDate(value.value.toDate(), dateFormat);
   } else {

--- a/packages/components/src/widgets/DateWidget.tsx
+++ b/packages/components/src/widgets/DateWidget.tsx
@@ -5,7 +5,7 @@ import {
 import { formatDate } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 
-const showDate = (value: SqDateValue, boxed: SqBoxedValue | undefined) => {
+const showDate = (value: SqDateValue, boxed?: SqBoxedValue) => {
   const dateFormat = boxed?.value?.dateFormat();
   if (dateFormat) {
     return formatDate(value.value.toDate(), dateFormat);

--- a/packages/components/src/widgets/DateWidget.tsx
+++ b/packages/components/src/widgets/DateWidget.tsx
@@ -1,5 +1,16 @@
+import { formatDate } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 
+const showDate = (value, boxed) => {
+  const dateFormat = boxed && boxed.value.dateFormat();
+  if (dateFormat) {
+    return formatDate(value.value.toDate(), dateFormat);
+  } else {
+    return value.value.toString();
+  }
+};
+
 widgetRegistry.register("Date", {
-  Chart: (value) => value.value.toString(),
+  Preview: (value, boxed) => showDate(value, boxed),
+  Chart: (value, _, boxed) => showDate(value, boxed),
 });

--- a/packages/components/src/widgets/DateWidget.tsx
+++ b/packages/components/src/widgets/DateWidget.tsx
@@ -1,7 +1,5 @@
-import {
-  SqBoxedValue,
-  SqDateValue,
-} from "../../../squiggle-lang/src/public/SqValue/index.js";
+import { SqBoxedValue, SqDateValue } from "@quri/squiggle-lang";
+
 import { formatDate } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 

--- a/packages/components/src/widgets/DistWidget/SummaryTable.tsx
+++ b/packages/components/src/widgets/DistWidget/SummaryTable.tsx
@@ -15,7 +15,7 @@ import {
 import { TextTooltip } from "@quri/ui";
 
 import { NumberShower } from "../../components/NumberShower.js";
-import { DEFAULT_DATE_FORMAT } from "../../lib/constants.js";
+import { formatDate } from "../../lib/d3/index.js";
 import { useSetVerticalLine } from "./DistProvider.js";
 
 type HoverableCellProps = PropsWithChildren<{
@@ -76,9 +76,7 @@ const SummaryTableRow: FC<SummaryTableRowProps> = ({
       if (isRange) {
         return SDuration.fromMs(number).toString();
       } else {
-        return d3.timeFormat(tickFormat ?? DEFAULT_DATE_FORMAT)(
-          new Date(number)
-        );
+        return formatDate(new Date(number), tickFormat);
       }
     } else if (tickFormat) {
       return d3.format(tickFormat)(number);

--- a/packages/components/src/widgets/DistWidget/index.tsx
+++ b/packages/components/src/widgets/DistWidget/index.tsx
@@ -17,7 +17,7 @@ widgetRegistry.register("Dist", {
   Preview(value, boxed) {
     const dist = value.value;
     const environment = value.context.project.getEnvironment();
-    const numberFormat = boxed && boxed.value.numberFormat();
+    const numberFormat = boxed?.value.numberFormat();
 
     const showNumber = (number: number) => {
       return numberFormat ? (
@@ -54,7 +54,7 @@ widgetRegistry.register("Dist", {
     );
   },
   Chart(value, settings, boxed) {
-    const numberFormat = boxed && boxed.value.numberFormat();
+    const numberFormat = boxed?.value.numberFormat();
     const plot = SqDistributionsPlot.create({
       distribution: value.value,
       ...generateDistributionPlotSettings(

--- a/packages/components/src/widgets/DurationWidget.tsx
+++ b/packages/components/src/widgets/DurationWidget.tsx
@@ -9,10 +9,7 @@ import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 import { leftWidgetMargin } from "./utils.js";
 
-const showDuration = (
-  duration: SqDurationValue,
-  boxed: SqBoxedValue | undefined
-) => {
+const showDuration = (duration: SqDurationValue, boxed?: SqBoxedValue) => {
   const numberFormat = boxed?.value.numberFormat();
   const { unitName, value } = duration.toUnitAndNumber();
   if (numberFormat) {

--- a/packages/components/src/widgets/DurationWidget.tsx
+++ b/packages/components/src/widgets/DurationWidget.tsx
@@ -1,5 +1,34 @@
+import { clsx } from "clsx";
+
+import {
+  SqBoxedValue,
+  SqDurationValue,
+} from "../../../squiggle-lang/src/public/SqValue/index.js";
+import { NumberShower } from "../components/NumberShower.js";
+import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
+import { leftWidgetMargin } from "./utils.js";
+
+const showDuration = (
+  duration: SqDurationValue,
+  boxed: SqBoxedValue | undefined
+) => {
+  const numberFormat = boxed?.value.numberFormat();
+  const { unitName, value } = duration.toUnitAndNumber();
+  if (numberFormat) {
+    return `${formatNumber(numberFormat, value)} ${unitName}s`;
+  } else {
+    return <NumberShower precision={4} number={value} unitName={unitName} />;
+  }
+};
 
 widgetRegistry.register("Duration", {
-  Chart: (value) => value.toString(),
+  Preview: (value, boxed) => showDuration(value, boxed),
+  Chart: (value, _, boxed) => {
+    return (
+      <div className={clsx("font-semibold text-indigo-800", leftWidgetMargin)}>
+        {showDuration(value, boxed)}
+      </div>
+    );
+  },
 });

--- a/packages/components/src/widgets/DurationWidget.tsx
+++ b/packages/components/src/widgets/DurationWidget.tsx
@@ -1,9 +1,7 @@
 import { clsx } from "clsx";
 
-import {
-  SqBoxedValue,
-  SqDurationValue,
-} from "../../../squiggle-lang/src/public/SqValue/index.js";
+import { SqBoxedValue, SqDurationValue } from "@quri/squiggle-lang";
+
 import { NumberShower } from "../components/NumberShower.js";
 import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";

--- a/packages/components/src/widgets/NumberWidget.tsx
+++ b/packages/components/src/widgets/NumberWidget.tsx
@@ -1,14 +1,27 @@
 import { clsx } from "clsx";
+import * as d3 from "d3";
 
+import { SqNumberValue } from "@quri/squiggle-lang";
+
+import { SqBoxedValue } from "../../../squiggle-lang/src/public/SqValue/index.js";
 import { NumberShower } from "../components/NumberShower.js";
 import { widgetRegistry } from "./registry.js";
 import { leftWidgetMargin } from "./utils.js";
 
+const insideValue = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
+  const numberFormat = boxed && boxed.value.numberFormat();
+  if (numberFormat) {
+    return d3.format(numberFormat)(value.value);
+  } else {
+    return <NumberShower precision={4} number={value.value} />;
+  }
+};
+
 widgetRegistry.register("Number", {
-  Preview: (value) => <NumberShower precision={4} number={value.value} />,
-  Chart: (value) => (
+  Preview: (value, boxed) => insideValue(value, boxed),
+  Chart: (value, _, boxed) => (
     <div className={clsx("font-semibold text-indigo-800", leftWidgetMargin)}>
-      <NumberShower precision={4} number={value.value} />
+      {insideValue(value, boxed)}
     </div>
   ),
 });

--- a/packages/components/src/widgets/NumberWidget.tsx
+++ b/packages/components/src/widgets/NumberWidget.tsx
@@ -8,7 +8,7 @@ import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 import { leftWidgetMargin } from "./utils.js";
 
-const showNumber = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
+const showNumber = (value: SqNumberValue, boxed?: SqBoxedValue) => {
   const numberFormat = boxed?.value.numberFormat();
   if (numberFormat) {
     return formatNumber(numberFormat, value.value);

--- a/packages/components/src/widgets/NumberWidget.tsx
+++ b/packages/components/src/widgets/NumberWidget.tsx
@@ -9,7 +9,7 @@ import { widgetRegistry } from "./registry.js";
 import { leftWidgetMargin } from "./utils.js";
 
 const showNumber = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
-  const numberFormat = boxed && boxed.value.numberFormat();
+  const numberFormat = boxed?.value.numberFormat();
   if (numberFormat) {
     return formatNumber(numberFormat, value.value);
   } else {

--- a/packages/components/src/widgets/NumberWidget.tsx
+++ b/packages/components/src/widgets/NumberWidget.tsx
@@ -1,17 +1,17 @@
 import { clsx } from "clsx";
-import * as d3 from "d3";
 
 import { SqNumberValue } from "@quri/squiggle-lang";
 
 import { SqBoxedValue } from "../../../squiggle-lang/src/public/SqValue/index.js";
 import { NumberShower } from "../components/NumberShower.js";
+import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 import { leftWidgetMargin } from "./utils.js";
 
 const insideValue = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
   const numberFormat = boxed && boxed.value.numberFormat();
   if (numberFormat) {
-    return d3.format(numberFormat)(value.value);
+    return formatNumber(numberFormat, value.value);
   } else {
     return <NumberShower precision={4} number={value.value} />;
   }

--- a/packages/components/src/widgets/NumberWidget.tsx
+++ b/packages/components/src/widgets/NumberWidget.tsx
@@ -8,7 +8,7 @@ import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";
 import { leftWidgetMargin } from "./utils.js";
 
-const insideValue = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
+const showNumber = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
   const numberFormat = boxed && boxed.value.numberFormat();
   if (numberFormat) {
     return formatNumber(numberFormat, value.value);
@@ -18,10 +18,10 @@ const insideValue = (value: SqNumberValue, boxed: SqBoxedValue | undefined) => {
 };
 
 widgetRegistry.register("Number", {
-  Preview: (value, boxed) => insideValue(value, boxed),
+  Preview: (value, boxed) => showNumber(value, boxed),
   Chart: (value, _, boxed) => (
     <div className={clsx("font-semibold text-indigo-800", leftWidgetMargin)}>
-      {insideValue(value, boxed)}
+      {showNumber(value, boxed)}
     </div>
   ),
 });

--- a/packages/components/src/widgets/NumberWidget.tsx
+++ b/packages/components/src/widgets/NumberWidget.tsx
@@ -1,8 +1,7 @@
 import { clsx } from "clsx";
 
-import { SqNumberValue } from "@quri/squiggle-lang";
+import { SqBoxedValue, SqNumberValue } from "@quri/squiggle-lang";
 
-import { SqBoxedValue } from "../../../squiggle-lang/src/public/SqValue/index.js";
 import { NumberShower } from "../components/NumberShower.js";
 import { formatNumber } from "../lib/d3/index.js";
 import { widgetRegistry } from "./registry.js";

--- a/packages/components/src/widgets/registry.ts
+++ b/packages/components/src/widgets/registry.ts
@@ -2,6 +2,7 @@ import { FC, ReactNode } from "react";
 
 import { SqValue } from "@quri/squiggle-lang";
 
+import { SqBoxedValue } from "../../../squiggle-lang/src/public/SqValue/index.js";
 import { PlaygroundSettings } from "../components/PlaygroundSettings.js";
 import { SqValueWithContext } from "../lib/utility.js";
 
@@ -13,8 +14,9 @@ type Widget<T extends SqValueTag = SqValueTag> = {
   Chart: FC<{
     value: Extract<SqValueWithContext, { tag: T }>;
     settings: PlaygroundSettings;
+    boxed: SqBoxedValue | undefined;
   }>;
-  Preview?: FC<{ value: ValueByTag<T> }>;
+  Preview?: FC<{ value: ValueByTag<T>; boxed: SqBoxedValue | undefined }>;
   Menu?: FC<{
     value: ValueByTag<T>;
   }>;
@@ -24,11 +26,12 @@ type Widget<T extends SqValueTag = SqValueTag> = {
 type WidgetConfig<T extends SqValueTag = SqValueTag> = {
   Chart(
     value: Extract<SqValueWithContext, { tag: T }>,
-    settings: PlaygroundSettings
+    settings: PlaygroundSettings,
+    boxed?: SqBoxedValue
   ): ReactNode;
-  Preview?: (value: ValueByTag<T>) => ReactNode;
-  Menu?: (value: ValueByTag<T>) => ReactNode;
-  heading?: (value: ValueByTag<T>) => string;
+  Preview?: (value: ValueByTag<T>, boxed?: SqBoxedValue) => ReactNode;
+  Menu?: (value: ValueByTag<T>, boxed?: SqBoxedValue) => ReactNode;
+  heading?: (value: ValueByTag<T>, boxed?: SqBoxedValue) => string;
 };
 
 class WidgetRegistry {
@@ -39,11 +42,11 @@ class WidgetRegistry {
     // It's not perfect but type-unsafe parts are contained in a few helper components such as `SquiggleValueChart`.
 
     const widget: Widget = {
-      Chart: ({ value, settings }) => {
+      Chart: ({ value, settings, boxed }) => {
         if (value.tag !== tag) {
           throw new Error(`${tag} widget used incorrectly`);
         }
-        return config.Chart(value as ValueByTag<T>, settings);
+        return config.Chart(value as ValueByTag<T>, settings, boxed);
       },
     };
     widget.Chart.displayName = `${tag}Chart`;
@@ -51,11 +54,11 @@ class WidgetRegistry {
     const { Preview, Menu, heading } = config;
 
     if (Preview) {
-      widget.Preview = ({ value }) => {
+      widget.Preview = ({ value, boxed }) => {
         if (value.tag !== tag) {
           throw new Error(`${tag} widget used incorrectly`);
         }
-        return Preview(value as ValueByTag<T>);
+        return Preview(value as ValueByTag<T>, boxed);
       };
       widget.Preview.displayName = `${tag}Preview`;
     }

--- a/packages/components/src/widgets/registry.ts
+++ b/packages/components/src/widgets/registry.ts
@@ -14,9 +14,9 @@ type Widget<T extends SqValueTag = SqValueTag> = {
   Chart: FC<{
     value: Extract<SqValueWithContext, { tag: T }>;
     settings: PlaygroundSettings;
-    boxed: SqBoxedValue | undefined;
+    boxed?: SqBoxedValue;
   }>;
-  Preview?: FC<{ value: ValueByTag<T>; boxed: SqBoxedValue | undefined }>;
+  Preview?: FC<{ value: ValueByTag<T>; boxed?: SqBoxedValue }>;
   Menu?: FC<{
     value: ValueByTag<T>;
   }>;

--- a/packages/components/src/widgets/registry.ts
+++ b/packages/components/src/widgets/registry.ts
@@ -1,8 +1,7 @@
 import { FC, ReactNode } from "react";
 
-import { SqValue } from "@quri/squiggle-lang";
+import { SqBoxedValue, SqValue } from "@quri/squiggle-lang";
 
-import { SqBoxedValue } from "../../../squiggle-lang/src/public/SqValue/index.js";
 import { PlaygroundSettings } from "../components/PlaygroundSettings.js";
 import { SqValueWithContext } from "../lib/utility.js";
 

--- a/packages/squiggle-lang/src/fr/scale.ts
+++ b/packages/squiggle-lang/src/fr/scale.ts
@@ -8,7 +8,10 @@ import {
   frScale,
   frString,
 } from "../library/registry/frTypes.js";
-import { FnFactory } from "../library/registry/helpers.js";
+import {
+  checkNumericTickFormat,
+  FnFactory,
+} from "../library/registry/helpers.js";
 import { SDate } from "../utility/SDate.js";
 
 const maker = new FnFactory({
@@ -46,17 +49,6 @@ function checkMinMaxDates(min: SDate | null, max: SDate | null) {
   }
 }
 
-// Regex taken from d3-format.
-// https://github.com/d3/d3-format/blob/f3cb31091df80a08f25afd4a7af2dcb3a6cd5eef/src/formatSpecifier.js#L1C65-L2C85
-const d3TickFormatRegex =
-  /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
-
-function checkTickFormat(tickFormat: string | null) {
-  if (tickFormat && !d3TickFormatRegex.test(tickFormat)) {
-    throw new REArgumentError(`Tick format [${tickFormat}] is invalid.`);
-  }
-}
-
 export const library = [
   maker.make({
     name: "linear",
@@ -68,7 +60,7 @@ export const library = [
         frScale,
         ([{ min, max, tickFormat, title }]) => {
           checkMinMax(min, max);
-          checkTickFormat(tickFormat);
+          checkNumericTickFormat(tickFormat);
           return {
             type: "linear",
             min: min ?? undefined,
@@ -96,7 +88,7 @@ export const library = [
             throw new REOther(`Min must be over 0 for log scale, got: ${min}`);
           }
           checkMinMax(min, max);
-          checkTickFormat(tickFormat);
+          checkNumericTickFormat(tickFormat);
           return {
             type: "log",
             min: min ?? undefined,
@@ -129,7 +121,7 @@ export const library = [
         frScale,
         ([{ min, max, tickFormat, title, constant }]) => {
           checkMinMax(min, max);
-          checkTickFormat(tickFormat);
+          checkNumericTickFormat(tickFormat);
           if (constant !== null && constant === 0) {
             throw new REOther(`Symlog scale constant cannot be 0.`);
           }
@@ -169,7 +161,7 @@ export const library = [
         frScale,
         ([{ min, max, tickFormat, title, exponent }]) => {
           checkMinMax(min, max);
-          checkTickFormat(tickFormat);
+          checkNumericTickFormat(tickFormat);
           if (exponent !== null && exponent <= 0) {
             throw new REOther(`Power Scale exponent must be over 0.`);
           }

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -4,12 +4,14 @@ import {
   frAny,
   frArray,
   frCalculator,
+  frDate,
   frDictWithArbitraryKeys,
   frDist,
   frDistOrNumber,
   frForceBoxed,
   frLambda,
   frLambdaTyped,
+  frNamed,
   frNumber,
   frOr,
   FrOrType,
@@ -148,15 +150,23 @@ export const library = [
     examples: [],
     definitions: [
       makeDefinition(
-        [frForceBoxed(frDistOrNumber), frString],
+        [frForceBoxed(frDistOrNumber), frNamed("numberFormat", frString)],
         frForceBoxed(frDistOrNumber),
         ([{ args, value }, format]) => {
           checkTickFormat(format);
           return { args: args.merge({ numberFormat: format }), value };
         }
       ),
+      makeDefinition(
+        [frForceBoxed(frDate), frNamed("timeFormat", frString)],
+        frForceBoxed(frDate),
+        ([{ args, value }, format]) => {
+          return { args: args.merge({ dateFormat: format }), value };
+        }
+      ),
     ],
   }),
+
   maker.make({
     name: "all",
     examples: [],

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -1,4 +1,3 @@
-import { REArgumentError } from "../errors/messages.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
 import {
   frAny,
@@ -20,7 +19,10 @@ import {
   frTableChart,
   FRType,
 } from "../library/registry/frTypes.js";
-import { FnFactory } from "../library/registry/helpers.js";
+import {
+  checkNumericTickFormat,
+  FnFactory,
+} from "../library/registry/helpers.js";
 import { Lambda } from "../reducer/lambda.js";
 import { Boxed } from "../value/boxed.js";
 import { Value, vBoxed, vString } from "../value/index.js";
@@ -70,15 +72,6 @@ function withInputOrFnInput<T>(inputType: FRType<any>, outputType: FRType<T>) {
       };
     }
   );
-}
-
-const d3TickFormatRegex =
-  /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
-
-function checkTickFormat(tickFormat: string | null) {
-  if (tickFormat && !d3TickFormatRegex.test(tickFormat)) {
-    throw new REArgumentError(`Tick format [${tickFormat}] is invalid.`);
-  }
 }
 
 export const library = [
@@ -153,7 +146,7 @@ export const library = [
         [frForceBoxed(frDistOrNumber), frNamed("numberFormat", frString)],
         frForceBoxed(frDistOrNumber),
         ([{ args, value }, format]) => {
-          checkTickFormat(format);
+          checkNumericTickFormat(format);
           return { args: args.merge({ numberFormat: format }), value };
         }
       ),

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -7,6 +7,7 @@ import {
   frDictWithArbitraryKeys,
   frDist,
   frDistOrNumber,
+  frDuration,
   frForceBoxed,
   frLambda,
   frLambdaTyped,
@@ -145,6 +146,14 @@ export const library = [
       makeDefinition(
         [frForceBoxed(frDistOrNumber), frNamed("numberFormat", frString)],
         frForceBoxed(frDistOrNumber),
+        ([{ args, value }, format]) => {
+          checkNumericTickFormat(format);
+          return { args: args.merge({ numberFormat: format }), value };
+        }
+      ),
+      makeDefinition(
+        [frForceBoxed(frDuration), frNamed("numberFormat", frString)],
+        frForceBoxed(frDuration),
         ([{ args, value }, format]) => {
           checkNumericTickFormat(format);
           return { args: args.merge({ numberFormat: format }), value };

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -1,3 +1,4 @@
+import { REArgumentError } from "../errors/messages.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
 import {
   frAny,
@@ -69,6 +70,15 @@ function withInputOrFnInput<T>(inputType: FRType<any>, outputType: FRType<T>) {
   );
 }
 
+const d3TickFormatRegex =
+  /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+
+function checkTickFormat(tickFormat: string | null) {
+  if (tickFormat && !d3TickFormatRegex.test(tickFormat)) {
+    throw new REArgumentError(`Tick format [${tickFormat}] is invalid.`);
+  }
+}
+
 export const library = [
   maker.make({
     name: "name",
@@ -131,6 +141,20 @@ export const library = [
       makeDefinition([frForceBoxed(frAny())], frAny(), ([{ args, value }]) => {
         return args.value.showAs || vString("None"); // Not sure what to use when blank.
       }),
+    ],
+  }),
+  maker.make({
+    name: "format",
+    examples: [],
+    definitions: [
+      makeDefinition(
+        [frForceBoxed(frDistOrNumber), frString],
+        frForceBoxed(frDistOrNumber),
+        ([{ args, value }, format]) => {
+          checkTickFormat(format);
+          return { args: args.merge({ numberFormat: format }), value };
+        }
+      ),
     ],
   }),
   maker.make({

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -71,7 +71,13 @@ export { parse } from "./public/parse.js";
 export { fmap as resultMap, type result } from "./utility/result.js";
 
 export { SDate } from "./utility/SDate.js";
-export { SDuration } from "./utility/SDuration.js";
+
+export {
+  type DurationUnitName,
+  durationUnits,
+  SDuration,
+} from "./utility/SDuration.js";
+
 export { type LocationRange as SqLocation } from "peggy";
 export { defaultEnv as defaultEnvironment } from "./dist/env.js";
 export {

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -2,7 +2,9 @@ import { type Env } from "./dist/env.js";
 import { registry } from "./library/registry/index.js";
 import { SqProject } from "./public/SqProject/index.js";
 import {
+  SqBoxedValue,
   SqDateValue,
+  SqDurationValue,
   SqLambdaValue,
   SqNumberValue,
   SqStringValue,
@@ -82,7 +84,9 @@ export { type LocationRange as SqLocation } from "peggy";
 export { defaultEnv as defaultEnvironment } from "./dist/env.js";
 export {
   type Env,
+  SqBoxedValue,
   SqDateValue,
+  SqDurationValue,
   SqLambdaValue,
   SqNumberValue,
   SqProject,

--- a/packages/squiggle-lang/src/library/registry/helpers.ts
+++ b/packages/squiggle-lang/src/library/registry/helpers.ts
@@ -8,6 +8,7 @@ import * as SampleSetDist from "../../dist/SampleSetDist/index.js";
 import * as SymbolicDist from "../../dist/SymbolicDist.js";
 import { PointMass } from "../../dist/SymbolicDist.js";
 import {
+  REArgumentError,
   REDistributionError,
   REOperationError,
   REOther,
@@ -466,3 +467,14 @@ export const frTypesMatchesLengths = (
   const max = inputs.length;
   return intersection(upTo(min, max), lengths).length > 0;
 };
+
+// Regex taken from d3-format.
+// https://github.com/d3/d3-format/blob/f3cb31091df80a08f25afd4a7af2dcb3a6cd5eef/src/formatSpecifier.js#L1C65-L2C85
+const d3TickFormatRegex =
+  /^(?:(.)?([<>=^]))?([+\-( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?(~)?([a-z%])?$/i;
+
+export function checkNumericTickFormat(tickFormat: string | null) {
+  if (tickFormat && !d3TickFormatRegex.test(tickFormat)) {
+    throw new REArgumentError(`Tick format [${tickFormat}] is invalid.`);
+  }
+}

--- a/packages/squiggle-lang/src/public/SqValue/SqBoxed.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqBoxed.ts
@@ -30,4 +30,8 @@ export class SqBoxed {
   numberFormat(): string | undefined {
     return this.args.numberFormat();
   }
+
+  dateFormat(): string | undefined {
+    return this.args.dateFormat();
+  }
 }

--- a/packages/squiggle-lang/src/public/SqValue/SqBoxed.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqBoxed.ts
@@ -1,7 +1,7 @@
+import { BoxedArgs } from "../../value/boxed.js";
 import { Value } from "../../value/index.js";
 import { SqValueContext } from "../SqValueContext.js";
 import { SqValue, wrapValue } from "./index.js";
-import { BoxedArgs } from "../../value/boxed.js";
 
 export class SqBoxed {
   constructor(
@@ -25,5 +25,9 @@ export class SqBoxed {
   showAs(): SqValue | undefined {
     const showAs = this.args.showAs();
     return showAs ? wrapValue(showAs, this.context) : undefined;
+  }
+
+  numberFormat(): string | undefined {
+    return this.args.numberFormat();
   }
 }

--- a/packages/squiggle-lang/src/public/SqValue/index.ts
+++ b/packages/squiggle-lang/src/public/SqValue/index.ts
@@ -206,6 +206,10 @@ export class SqDurationValue extends SqAbstractValue<"Duration", number> {
     return this._value.value;
   }
 
+  toUnitAndNumber() {
+    return this._value.value.toUnitAndNumber();
+  }
+
   asJS() {
     return this._value.value.toMs();
   }

--- a/packages/squiggle-lang/src/utility/SDate.ts
+++ b/packages/squiggle-lang/src/utility/SDate.ts
@@ -35,7 +35,7 @@ export class SDate {
     return Result.fmap(makeWithYearInt(floor), (earlyDate) => {
       const diff = year - floor;
       return new SDate(earlyDate).addDuration(
-        SDuration.fromMs(diff * durationUnits.Year)
+        SDuration.fromMs(diff * durationUnits.Year.ms)
       );
     });
   }

--- a/packages/squiggle-lang/src/utility/SDuration.ts
+++ b/packages/squiggle-lang/src/utility/SDuration.ts
@@ -52,7 +52,7 @@ export class SDuration {
     return this.ms / durationUnits.Year;
   }
 
-  toString(): string {
+  toUnitAndNumber(): { value: number; unitName: string } {
     const units: [number, string][] = [
       [durationUnits.Year, "year"],
       [durationUnits.Day, "day"],
@@ -64,12 +64,16 @@ export class SDuration {
     for (const [unitValue, unitName] of units) {
       if (Math.abs(this.ms) >= unitValue) {
         const value = this.ms / unitValue;
-        const suffix = value !== 1.0 ? "s" : "";
-        return `${value.toPrecision(3)} ${unitName}${suffix}`;
+        return { unitName, value };
       }
     }
+    return { unitName: "ms", value: this.ms };
+  }
 
-    return `${this.ms.toFixed()} ms`;
+  toString(): string {
+    const { unitName, value } = this.toUnitAndNumber();
+    const suffix = value !== 1.0 ? "s" : "";
+    return `${value.toPrecision(3)} ${unitName}${suffix}`;
   }
 
   add(other: SDuration): SDuration {

--- a/packages/squiggle-lang/src/utility/SDuration.ts
+++ b/packages/squiggle-lang/src/utility/SDuration.ts
@@ -1,10 +1,30 @@
 export const durationUnits = {
-  Second: 1000,
-  Minute: 60 * 1000,
-  Hour: 60 * 60 * 1000,
-  Day: 24 * 60 * 60 * 1000,
-  Year: 24 * 60 * 60 * 1000 * 365.25,
-} as const;
+  Millisecond: { ms: 1, name: "ms", plural: "ms" },
+  Second: { ms: 1000, name: "second", plural: "seconds" },
+  Minute: { ms: 60 * 1000, name: "minute", plural: "minutes" },
+  Hour: { ms: 60 * 60 * 1000, name: "hour", plural: "hours" },
+  Day: { ms: 24 * 60 * 60 * 1000, name: "day", plural: "days" },
+  Year: { ms: 24 * 60 * 60 * 1000 * 365.25, name: "year", plural: "years" },
+};
+
+export type DurationUnitName = keyof typeof durationUnits;
+
+export function msToGreatestUnit(msTotal: number): {
+  value: number;
+  unitName: DurationUnitName;
+} {
+  for (const unitName of Object.keys(durationUnits)
+    .filter((r) => r !== "Millisecond")
+    .reverse()) {
+    const _unitName = unitName as DurationUnitName;
+    const { ms } = durationUnits[_unitName];
+    if (Math.abs(msTotal) >= ms) {
+      const value = msTotal / ms;
+      return { unitName: _unitName, value };
+    }
+  }
+  return { unitName: "Millisecond", value: msTotal };
+}
 
 //This is our own internal date duration class. It's used by the interpreter, but meant to act like a simple date library.
 export class SDuration {
@@ -17,19 +37,19 @@ export class SDuration {
   }
 
   static fromMinutes(minutes: number): SDuration {
-    return new SDuration(minutes * durationUnits.Minute);
+    return new SDuration(minutes * durationUnits.Minute.ms);
   }
 
   static fromHours(hours: number): SDuration {
-    return new SDuration(hours * durationUnits.Hour);
+    return new SDuration(hours * durationUnits.Hour.ms);
   }
 
   static fromDays(days: number): SDuration {
-    return new SDuration(days * durationUnits.Day);
+    return new SDuration(days * durationUnits.Day.ms);
   }
 
   static fromYears(years: number): SDuration {
-    return new SDuration(years * durationUnits.Year);
+    return new SDuration(years * durationUnits.Year.ms);
   }
 
   toMs(): number {
@@ -37,43 +57,29 @@ export class SDuration {
   }
 
   toMinutes(): number {
-    return this.ms / durationUnits.Minute;
+    return this.ms / durationUnits.Minute.ms;
   }
 
   toHours(): number {
-    return this.ms / durationUnits.Hour;
+    return this.ms / durationUnits.Hour.ms;
   }
 
   toDays(): number {
-    return this.ms / durationUnits.Day;
+    return this.ms / durationUnits.Day.ms;
   }
 
   toYears(): number {
-    return this.ms / durationUnits.Year;
+    return this.ms / durationUnits.Year.ms;
   }
 
-  toUnitAndNumber(): { value: number; unitName: string } {
-    const units: [number, string][] = [
-      [durationUnits.Year, "year"],
-      [durationUnits.Day, "day"],
-      [durationUnits.Hour, "hour"],
-      [durationUnits.Minute, "minute"],
-      [durationUnits.Second, "second"],
-    ];
-
-    for (const [unitValue, unitName] of units) {
-      if (Math.abs(this.ms) >= unitValue) {
-        const value = this.ms / unitValue;
-        return { unitName, value };
-      }
-    }
-    return { unitName: "ms", value: this.ms };
+  toUnitAndNumber(): { value: number; unitName: DurationUnitName } {
+    return msToGreatestUnit(this.ms);
   }
 
   toString(): string {
     const { unitName, value } = this.toUnitAndNumber();
-    const suffix = value !== 1.0 ? "s" : "";
-    return `${value.toPrecision(3)} ${unitName}${suffix}`;
+    const suffix = value !== 1.0 ? durationUnits[unitName].plural : "";
+    return `${value.toPrecision(3)} ${suffix}`;
   }
 
   add(other: SDuration): SDuration {

--- a/packages/squiggle-lang/src/value/boxed.ts
+++ b/packages/squiggle-lang/src/value/boxed.ts
@@ -5,6 +5,7 @@ export type BoxedArgsType = {
   name?: string;
   description?: string;
   showAs?: Value;
+  numberFormat?: string;
 };
 
 //I expect these to get much more complicated later, so it seemed prudent to make a class now.
@@ -22,6 +23,9 @@ export class BoxedArgs {
     }
     if (value.showAs) {
       result.push(["showAs", value.showAs]);
+    }
+    if (value.numberFormat) {
+      result.push(["numberFormat", vString(value.numberFormat)]);
     }
     return result;
   }
@@ -53,6 +57,10 @@ export class BoxedArgs {
 
   showAs() {
     return this.value.showAs;
+  }
+
+  numberFormat() {
+    return this.value.numberFormat;
   }
 }
 

--- a/packages/squiggle-lang/src/value/boxed.ts
+++ b/packages/squiggle-lang/src/value/boxed.ts
@@ -6,6 +6,7 @@ export type BoxedArgsType = {
   description?: string;
   showAs?: Value;
   numberFormat?: string;
+  dateFormat?: string;
 };
 
 //I expect these to get much more complicated later, so it seemed prudent to make a class now.
@@ -26,6 +27,9 @@ export class BoxedArgs {
     }
     if (value.numberFormat) {
       result.push(["numberFormat", vString(value.numberFormat)]);
+    }
+    if (value.dateFormat) {
+      result.push(["dateFormat", vString(value.dateFormat)]);
     }
     return result;
   }
@@ -61,6 +65,10 @@ export class BoxedArgs {
 
   numberFormat() {
     return this.value.numberFormat;
+  }
+
+  dateFormat() {
+    return this.value.dateFormat;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/quantified-uncertainty/squiggle/issues/2672

This adds  ``Tag.format`` to Numbers, Dists, and Dates, and Durations.

Gets saves as ``numericFormat`` for numbers/dists/durations, but as a ``timeFormat`` for Dates. 

I think this PR is fairly awkward for a few reasons.
1. Boxed API in components and widgets
2. Awkward that the Tag() interface is very type-specific.
3. Awkward that we're using one Tag object, instead of type-specific objects.

I suggest we implement this now but treat it as experimental. Later on it would be good to refactor, but I want to wait until we have a better idea of how to take this. 

This depends on https://github.com/quantified-uncertainty/squiggle/pull/2667