### PR TITLE
Tag percentages with certain format

### DIFF
--- a/.changeset/few-panthers-wonder.md
+++ b/.changeset/few-panthers-wonder.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Tag percentates with percentage format

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -48,7 +48,7 @@ describe("Peggy parse", () => {
   });
 
   describe("units", () => {
-    testEvalToBe("100%", "1");
+    testEvalToBe("100%", '1, with params numberFormat: ".2~p"');
     testEvalToBe("1-0%", "1");
   });
 

--- a/packages/squiggle-lang/src/fr/units.ts
+++ b/packages/squiggle-lang/src/fr/units.ts
@@ -15,7 +15,7 @@ const makeUnitFn = (
   format?: string
 ) => {
   return maker.make({
-    output: "Number",
+    output: format ? "Boxed" : "Number",
     name: "fromUnit_" + shortName,
     description: `Unit conversion from ${fullName}.`,
     examples: [`3${shortName} // ${3 * multiplier}`],
@@ -36,7 +36,7 @@ const makeUnitFn = (
 export const library = [
   makeUnitFn("n", "nano", 1e-9),
   makeUnitFn("m", "mili", 1e-3),
-  makeUnitFn("%", "percent", 1e-2, ".2%"),
+  makeUnitFn("%", "percent", 1e-2, ".2~p"),
   makeUnitFn("k", "kilo", 1e3),
   makeUnitFn("M", "mega", 1e6),
   makeUnitFn("B", "billion", 1e9),

--- a/packages/squiggle-lang/src/fr/units.ts
+++ b/packages/squiggle-lang/src/fr/units.ts
@@ -1,6 +1,7 @@
 import { makeDefinition } from "../library/registry/fnDefinition.js";
-import { frNumber } from "../library/registry/frTypes.js";
+import { frForceBoxed, frNumber } from "../library/registry/frTypes.js";
 import { FnFactory } from "../library/registry/helpers.js";
+import { BoxedArgs } from "../value/boxed.js";
 
 const maker = new FnFactory({
   nameSpace: "",
@@ -10,7 +11,8 @@ const maker = new FnFactory({
 const makeUnitFn = (
   shortName: string,
   fullName: string,
-  multiplier: number
+  multiplier: number,
+  format?: string
 ) => {
   return maker.make({
     output: "Number",
@@ -19,7 +21,14 @@ const makeUnitFn = (
     examples: [`3${shortName} // ${3 * multiplier}`],
     isUnit: true,
     definitions: [
-      makeDefinition([frNumber], frNumber, ([x]) => x * multiplier),
+      format
+        ? makeDefinition([frNumber], frForceBoxed(frNumber), ([x]) => {
+            return {
+              value: x * multiplier,
+              args: new BoxedArgs({ numberFormat: format }),
+            };
+          })
+        : makeDefinition([frNumber], frNumber, ([x]) => x * multiplier),
     ],
   });
 };
@@ -27,7 +36,7 @@ const makeUnitFn = (
 export const library = [
   makeUnitFn("n", "nano", 1e-9),
   makeUnitFn("m", "mili", 1e-3),
-  makeUnitFn("%", "percent", 1e-2),
+  makeUnitFn("%", "percent", 1e-2, ".2%"),
   makeUnitFn("k", "kilo", 1e3),
   makeUnitFn("M", "mega", 1e6),
   makeUnitFn("B", "billion", 1e9),


### PR DESCRIPTION
<img width="1290" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/7f14216f-3b4b-4302-bc3b-714209028255">

Pretty straightforward. I'm a bit nervous that this will have trouble for huge or tiny percentages, but as I think about it, that doesn't seem like a huge concern - I think we can deal with it later on, as needed. 