### PR TITLE
Decorator format() and getFormat() additions

### DIFF
--- a/.changeset/thick-wolves-itch.md
+++ b/.changeset/thick-wolves-itch.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+@format can be used as decorator, adds getFormat(), tag fns get tagged variables

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -262,16 +262,17 @@ Calculator.make(
 export const Tagged: Story = {
   name: "Tagged values",
   args: {
-    defaultCode: `
-z = 34 -> Tag.format(".1f")
-x = Tag.name(5 to 10, "My favorite Dist")
-    -> Tag.description(
-      "This is a long description"
-    )
-    -> Tag.format(
-      "$.1f"
-    )
-  y = x -> Tag.all
-   `,
+    defaultCode: `z = 34 -> Tag.format(".1f")
+
+    @name("My favorite Dist")
+    @description("This is a long description")
+    @format("$.2")
+    x = 5 to 10
+    
+    @showAs(Plot.numericFn)
+    @name("My favorite Fn")
+    fn = {|e| e}
+    
+    y = x -> Tag.all`,
   },
 };

--- a/packages/squiggle-lang/__tests__/library/tag_test.ts
+++ b/packages/squiggle-lang/__tests__/library/tag_test.ts
@@ -19,6 +19,10 @@ describe("Tags", () => {
     );
   });
 
+  describe("format", () => {
+    testEvalToBe("123 -> Tag.format('.2%') -> Tag.getFormat", '".2%"');
+  });
+
   describe("omit", () => {
     testEvalToBe(
       "123 -> Tag.name('myName') -> Tag.description('myDescription') -> Tag.format('.2%') -> Tag.omit(['name', 'description']) -> Tag.all",
@@ -32,6 +36,7 @@ describe("Tags", () => {
       "{}"
     );
   });
+
   testEvalToBe(
     `
 @name("five")
@@ -62,4 +67,17 @@ x
 `,
     "Error(Tag.getName is not a decorator)"
   );
+
+  describe("can access tags when called as a decorator", () => {
+    testEvalToBe(
+      `
+@showAs({|f| Tag.getName(f) == "testName" ? Plot.dist(f) : "none"})
+@name("testName")
+x = 5 to 10
+
+x -> Tag.getName
+`,
+      '"testName"'
+    );
+  });
 });

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -57,7 +57,7 @@ function _ensureTypeUsingLambda<T1>(
 function decoratorWithInputOrFnInput<T>(
   inputType: FRType<any>,
   outputType: FRType<T>,
-  merge: (arg: T) => ValueTagsType
+  toValueTagsFn: (arg: T) => ValueTagsType
 ) {
   return makeDefinition(
     [
@@ -78,7 +78,7 @@ function decoratorWithInputOrFnInput<T>(
       );
       return {
         value,
-        tags: tags.merge(merge(correctTypedInputValue)),
+        tags: tags.merge(toValueTagsFn(correctTypedInputValue)),
       };
     },
     { isDecorator: true }

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -28,7 +28,7 @@ import {
 import { Lambda } from "../reducer/lambda.js";
 import { getOrThrow } from "../utility/result.js";
 import { Value, vString } from "../value/index.js";
-import { ValueTags } from "../value/valueTags.js";
+import { ValueTags, ValueTagsType } from "../value/valueTags.js";
 
 const maker = new FnFactory({
   nameSpace: "Tag",
@@ -38,13 +38,13 @@ const maker = new FnFactory({
 //I could also see inlining this into the next function, either way is fine.
 function _ensureTypeUsingLambda<T1>(
   outputType: FRType<T1>,
-  showAs: FrOrType<T1, Lambda>,
+  inputValue: FrOrType<T1, Lambda>,
   runLambdaToGetType: (fn: Lambda) => Value
 ): T1 {
-  if (showAs.tag === "1") {
-    return showAs.value;
+  if (inputValue.tag === "1") {
+    return inputValue.value;
   }
-  const show = runLambdaToGetType(showAs.value);
+  const show = runLambdaToGetType(inputValue.value);
   const unpack = outputType.unpack(show);
   if (unpack) {
     return unpack;
@@ -56,7 +56,8 @@ function _ensureTypeUsingLambda<T1>(
 // This constructs definitions where the second argument is either a type T or a function that takes in the first argument and returns a type T.
 function decoratorWithInputOrFnInput<T>(
   inputType: FRType<any>,
-  outputType: FRType<T>
+  outputType: FRType<T>,
+  merge: (arg: T) => ValueTagsType
 ) {
   return makeDefinition(
     [
@@ -64,21 +65,30 @@ function decoratorWithInputOrFnInput<T>(
       frOr(outputType, frLambdaTyped([inputType], outputType)),
     ],
     frWithTags(inputType),
-    ([{ value, tags }, showAs], context) => {
-      const runLambdaToGetType = (fn: Lambda) =>
-        fn.call([inputType.pack(value)], context);
-      const showAsVal: T = _ensureTypeUsingLambda(
+    ([{ value, tags }, newInput], context) => {
+      const runLambdaToGetType = (fn: Lambda) => {
+        //When we call the function, we pass in the tags as well, just in case they are asked for in the call.
+        const val = frWithTags(inputType).pack({ value: value, tags });
+        return fn.call([val], context);
+      };
+      const correctTypedInputValue: T = _ensureTypeUsingLambda(
         outputType,
-        showAs,
+        newInput,
         runLambdaToGetType
       );
       return {
         value,
-        tags: tags.merge({ showAs: outputType.pack(showAsVal) }),
+        tags: tags.merge(merge(correctTypedInputValue)),
       };
     },
     { isDecorator: true }
   );
+}
+
+function showAsDef<T>(inputType: FRType<any>, outputType: FRType<T>) {
+  return decoratorWithInputOrFnInput(inputType, outputType, (result) => ({
+    showAs: outputType.pack(result),
+  }));
 }
 
 export const library = [
@@ -128,22 +138,13 @@ export const library = [
     name: "showAs",
     examples: [],
     definitions: [
-      decoratorWithInputOrFnInput(frDist, frPlot),
-      decoratorWithInputOrFnInput(frArray(frAny()), frTableChart),
-      decoratorWithInputOrFnInput(
-        frLambdaTyped([frNumber], frDistOrNumber),
-        frPlot
-      ),
-      decoratorWithInputOrFnInput(
-        frLambdaTyped([frDate], frDistOrNumber),
-        frPlot
-      ),
-      decoratorWithInputOrFnInput(
-        frLambdaTyped([frDuration], frDistOrNumber),
-        frPlot
-      ),
+      showAsDef(frWithTags(frDist), frPlot),
+      showAsDef(frArray(frAny()), frTableChart),
+      showAsDef(frLambdaTyped([frNumber], frDistOrNumber), frPlot),
+      showAsDef(frLambdaTyped([frDate], frDistOrNumber), frPlot),
+      showAsDef(frLambdaTyped([frDuration], frDistOrNumber), frPlot),
       //The frLambda definition needs to come after the more narrow frLambdaTyped definitions.
-      decoratorWithInputOrFnInput(frLambda, frCalculator),
+      showAsDef(frLambda, frCalculator),
     ],
   }),
   maker.make({
@@ -185,6 +186,16 @@ export const library = [
         },
         { isDecorator: true }
       ),
+    ],
+  }),
+  maker.make({
+    name: "getFormat",
+    examples: [],
+    definitions: [
+      makeDefinition([frAny()], frString, ([value]) => {
+        const tags = value.tags?.value;
+        return tags?.numberFormat || tags?.dateFormat || "None";
+      }),
     ],
   }),
   maker.make({

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -192,9 +192,14 @@ export const library = [
     name: "getFormat",
     examples: [],
     definitions: [
-      makeDefinition([frAny()], frString, ([value]) => {
-        const tags = value.tags?.value;
-        return tags?.numberFormat || tags?.dateFormat || "None";
+      makeDefinition([frWithTags(frDistOrNumber)], frString, ([{ tags }]) => {
+        return tags?.numberFormat() || "None";
+      }),
+      makeDefinition([frWithTags(frDuration)], frString, ([{ tags }]) => {
+        return tags?.numberFormat() || "None";
+      }),
+      makeDefinition([frWithTags(frDate)], frString, ([{ tags }]) => {
+        return tags?.dateFormat() || "None";
       }),
     ],
   }),

--- a/packages/squiggle-lang/src/fr/tag.ts
+++ b/packages/squiggle-lang/src/fr/tag.ts
@@ -165,7 +165,8 @@ export const library = [
         ([{ value, tags }, format]) => {
           checkNumericTickFormat(format);
           return { value, tags: tags.merge({ numberFormat: format }) };
-        }
+        },
+        { isDecorator: true }
       ),
       makeDefinition(
         [frWithTags(frDuration), frNamed("numberFormat", frString)],
@@ -173,14 +174,16 @@ export const library = [
         ([{ value, tags }, format]) => {
           checkNumericTickFormat(format);
           return { value, tags: tags.merge({ numberFormat: format }) };
-        }
+        },
+        { isDecorator: true }
       ),
       makeDefinition(
         [frWithTags(frDate), frNamed("timeFormat", frString)],
         frWithTags(frDate),
         ([{ value, tags }, format]) => {
           return { value, tags: tags.merge({ dateFormat: format }) };
-        }
+        },
+        { isDecorator: true }
       ),
     ],
   }),


### PR DESCRIPTION
This does a few things:
1. Makes ``format`` a decorator.
2. Adds ``getFormat``.
3. When functions are called in decorators, where the underlying object should be passed (like ``showAs(fn)``), passes the value with its tags. This probably isn't a great practice to be used on a lot, but is something I would have expected. 
4. I broke up the function ``decoratorWithInputOrFnInput`` so that it could be used for Tags other than just ``showAs``. I didn't end up using this here (considered for ``description``, but didn't yet), but could easily see doing so later. 