### PR TITLE
Viewer provider refactorings

### DIFF
--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -11,8 +11,19 @@ module.exports = {
     "plugin:@typescript-eslint/recommended",
   ],
   parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "@wogns3623/better-exhaustive-deps"],
   rules: {
+    "react-hooks/exhaustive-deps": "off",
+
+    "@wogns3623/better-exhaustive-deps/exhaustive-deps": [
+      "warn",
+      {
+        checkMemoizedVariableIsStatic: true,
+        staticHooks: {
+          useLazyRef: true,
+        },
+      },
+    ],
     "no-constant-condition": [
       "error",
       {

--- a/packages/components/.eslintrc.cjs
+++ b/packages/components/.eslintrc.cjs
@@ -13,8 +13,9 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "@wogns3623/better-exhaustive-deps"],
   rules: {
+    // Replace exhaustive-deps hook with a better fork
+    // Context: https://github.com/facebook/react/issues/16873
     "react-hooks/exhaustive-deps": "off",
-
     "@wogns3623/better-exhaustive-deps/exhaustive-deps": [
       "warn",
       {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,6 +64,7 @@
     "@types/react-dom": "^18.2.17",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
+    "@wogns3623/eslint-plugin-better-exhaustive-deps": "^1.1.0",
     "canvas": "^2.11.2",
     "eslint": "^8.55.0",
     "eslint-plugin-react": "^7.33.2",

--- a/packages/components/src/components/CodeEditor/codemirrorHooks.ts
+++ b/packages/components/src/components/CodeEditor/codemirrorHooks.ts
@@ -31,7 +31,7 @@ export function useReactiveExtension(
     view?.dispatch({
       effects: compartment.reconfigure(configure()),
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line @wogns3623/better-exhaustive-deps/exhaustive-deps
   }, [view, ...deps]);
   return extension;
 }
@@ -58,7 +58,7 @@ export function useConfigureCodemirrorView(
       view?.destroy();
     };
     // we initialize the view only once; no need for deps
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line @wogns3623/better-exhaustive-deps/exhaustive-deps
   }, []);
 
   const setViewDom = useCallback(

--- a/packages/components/src/components/SquiggleViewer/ItemSettingsMenuItems.tsx
+++ b/packages/components/src/components/SquiggleViewer/ItemSettingsMenuItems.tsx
@@ -65,12 +65,9 @@ const ItemSettingsModal: FC<Props> = ({
 
   const { getLeftPanelElement } = useContext(PlaygroundContext);
 
-  const { dispatch } = useContext(ViewerContext);
+  const { itemStore } = useContext(ViewerContext);
   const resetScroll = () => {
-    dispatch({
-      type: "SCROLL_TO_PATH",
-      payload: { path },
-    });
+    itemStore.scrollToPath(path);
   };
 
   return (

--- a/packages/components/src/components/SquiggleViewer/SquiggleValueMenu.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValueMenu.tsx
@@ -105,7 +105,7 @@ const SetChildrenCollapsedStateItem: FC<{
   const setCollapsed = useSetCollapsed();
   const closeDropdown = useCloseDropdown();
 
-  const { getLocalItemState } = useViewerContext();
+  const { itemStore } = useViewerContext();
 
   if (value.tag !== "Array" && value.tag !== "Dict") {
     return null;
@@ -115,10 +115,7 @@ const SetChildrenCollapsedStateItem: FC<{
 
   const allChildrenInRequiredState = childrenValues.every((childValue) => {
     const childPath = childValue.context?.path;
-    return (
-      childPath &&
-      getLocalItemState({ path: childPath }).collapsed === collapsed
-    );
+    return childPath && itemStore.getState(childPath).collapsed === collapsed;
   });
   if (allChildrenInRequiredState) {
     return null; // action won't do anything useful

--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -2,12 +2,11 @@
 import "../../widgets/index.js";
 
 import { clsx } from "clsx";
-import { FC, PropsWithChildren, useMemo, useState } from "react";
+import { FC, PropsWithChildren, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { CommentIcon, TextTooltip } from "@quri/ui";
 
-import { SHORT_STRING_LENGTH } from "../../lib/constants.js";
 import { SqValueWithContext } from "../../lib/utility.js";
 import { ErrorBoundary } from "../ErrorBoundary.js";
 import { CollapsedIcon, ExpandedIcon } from "./icons.js";
@@ -15,14 +14,12 @@ import { SquiggleValueChart } from "./SquiggleValueChart.js";
 import { SquiggleValueHeader } from "./SquiggleValueHeader.js";
 import { SquiggleValueMenu } from "./SquiggleValueMenu.js";
 import { SquiggleValuePreview } from "./SquiggleValuePreview.js";
-import { getChildrenValues, pathToShortName } from "./utils.js";
+import { pathToShortName } from "./utils.js";
 import {
-  useCollapseChildren,
   useFocus,
   useIsFocused,
   useMergedSettings,
   useRegisterAsItemViewer,
-  useSetCollapsed,
   useToggleCollapsed,
   useViewerContext,
 } from "./ViewerProvider.js";
@@ -112,47 +109,20 @@ const ValueViewerBody: FC<Props> = ({ value }) => {
   );
 };
 
-const tagsDefaultCollapsed = new Set(["Bool", "Number", "Void", "Input"]);
-
 export const ValueWithContextViewer: FC<Props> = ({ value }) => {
   const { tag } = value;
   const { path } = value.context;
 
   const toggleCollapsed_ = useToggleCollapsed();
-  const setCollapsed = useSetCollapsed();
-  const collapseChildren = useCollapseChildren();
   const focus = useFocus();
+
   const { itemStore } = useViewerContext();
+  const itemState = itemStore.getStateOrInitialize(value);
+
   const isFocused = useIsFocused(path);
 
   const isRoot = path.isRoot();
   const boxedName = tag === "Boxed" ? value.value.name() : undefined;
-
-  // Collapse children and element if desired. Uses crude heuristics.
-  // TODO - this code has side effects, it'd be better if we ran it somewhere else, e.g. traverse values recursively when `ViewerProvider` is initialized, or add a `getStateOrInitialize` method on `ItemStore`.
-  useState(() => {
-    const shouldBeginCollapsed = (
-      isRoot: boolean,
-      v: SqValueWithContext
-    ): boolean => {
-      if (isRoot) {
-        return getChildrenValues(v).length > 30;
-      } else {
-        return (
-          getChildrenValues(v).length > 5 ||
-          tagsDefaultCollapsed.has(v.tag) ||
-          (v.tag === "String" && v.value.length <= SHORT_STRING_LENGTH)
-        );
-      }
-    };
-
-    if (getChildrenValues(value).length > 10) {
-      collapseChildren(value);
-    }
-    if (shouldBeginCollapsed(isRoot, value)) {
-      setCollapsed(path, true, { skipUpdate: true });
-    }
-  });
 
   const toggleCollapsed = () => {
     toggleCollapsed_(path);
@@ -160,7 +130,7 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
 
   const ref = useRegisterAsItemViewer(path);
 
-  const isOpen = isFocused || !itemStore.getState(path).collapsed;
+  const isOpen = isFocused || !itemState.collapsed;
   const _focus = () => !isFocused && !isRoot && focus(path);
 
   const triangleToggle = () => {

--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -122,7 +122,7 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
   const setCollapsed = useSetCollapsed();
   const collapseChildren = useCollapseChildren();
   const focus = useFocus();
-  const { getLocalItemState } = useViewerContext();
+  const { itemStore } = useViewerContext();
   const isFocused = useIsFocused(path);
 
   const isRoot = path.isRoot();
@@ -160,7 +160,7 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
 
   const ref = useRegisterAsItemViewer(path);
 
-  const isOpen = isFocused || !getLocalItemState({ path }).collapsed;
+  const isOpen = isFocused || !itemStore.getState(path).collapsed;
   const _focus = () => !isFocused && !isRoot && focus(path);
 
   const triangleToggle = () => {

--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -129,7 +129,7 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
   const boxedName = tag === "Boxed" ? value.value.name() : undefined;
 
   // Collapse children and element if desired. Uses crude heuristics.
-  // TODO - this code has side effects, it'd be better if we ran it somewhere else, e.g. traverse values recursively when `ViewerProvider` is initialized.
+  // TODO - this code has side effects, it'd be better if we ran it somewhere else, e.g. traverse values recursively when `ViewerProvider` is initialized, or add a `getStateOrInitialize` method on `ItemStore`.
   useState(() => {
     const shouldBeginCollapsed = (
       isRoot: boolean,
@@ -150,7 +150,7 @@ export const ValueWithContextViewer: FC<Props> = ({ value }) => {
       collapseChildren(value);
     }
     if (shouldBeginCollapsed(isRoot, value)) {
-      setCollapsed(path, true);
+      setCollapsed(path, true, { skipUpdate: true });
     }
   });
 

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -192,12 +192,16 @@ export function useToggleCollapsed() {
 
 export function useSetCollapsed() {
   const { itemStore } = useViewerContext();
-  return (path: SqValuePath, isCollapsed: boolean) => {
+  return (
+    path: SqValuePath,
+    isCollapsed: boolean,
+    options?: { skipUpdate: boolean }
+  ) => {
     itemStore.setState(path, (state) => ({
       ...state,
       collapsed: isCollapsed,
     }));
-    itemStore.forceUpdate(path);
+    options?.skipUpdate || itemStore.forceUpdate(path);
   };
 }
 
@@ -231,7 +235,7 @@ export function useUnfocus() {
   return () => setFocused(undefined);
 }
 
-// Should be used only on initial render.
+// Should be used only on initial render; doesn't call `forceUpdate`.
 export function useCollapseChildren() {
   const { itemStore } = useViewerContext();
   return useCallback(

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, useImperativeHandle } from "react";
+import { forwardRef, Fragment, memo, useImperativeHandle } from "react";
 
 import {
   result,
@@ -14,7 +14,7 @@ import { MessageAlert } from "../Alert.js";
 import { CodeEditorHandle } from "../CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
-import { extractSubvalueByPath, pathIsEqual, pathItemFormat } from "./utils.js";
+import { pathIsEqual, pathItemFormat, useGetSubvalueByPath } from "./utils.js";
 import { ValueViewer } from "./ValueViewer.js";
 import {
   useFocus,
@@ -42,7 +42,7 @@ const SquiggleViewerOuter = forwardRef<
   { resultVariables, resultItem, rootPathOverride },
   ref
 ) {
-  const { focused, itemStore, getCalculator } = useViewerContext();
+  const { focused, itemStore } = useViewerContext();
   const unfocus = useUnfocus();
   const focus = useFocus();
 
@@ -73,12 +73,12 @@ const SquiggleViewerOuter = forwardRef<
         .itemsAsValuePaths({ includeRoot: false })
         .slice(rootPathFocusedAdjustment, -1)
         .map((path, i) => (
-          <>
+          <Fragment key={i}>
             <div onClick={() => focus(path)} className={navLinkStyle}>
               {pathItemFormat(path.items[i + rootPathFocusedAdjustment])}
             </div>
             <ChevronRightIcon className="text-slate-300" size={24} />
-          </>
+          </Fragment>
         ))}
     </div>
   );
@@ -93,19 +93,13 @@ const SquiggleViewerOuter = forwardRef<
     ? resultVariables.value.value.entries().length
     : 0;
 
+  const getSubvalueByPath = useGetSubvalueByPath();
+
   let focusedItem: SqValue | undefined;
   if (focused && resultVariables.ok && focused.root === "bindings") {
-    focusedItem = extractSubvalueByPath(
-      resultVariables.value,
-      focused,
-      getCalculator
-    );
+    focusedItem = getSubvalueByPath(resultVariables.value, focused);
   } else if (focused && resultItem?.ok && focused.root === "result") {
-    focusedItem = extractSubvalueByPath(
-      resultItem.value,
-      focused,
-      getCalculator
-    );
+    focusedItem = getSubvalueByPath(resultItem.value, focused);
   }
 
   const body = () => {

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -42,7 +42,7 @@ const SquiggleViewerOuter = forwardRef<
   { resultVariables, resultItem, rootPathOverride },
   ref
 ) {
-  const { focused, dispatch, getCalculator } = useViewerContext();
+  const { focused, itemStore, getCalculator } = useViewerContext();
   const unfocus = useUnfocus();
   const focus = useFocus();
 
@@ -85,10 +85,7 @@ const SquiggleViewerOuter = forwardRef<
 
   useImperativeHandle(ref, () => ({
     viewValuePath(path: SqValuePath) {
-      dispatch({
-        type: "SCROLL_TO_PATH",
-        payload: { path },
-      });
+      itemStore.scrollToPath(path);
     },
   }));
 

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -1,6 +1,6 @@
 import { PathItem, SqValue, SqValuePath } from "@quri/squiggle-lang";
 
-import { CalculatorState } from "../../widgets/CalculatorWidget/types.js";
+import { useViewerContext } from "./ViewerProvider.js";
 
 export const pathItemFormat = (item: PathItem): string => {
   if (item.type === "cellAddress") {
@@ -62,71 +62,63 @@ export function getChildrenValues(value: SqValue): SqValue[] {
   }
 }
 
-type GetCalculatorFn = ({
-  path,
-}: {
-  path: SqValuePath;
-}) => CalculatorState | undefined;
+// This needs to be a hook because it relies on ItemStore to traverse calculator nodes in path.
+export function useGetSubvalueByPath() {
+  const { itemStore } = useViewerContext();
 
-function getCalculatorResult(
-  pathItem: SqValuePath,
-  getCalculator: GetCalculatorFn
-): SqValue | undefined {
-  // The previous path item is the one that is the parent of the calculator result.
-  // This is the one that we use in the ProviderContext to store information about the calculator.
-  const allItems = pathItem.itemsAsValuePaths({ includeRoot: true });
-  const previousPathItem: SqValuePath | undefined =
-    allItems.length > 1 ? allItems[allItems.length - 2] : undefined;
+  const getCalculatorResult = (pathItem: SqValuePath): SqValue | undefined => {
+    // The previous path item is the one that is the parent of the calculator result.
+    // This is the one that we use in the ViewerContext to store information about the calculator.
+    const allItems = pathItem.itemsAsValuePaths({ includeRoot: true });
+    const previousPathItem: SqValuePath | undefined =
+      allItems.length > 1 ? allItems[allItems.length - 2] : undefined;
 
-  if (!previousPathItem) {
-    return undefined;
-  }
-
-  const calculatorState = getCalculator({ path: previousPathItem });
-  const result = calculatorState?.calculatorResult;
-  if (result?.ok) {
-    return result.value;
-  } else {
-    return undefined;
-  }
-}
-
-export function extractSubvalueByPath(
-  value: SqValue,
-  path: SqValuePath,
-  getCalculator: GetCalculatorFn
-): SqValue | undefined {
-  if (!value.context) {
-    return;
-  }
-  const { context } = value;
-  for (const pathItem of path.itemsAsValuePaths({ includeRoot: false })) {
-    const key = pathItem.items[pathItem.items.length - 1];
-    let nextValue: SqValue | undefined;
-    if (key.type === "number" && value.tag === "Array") {
-      nextValue = value.value.getValues()[key.value];
-    } else if (key.type === "string" && value.tag === "Dict") {
-      nextValue = value.value.get(key.value);
-    } else if (key.type === "cellAddress" && value.tag === "TableChart") {
-      // Maybe it would be better to get the environment in a different way.
-      const environment = context.project.getEnvironment();
-      const item = value.value.item(
-        key.value.row,
-        key.value.column,
-        environment
-      );
-      if (item.ok) {
-        nextValue = item.value;
-      } else {
-        return;
-      }
-    } else if (key.type === "calculator") {
-      nextValue = getCalculatorResult(pathItem, getCalculator);
+    if (!previousPathItem) {
+      return undefined;
     }
-    if (!nextValue) {
+
+    const calculatorState = itemStore.getCalculator(previousPathItem);
+    const result = calculatorState?.calculatorResult;
+    if (result?.ok) {
+      return result.value;
+    } else {
+      return undefined;
+    }
+  };
+
+  return (value: SqValue, path: SqValuePath): SqValue | undefined => {
+    if (!value.context) {
       return;
     }
-    value = nextValue;
-  }
-  return value;
+    const { context } = value;
+    for (const pathItem of path.itemsAsValuePaths({ includeRoot: false })) {
+      const key = pathItem.items[pathItem.items.length - 1];
+      let nextValue: SqValue | undefined;
+      if (key.type === "number" && value.tag === "Array") {
+        nextValue = value.value.getValues()[key.value];
+      } else if (key.type === "string" && value.tag === "Dict") {
+        nextValue = value.value.get(key.value);
+      } else if (key.type === "cellAddress" && value.tag === "TableChart") {
+        // Maybe it would be better to get the environment in a different way.
+        const environment = context.project.getEnvironment();
+        const item = value.value.item(
+          key.value.row,
+          key.value.column,
+          environment
+        );
+        if (item.ok) {
+          nextValue = item.value;
+        } else {
+          return;
+        }
+      } else if (key.type === "calculator") {
+        nextValue = getCalculatorResult(pathItem);
+      }
+      if (!nextValue) {
+        return;
+      }
+      value = nextValue;
+    }
+    return value;
+  };
 }

--- a/packages/components/src/widgets/CalculatorWidget/useSavedCalculatorState.tsx
+++ b/packages/components/src/widgets/CalculatorWidget/useSavedCalculatorState.tsx
@@ -12,13 +12,12 @@ export function useSavedCalculatorState(
 ) {
   const path = useMemo(() => calculatorValue.context.path, [calculatorValue]);
 
-  const { getLocalItemState, dispatch: viewerContextDispatch } =
-    useViewerContext();
+  const { itemStore } = useViewerContext();
 
   // Load state just once on initial render.
   // After the initial load, Calculator component owns the state and pushes it to ViewerContext.
   const [savedState] = useState<CalculatorState | undefined>(() => {
-    const itemState = getLocalItemState({ path });
+    const itemState = itemStore.getState(path);
 
     const sameCalculatorCacheExists =
       itemState.calculator &&
@@ -33,15 +32,9 @@ export function useSavedCalculatorState(
 
   const updateSavedState = useCallback(
     (state: CalculatorState) => {
-      viewerContextDispatch({
-        type: "CALCULATOR_UPDATE",
-        payload: {
-          path,
-          calculator: state,
-        },
-      });
+      itemStore.updateCalculatorState(path, state);
     },
-    [path, viewerContextDispatch]
+    [path, itemStore]
   );
 
   return [savedState, updateSavedState] as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^6.13.1
         version: 6.13.2(eslint@8.55.0)(typescript@5.3.2)
+      '@wogns3623/eslint-plugin-better-exhaustive-deps':
+        specifier: ^1.1.0
+        version: 1.1.0(eslint@8.55.0)
       canvas:
         specifier: ^2.11.2
         version: 2.11.2
@@ -222,7 +225,7 @@ importers:
         version: 4.6.0(eslint@8.55.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.10.4)
+        version: 29.7.0(@types/node@20.10.4)(ts-node@10.9.1)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0(canvas@2.11.2)
@@ -4576,49 +4579,6 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core@29.7.0:
-    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.10.4
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.10.4)
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.5
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /@jest/core@29.7.0(ts-node@10.9.1):
     resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -7512,7 +7472,7 @@ packages:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.5.16
-      jest: 29.7.0(@types/node@20.10.4)
+      jest: 29.7.0(@types/node@20.10.4)(ts-node@10.9.1)
       lodash: 4.17.21
       redent: 3.0.0
     dev: true
@@ -8388,6 +8348,14 @@ packages:
       '@whatwg-node/fetch': 0.9.7
       tslib: 2.6.2
     dev: false
+
+  /@wogns3623/eslint-plugin-better-exhaustive-deps@1.1.0(eslint@8.55.0):
+    resolution: {integrity: sha512-AkQzn7bSngpml8nqkJmXMTHfoO1sviqTfc6jaNaQKX1Rj6jHqRmm4hzn1ahN3oH4b7sTjMnzXfGjN/16XcFKxw==}
+    peerDependencies:
+      eslint: '>=0.8.0'
+    dependencies:
+      eslint: 8.55.0
+    dev: true
 
   /@xobotyi/scrollbar-width@1.9.5:
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
@@ -9933,25 +9901,6 @@ packages:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.11
-    dev: true
-
-  /create-jest@29.7.0(@types/node@20.10.4):
-    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.10.4)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
     dev: true
 
   /create-jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.1):
@@ -13538,34 +13487,6 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.7.0(@types/node@20.10.4):
-    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.10.4)
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.10.4)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-    dev: true
-
   /jest-cli@29.7.0(@types/node@20.10.4)(ts-node@10.9.1):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -13592,46 +13513,6 @@ packages:
       - babel-plugin-macros
       - supports-color
       - ts-node
-    dev: true
-
-  /jest-config@29.7.0(@types/node@20.10.4):
-    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    peerDependencies:
-      '@types/node': '*'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.2
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.10.4
-      babel-jest: 29.7.0(@babel/core@7.23.2)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.5
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
     dev: true
 
   /jest-config@29.7.0(@types/node@20.10.4)(ts-node@10.9.1):
@@ -13988,27 +13869,6 @@ packages:
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
-
-  /jest@29.7.0(@types/node@20.10.4):
-    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-    dependencies:
-      '@jest/core': 29.7.0
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.10.4)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
     dev: true
 
   /jest@29.7.0(@types/node@20.10.4)(ts-node@10.9.1):
@@ -19272,7 +19132,7 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.18.20
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.10.4)
+      jest: 29.7.0(@types/node@20.10.4)(ts-node@10.9.1)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
- add `ItemStore`, remove `dispatch` from `ViewerProvider`
- move the logic for detecting the initial collapsed state to `ItemStore` method, so React won't complain about calling `setState` during render
- fix a bug in detecting the initial collapsed state, where it would be recalculated and lost after focus/unfocus
- also, replace the original react-hooks eslint check with https://github.com/wogns3623/eslint-plugin-better-exhaustive-deps; I ended up not using it for this, but I like that it exists and it will help in the future