### PR TITLE
Tag.focus()

### DIFF
--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -130,19 +130,19 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
   const isFocused = useIsFocused(path);
 
   const isRoot = path.isRoot();
-  const boxedName = tag === "Boxed" ? value.value.name() : undefined;
-  const boxedFocus = tag === "Boxed" ? value.value.focus() : undefined;
+  const taggedName = tag === "Boxed" ? value.value.name() : undefined;
+  const taggedFocus = tag === "Boxed" ? value.value.focus() : undefined;
 
   useEffect(() => {
     const localItemState = getLocalItemState({ path });
-    const alreadyFocusedWithTag = localItemState.hasFocusedWithTag;
-    if (boxedFocus && !alreadyFocusedWithTag) {
+    const previouslyFocusedWithTag = localItemState.hasFocusedWithTag;
+    if (taggedFocus && !previouslyFocusedWithTag) {
       focusWithTag(path);
-    } else if (!boxedFocus && alreadyFocusedWithTag && isFocused) {
+    } else if (!taggedFocus && previouslyFocusedWithTag && isFocused) {
       unfocusWithTag(path);
     }
   }, [
-    boxedFocus,
+    taggedFocus,
     path,
     isFocused,
     getLocalItemState,
@@ -210,10 +210,10 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
   const name = pathToShortName(path);
   const headerName = (
     <div
-      className={clsx(!boxedName && "font-mono", headerClasses())}
+      className={clsx(!taggedName && "font-mono", headerClasses())}
       onClick={_focus}
     >
-      {boxedName ? boxedName : name}
+      {taggedName ? taggedName : name}
     </div>
   );
 

--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -2,7 +2,7 @@
 import "../../widgets/index.js";
 
 import { clsx } from "clsx";
-import { FC, PropsWithChildren, useMemo, useState } from "react";
+import { FC, PropsWithChildren, useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { CommentIcon, TextTooltip } from "@quri/ui";
@@ -24,6 +24,7 @@ import {
   useRegisterAsItemViewer,
   useSetCollapsed,
   useToggleCollapsed,
+  useUnfocus,
   useViewerContext,
 } from "./ViewerProvider.js";
 
@@ -122,11 +123,23 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
   const setCollapsed = useSetCollapsed();
   const collapseChildren = useCollapseChildren();
   const focus = useFocus();
+  const unFocus = useUnfocus();
   const { getLocalItemState } = useViewerContext();
   const isFocused = useIsFocused(path);
 
   const isRoot = path.isRoot();
   const boxedName = tag === "Boxed" ? value.value.name() : undefined;
+  const [prevBoxedName] = useState(boxedName);
+
+  useEffect(() => {
+    if (prevBoxedName !== boxedName) {
+      if (boxedName === "HI") {
+        focus(path);
+      } else if (prevBoxedName === "HI") {
+        unFocus();
+      }
+    }
+  }, [boxedName, focus, path, prevBoxedName, unFocus]);
 
   // Collapse children and element if desired. Uses crude heuristics.
   // TODO - this code has side effects, it'd be better if we ran it somewhere else, e.g. traverse values recursively when `ViewerProvider` is initialized.

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -55,13 +55,6 @@ export type Action =
       };
     }
   | {
-      type: "SET_FOCUSED_WITH_TAG";
-      payload: {
-        path: SqValuePath;
-        value: boolean;
-      };
-    }
-  | {
       type: "FOCUS";
       payload: {
         path: SqValuePath;
@@ -407,8 +400,7 @@ export const ViewerProvider: FC<
           forceUpdate(action.payload.path);
           return;
         case "FOCUS": {
-          const { path } = action.payload;
-          setFocused(path);
+          setFocused(action.payload.path);
           return;
         }
         case "UNFOCUS": {

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -118,13 +118,13 @@ noShow1 = false
 noShow2 = false
 
 /*** Triple stars are forbidden too; again, JSDoc convention. */
-noShow2 = false
+noShow3 = false
 
 /** This comment won't show because \`show2\` is shadowed */
 show2 = false
 
 /** If variable is redefined, we attach the last comment */
-show2 = true
+show3 = true
 
 /** line 1 */
 /** line 2 - only this line will be shown */

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -20,7 +20,7 @@ import {
 import { FnFactory } from "../library/registry/helpers.js";
 import { Lambda } from "../reducer/lambda.js";
 import { Boxed } from "../value/boxed.js";
-import { Value, vBoxed, vString } from "../value/index.js";
+import { Value, vBool, vBoxed, vString } from "../value/index.js";
 
 const maker = new FnFactory({
   nameSpace: "Tag",
@@ -128,9 +128,35 @@ export const library = [
     name: "getShowAs",
     examples: [],
     definitions: [
-      makeDefinition([frForceBoxed(frAny())], frAny(), ([{ args, value }]) => {
+      makeDefinition([frForceBoxed(frAny())], frAny(), ([{ args }]) => {
         return args.value.showAs || vString("None"); // Not sure what to use when blank.
       }),
+    ],
+  }),
+  maker.make({
+    name: "focus",
+    examples: [],
+    definitions: [
+      makeDefinition(
+        [frForceBoxed(frAny({ genericName: "A" }))],
+        frForceBoxed(frAny({ genericName: "A" })),
+        ([{ args, value }]) => {
+          return { value: value, args: args.merge({ focus: true }) };
+        }
+      ),
+    ],
+  }),
+  maker.make({
+    name: "getFocus",
+    examples: [],
+    definitions: [
+      makeDefinition(
+        [frForceBoxed(frAny({ genericName: "A" }))],
+        frAny(),
+        ([{ args, value }]) => {
+          return args.value.focus ? vBool(true) : vString("None");
+        }
+      ),
     ],
   }),
   maker.make({

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -150,13 +150,9 @@ export const library = [
     name: "getFocus",
     examples: [],
     definitions: [
-      makeDefinition(
-        [frForceBoxed(frAny({ genericName: "A" }))],
-        frAny(),
-        ([{ args, value }]) => {
-          return args.value.focus ? vBool(true) : vString("None");
-        }
-      ),
+      makeDefinition([frForceBoxed(frAny())], frAny(), ([{ args, value }]) => {
+        return args.value.focus ? vBool(true) : vString("None");
+      }),
     ],
   }),
   maker.make({

--- a/packages/squiggle-lang/src/public/SqValue/SqBoxed.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqBoxed.ts
@@ -1,7 +1,7 @@
+import { BoxedArgs } from "../../value/boxed.js";
 import { Value } from "../../value/index.js";
 import { SqValueContext } from "../SqValueContext.js";
 import { SqValue, wrapValue } from "./index.js";
-import { BoxedArgs } from "../../value/boxed.js";
 
 export class SqBoxed {
   constructor(
@@ -25,5 +25,9 @@ export class SqBoxed {
   showAs(): SqValue | undefined {
     const showAs = this.args.showAs();
     return showAs ? wrapValue(showAs, this.context) : undefined;
+  }
+
+  focus(): true | undefined {
+    return this.args.value.focus;
   }
 }

--- a/packages/squiggle-lang/src/value/boxed.ts
+++ b/packages/squiggle-lang/src/value/boxed.ts
@@ -1,10 +1,11 @@
 import { ImmutableMap } from "../utility/immutableMap.js";
-import { Value, vString } from "./index.js";
+import { Value, vBool, vString } from "./index.js";
 
 export type BoxedArgsType = {
   name?: string;
   description?: string;
   showAs?: Value;
+  focus?: true;
 };
 
 //I expect these to get much more complicated later, so it seemed prudent to make a class now.
@@ -22,6 +23,9 @@ export class BoxedArgs {
     }
     if (value.showAs) {
       result.push(["showAs", value.showAs]);
+    }
+    if (value.focus) {
+      result.push(["focus", vBool(true)]);
     }
     return result;
   }


### PR DESCRIPTION
A new focus() tag, that makes a variable in question focused. 

The implementation is a bit janky. I'm not sure how used this will be - would like to put it out there and see if it seems to wok well. 