### PR TITLE
Tailwind config for versioned components CSS

### DIFF
--- a/packages/hub/src/app/api/auth/[...nextauth]/authOptions.ts
+++ b/packages/hub/src/app/api/auth/[...nextauth]/authOptions.ts
@@ -1,11 +1,11 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { AuthOptions } from "next-auth";
-import { Provider } from "next-auth/providers";
 import EmailProvider from "next-auth/providers/email";
 import GithubProvider from "next-auth/providers/github";
+import { Provider } from "next-auth/providers/index";
 
-import { prisma } from "@/prisma";
 import { indexUserId } from "@/graphql/helpers/searchHelpers";
+import { prisma } from "@/prisma";
 
 function buildAuthOptions() {
   const providers: Provider[] = [];

--- a/packages/hub/tailwind.config.ts
+++ b/packages/hub/tailwind.config.ts
@@ -1,10 +1,13 @@
 import type { Config } from "tailwindcss";
 
+import { getVersionedTailwindContent } from "@quri/versioned-squiggle-components/tailwind";
+
 export default {
   content: [
     "./src/**/*.{ts,tsx}",
     "../ui/src/**/*.{ts,tsx}",
     "../components/src/**/*.{ts,tsx}",
+    ...getVersionedTailwindContent(),
   ],
   theme: {
     extend: {

--- a/packages/hub/tsconfig.json
+++ b/packages/hub/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "es2020",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "es2021",
     "lib": ["dom", "dom.iterable", "esnext"],
     "esModuleInterop": true,

--- a/packages/versioned-components/package.json
+++ b/packages/versioned-components/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@quri/squiggle-components": "workspace:*",
     "@quri/ui": "workspace:*",
+    "glob": "^10.3.10",
     "squiggle-components-0.8.5": "npm:@quri/squiggle-components@0.8.5",
     "squiggle-components-0.8.6": "npm:@quri/squiggle-components@0.8.6"
   },
@@ -36,6 +37,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "default": "./dist/src/index.js"
+    },
+    "./tailwind": {
+      "types": "./dist/src/tailwind.d.cts",
+      "default": "./dist/src/tailwind.cjs"
     }
   },
   "module": "./dist/src/index.js",

--- a/packages/versioned-components/src/tailwind.cts
+++ b/packages/versioned-components/src/tailwind.cts
@@ -1,0 +1,23 @@
+import { glob } from "glob";
+import fs from "node:fs";
+import path from "node:path";
+
+// Generated paths will be absolute and fully symlink-resolved.
+export function getVersionedTailwindContent() {
+  // relative to this package's root; this file will be located in `./dist/src/tailwind.js`
+  const srcGlobs = [
+    "../../../../node_modules/.pnpm/@quri+ui@*/node_modules/@quri/ui/src",
+    "../../node_modules/squiggle-components-*/src",
+  ];
+
+  const resolvedGlobs = srcGlobs.map((dir) => path.resolve(__dirname, dir));
+
+  // This is necessary because of this bug: https://github.com/vercel/next.js/issues/50388
+  const dirs = resolvedGlobs.map((globDir) => glob.sync(globDir)).flat();
+
+  const extraContent = dirs.map((dir) =>
+    path.join(fs.realpathSync(dir), "/**/*.{js,jsx,ts,tsx,md,mdx}")
+  );
+
+  return extraContent;
+}

--- a/packages/website/tailwind.config.ts
+++ b/packages/website/tailwind.config.ts
@@ -1,11 +1,14 @@
 import type { Config } from "tailwindcss";
 
+import { getVersionedTailwindContent } from "@quri/versioned-squiggle-components/tailwind";
+
 export default {
   content: [
     "./src/**/*.{js,jsx,ts,tsx,md,mdx}",
     "../ui/src/**/*.{ts,tsx}",
     "../components/src/**/*.{ts,tsx}",
     "./theme.config.jsx",
+    ...getVersionedTailwindContent(),
   ],
   theme: {
     extend: {

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "target": "es2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "skipLibCheck": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -738,6 +738,9 @@ importers:
       '@quri/ui':
         specifier: workspace:*
         version: link:../ui
+      glob:
+        specifier: ^10.3.10
+        version: 10.3.10
       squiggle-components-0.8.5:
         specifier: npm:@quri/squiggle-components@0.8.5
         version: /@quri/squiggle-components@0.8.5(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)(tailwindcss@3.3.5)


### PR DESCRIPTION
Fixes #2784.

The main idea is simple, but I had to resolve symlinks, fight TypeScript and ESM issues, and take care to export the function from a separate file because it uses `node:*` modules.

Also had to change `moduleResolution` to `"bundler"` in `tsconfig.json` files; looks like it's working now with Next.js without issues (it wasn't working a few months ago, it's a new option).