### PR TITLE
Refactored plot xPoints to get extra points, if requested by components

### DIFF
--- a/packages/components/src/widgets/LambdaWidget/FunctionChart/AutomaticFunctionChart.tsx
+++ b/packages/components/src/widgets/LambdaWidget/FunctionChart/AutomaticFunctionChart.tsx
@@ -84,6 +84,7 @@ export const AutomaticFunctionChart: FC<AutomaticFunctionChartProps> = ({
 
   const min: number = settings.functionChartSettings.start;
   const max: number = settings.functionChartSettings.stop;
+  const xCount: number = settings.functionChartSettings.count;
 
   const includedDomain = fn.signatures().find((s) => s.length === 1)?.[0]
     ?.domain;
@@ -117,6 +118,7 @@ export const AutomaticFunctionChart: FC<AutomaticFunctionChartProps> = ({
           plot={plot}
           environment={environment}
           height={height}
+          xCount={xCount}
         />
       );
     }
@@ -133,6 +135,7 @@ export const AutomaticFunctionChart: FC<AutomaticFunctionChartProps> = ({
             plot={plot}
             environment={environment}
             height={height}
+            xCount={xCount}
           />
         </ErrorBoundary>
       );

--- a/packages/components/src/widgets/LambdaWidget/FunctionChart/DistFunctionChart.tsx
+++ b/packages/components/src/widgets/LambdaWidget/FunctionChart/DistFunctionChart.tsx
@@ -33,6 +33,7 @@ type FunctionChart1DistProps = {
   plot: SqDistFnPlot;
   environment: Env;
   height: number;
+  xCount: number;
 };
 
 const intervals = [
@@ -57,11 +58,17 @@ type Datum = {
 function getDistPlotPercentiles({
   plot,
   environment,
+  xCount,
 }: {
   plot: SqDistFnPlot;
   environment: Env;
+  xCount;
 }) {
-  const { functionImage, errors, xScale } = getFunctionImage(plot, environment);
+  const { functionImage, errors, xScale } = getFunctionImage(
+    plot,
+    environment,
+    xCount
+  );
 
   const data: Datum[] = functionImage
     .map(({ x, y: dist }) => {
@@ -94,17 +101,19 @@ function useDrawDistFunctionChart({
   plot,
   environment,
   height: innerHeight,
+  xCount,
 }: {
   plot: SqDistFnPlot;
   environment: Env;
   height: number;
+  xCount: number;
 }) {
   const height = innerHeight + 30; // consider paddings, should match suggestedPadding below
   const { cursor, initCursor } = useCanvasCursor();
 
   const { data, errors, xScale } = useMemo(
-    () => getDistPlotPercentiles({ plot, environment }),
-    [plot, environment]
+    () => getDistPlotPercentiles({ plot, environment, xCount }),
+    [plot, environment, xCount]
   );
 
   // note that range is not set on these scales yet (it happens in `draw()` below), so you can't use these in the following code
@@ -233,6 +242,7 @@ export const DistFunctionChart: FC<FunctionChart1DistProps> = ({
   plot,
   environment,
   height,
+  xCount,
 }) => {
   const {
     ref: canvasRef,
@@ -243,6 +253,7 @@ export const DistFunctionChart: FC<FunctionChart1DistProps> = ({
     plot,
     environment,
     height,
+    xCount,
   });
   //TODO: This custom error handling is a bit hacky and should be improved.
   const valueAtCursor: result<SqValue, SqError> | undefined = useMemo(() => {

--- a/packages/components/src/widgets/LambdaWidget/FunctionChart/NumericFunctionChart.tsx
+++ b/packages/components/src/widgets/LambdaWidget/FunctionChart/NumericFunctionChart.tsx
@@ -23,19 +23,21 @@ type Props = {
   plot: SqNumericFnPlot;
   environment: Env;
   height: number;
+  xCount: number;
 };
 
 export const NumericFunctionChart: FC<Props> = ({
   plot,
   environment,
   height: innerHeight,
+  xCount,
 }) => {
   const height = innerHeight + 30; // consider paddings, should match suggestedPadding below
   const { cursor, initCursor } = useCanvasCursor();
 
   const { functionImage, errors, xScale } = useMemo(
-    () => getFunctionImage(plot, environment),
-    [plot, environment]
+    () => getFunctionImage(plot, environment, xCount),
+    [plot, environment, xCount]
   );
 
   const draw = useCallback(

--- a/packages/components/src/widgets/LambdaWidget/FunctionChart/utils.ts
+++ b/packages/components/src/widgets/LambdaWidget/FunctionChart/utils.ts
@@ -62,15 +62,8 @@ export function getFunctionImage<T extends SqNumericFnPlot | SqDistFnPlot>(
 
   //It would be nice to move this to squiggle-lang, but the Scale domain types use D3 for choosing x values.
   const adjustedXPoints = () => {
-    const manualXPoints = plot.xPoints({ min, max });
-    const extraPointsWanted = xPointCount - manualXPoints.length;
-
-    if (extraPointsWanted < 1) {
-      return manualXPoints;
-    }
-
-    const extraPoints = rangeByCount({ scale, count: extraPointsWanted });
-    return plot.xPoints({ min, max, extraPoints });
+    const requestedXPoints = rangeByCount({ scale, count: xPointCount });
+    return plot.xPoints({ min, max, requestedXPoints });
   };
 
   const chartPointsToRender = adjustedXPoints();

--- a/packages/components/src/widgets/LambdaWidget/FunctionChart/utils.ts
+++ b/packages/components/src/widgets/LambdaWidget/FunctionChart/utils.ts
@@ -63,27 +63,14 @@ export function getFunctionImage<T extends SqNumericFnPlot | SqDistFnPlot>(
   //It would be nice to move this to squiggle-lang, but the Scale domain types use D3 for choosing x values.
   const adjustedXPoints = () => {
     const manualXPoints = plot.xPoints({ min, max });
-    const requestedCount = xPointCount;
+    const extraPointsWanted = xPointCount - manualXPoints.length;
 
-    if (!manualXPoints) {
-      return rangeByCount({
-        scale,
-        count: requestedCount,
-      });
+    if (extraPointsWanted < 1) {
+      return manualXPoints;
     }
 
-    const extraPointsWanted = requestedCount - manualXPoints.length;
-    return plot.xPoints({
-      min,
-      max,
-      extraPoints:
-        extraPointsWanted > 3
-          ? rangeByCount({
-              scale,
-              count: extraPointsWanted,
-            })
-          : undefined,
-    });
+    const extraPoints = rangeByCount({ scale, count: extraPointsWanted });
+    return plot.xPoints({ min, max, extraPoints });
   };
 
   const chartPointsToRender = adjustedXPoints();
@@ -93,10 +80,6 @@ export function getFunctionImage<T extends SqNumericFnPlot | SqDistFnPlot>(
     y: ImageValue<T>;
   }[] = [];
   const errors: ImageError[] = [];
-
-  if (!chartPointsToRender) {
-    throw new Error("Internal error: chartPointsToRender is undefined");
-  }
 
   for (const x of chartPointsToRender) {
     const result = plot.fn.call([plot.xScale.numberToValue(x)], environment);

--- a/packages/components/src/widgets/LambdaWidget/FunctionChart/utils.ts
+++ b/packages/components/src/widgets/LambdaWidget/FunctionChart/utils.ts
@@ -51,7 +51,8 @@ export type ImageError = {
 
 export function getFunctionImage<T extends SqNumericFnPlot | SqDistFnPlot>(
   plot: T,
-  environment: Env
+  environment: Env,
+  xPointCount: number
 ) {
   const min = plot.xScale?.min ?? functionChartDefaults.min;
   const max = plot.xScale?.max ?? functionChartDefaults.max;
@@ -62,7 +63,8 @@ export function getFunctionImage<T extends SqNumericFnPlot | SqDistFnPlot>(
   //It would be nice to move this to squiggle-lang, but the Scale domain types use D3 for choosing x values.
   const adjustedXPoints = () => {
     const manualXPoints = plot.xPoints({ min, max });
-    const requestedCount = functionChartDefaults.points;
+    const requestedCount = xPointCount;
+
     if (!manualXPoints) {
       return rangeByCount({
         scale,

--- a/packages/components/src/widgets/PlotWidget/index.tsx
+++ b/packages/components/src/widgets/PlotWidget/index.tsx
@@ -26,6 +26,7 @@ widgetRegistry.register("Plot", {
             plot={plot}
             environment={environment}
             height={settings.chartHeight}
+            xCount={settings.functionChartSettings.count}
           />
         );
       }
@@ -38,6 +39,7 @@ widgetRegistry.register("Plot", {
               xyPointLength: environment.xyPointLength / 10,
             }}
             height={settings.chartHeight}
+            xCount={settings.functionChartSettings.count}
           />
         );
       }

--- a/packages/squiggle-lang/__tests__/library/plot_test.ts
+++ b/packages/squiggle-lang/__tests__/library/plot_test.ts
@@ -40,9 +40,11 @@ describe("Plot", () => {
     testEvalToMatch(`Plot.numericFn({|x| x * 5})`, "Plot for numeric function");
     testEvalToMatch(
       `Plot.numericFn({
-        fn: {|x| x * 5}
+        fn: {|x| x * 5},
+        xPoints: [10,20,40]
       })`,
-      "Plot for numeric function"
+      "Plot for numeric function",
+      true
     );
 
     testEvalToMatch(

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -113,16 +113,20 @@ function formatXPoints(
   xScale: Scale | null
 ) {
   const points = xPoints
-    ? sort(uniq(clamp(xPoints, { min: xScale?.min, max: xScale!.max })))
+    ? sort(
+        uniq(
+          clamp(xPoints, { min: xScale?.min || undefined, max: xScale?.max })
+        )
+      )
     : null;
 
   if (points === null) {
     return null;
   }
 
-  if (points.length > 10000 || points.length < 1) {
+  if (points.length > 10000) {
     throw new REArgumentError(
-      "xPoints must have between 1 and 10000 unique elements, within the provided xScale"
+      "xPoints must have under 10001 unique elements, within the provided xScale"
     );
   }
 

--- a/packages/squiggle-lang/src/fr/plot.ts
+++ b/packages/squiggle-lang/src/fr/plot.ts
@@ -121,7 +121,10 @@ function formatXPoints(
   const points = xPoints
     ? sort(
         uniq(
-          clamp(xPoints, { min: xScale?.min || undefined, max: xScale?.max })
+          clamp(xPoints, {
+            min: xScale?.min || undefined,
+            max: xScale?.max || undefined,
+          })
         )
       )
     : null;

--- a/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
@@ -1,6 +1,7 @@
 import { BaseDist } from "../../dist/BaseDist.js";
 import { Env } from "../../dist/env.js";
 import { SampleSetDist } from "../../dist/SampleSetDist/index.js";
+import { clamp, sort, uniq } from "../../utility/E_A_Floats.js";
 import * as Result from "../../utility/result.js";
 import { Plot, vPlot } from "../../value/index.js";
 import { SqError, SqOtherError } from "../SqError.js";
@@ -55,6 +56,25 @@ abstract class SqAbstractPlot<T extends Plot["type"]> {
   }
 }
 
+function getXPointsWithParams(
+  points: number[] | undefined,
+  {
+    min,
+    max,
+    extraPoints,
+  }: {
+    min?: number;
+    max?: number;
+    extraPoints?: number[];
+  }
+) {
+  if (!extraPoints) {
+    return points;
+  } else {
+    const _points = [...extraPoints, ...(points || [])];
+    return sort(uniq(clamp(_points, { min, max })));
+  }
+}
 export class SqDistributionsPlot extends SqAbstractPlot<"distributions"> {
   tag = "distributions" as const;
 
@@ -154,8 +174,12 @@ export class SqNumericFnPlot extends SqAbstractPlot<"numericFn"> {
     return wrapScale(this._value.yScale);
   }
 
-  get xPoints(): number[] | undefined {
-    return this._value.xPoints;
+  xPoints(params: {
+    min?: number;
+    max?: number;
+    extraPoints?: number[];
+  }): number[] | undefined {
+    return getXPointsWithParams(this._value.xPoints, params);
   }
 
   override toString() {
@@ -222,8 +246,12 @@ export class SqDistFnPlot extends SqAbstractPlot<"distFn"> {
     return wrapScale(this._value.distXScale);
   }
 
-  get xPoints(): number[] | undefined {
-    return this._value.xPoints;
+  xPoints(params: {
+    min?: number;
+    max?: number;
+    extraPoints?: number[];
+  }): number[] | undefined {
+    return getXPointsWithParams(this._value.xPoints, params);
   }
 
   override toString() {

--- a/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
@@ -68,13 +68,11 @@ function getXPointsWithParams(
     extraPoints?: number[];
   }
 ) {
-  if (!extraPoints) {
-    return points;
-  } else {
-    const _points = [...extraPoints, ...(points || [])];
-    return sort(uniq(clamp(_points, { min, max })));
-  }
+  const combinedPoints = [...(extraPoints || []), ...(points || [])];
+  //Technically, we don't need sort(uniq()) if it's just ``points``, but it's not worth the extra logic to avoid it.
+  return sort(uniq(clamp(combinedPoints, { min, max })));
 }
+
 export class SqDistributionsPlot extends SqAbstractPlot<"distributions"> {
   tag = "distributions" as const;
 
@@ -178,7 +176,7 @@ export class SqNumericFnPlot extends SqAbstractPlot<"numericFn"> {
     min?: number;
     max?: number;
     extraPoints?: number[];
-  }): number[] | undefined {
+  }): number[] {
     return getXPointsWithParams(this._value.xPoints, params);
   }
 
@@ -250,7 +248,7 @@ export class SqDistFnPlot extends SqAbstractPlot<"distFn"> {
     min?: number;
     max?: number;
     extraPoints?: number[];
-  }): number[] | undefined {
+  }): number[] {
     return getXPointsWithParams(this._value.xPoints, params);
   }
 

--- a/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
@@ -61,14 +61,14 @@ function getXPointsWithParams(
   {
     min,
     max,
-    extraPoints,
+    requestedXPoints,
   }: {
     min?: number;
     max?: number;
-    extraPoints?: number[];
+    requestedXPoints?: number[];
   }
 ) {
-  const combinedPoints = [...(extraPoints || []), ...(points || [])];
+  const combinedPoints = [...(requestedXPoints || []), ...(points || [])];
   //Technically, we don't need sort(uniq()) if it's just ``points``, but it's not worth the extra logic to avoid it.
   return sort(uniq(clamp(combinedPoints, { min, max })));
 }
@@ -175,7 +175,7 @@ export class SqNumericFnPlot extends SqAbstractPlot<"numericFn"> {
   xPoints(params: {
     min?: number;
     max?: number;
-    extraPoints?: number[];
+    requestedXPoints?: number[];
   }): number[] {
     return getXPointsWithParams(this._value.xPoints, params);
   }
@@ -247,7 +247,7 @@ export class SqDistFnPlot extends SqAbstractPlot<"distFn"> {
   xPoints(params: {
     min?: number;
     max?: number;
-    extraPoints?: number[];
+    requestedXPoints?: number[];
   }): number[] {
     return getXPointsWithParams(this._value.xPoints, params);
   }

--- a/packages/squiggle-lang/src/utility/E_A_Floats.ts
+++ b/packages/squiggle-lang/src/utility/E_A_Floats.ts
@@ -1,4 +1,5 @@
 import isInteger from "lodash/isInteger.js";
+import _uniq from "lodash/uniq.js";
 
 import * as E_A from "./E_A.js";
 import * as E_A_Sorted from "./E_A_Sorted.js";
@@ -83,6 +84,10 @@ export const sort = (t: readonly number[]): number[] => {
   return Array.from(new Float64Array(t).sort());
 };
 
+export const uniq = (t: readonly number[]): number[] => {
+  return _uniq(t);
+};
+
 export const variance = (xs: readonly number[]) => {
   // Variance is shift-invariant; subtract the middle of the range for precision
   // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Computing_shifted_data
@@ -118,4 +123,19 @@ export const diff = (t: readonly number[]): number[] => {
 export const quantile = (samples: readonly number[], point: number): number => {
   const sorted = sort(samples);
   return E_A_Sorted.quantile(sorted, point);
+};
+
+export const clamp = (
+  samples: readonly number[],
+  { min, max }: { min: number | undefined; max: number | undefined }
+): number[] => {
+  return samples.filter((x) => {
+    if (min !== undefined && x < min) {
+      return false;
+    }
+    if (max !== undefined && x > max) {
+      return false;
+    }
+    return true;
+  });
 };


### PR DESCRIPTION
Some simple logic to make sure that if 3 ``xPoints`` are given, but the Playground wants 10, it fills it with 7 extra. 

Was unsure of the best way to test. Also, seemed perhaps too small for a changelog. 