### PR TITLE
Viewer improvements

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from "@storybook/react-vite";
+import { mergeConfig } from "vite";
 
 const config: StorybookConfig = {
   stories: [
@@ -36,6 +37,15 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: true,
+  },
+  async viteFinal(config) {
+    // Merge custom configuration into the default config
+    return mergeConfig(config, {
+      // https://github.com/storybookjs/storybook/issues/22223
+      build: {
+        target: "esnext",
+      },
+    });
   },
 };
 

--- a/packages/components/src/components/CodeEditor/useSubmitExtension.ts
+++ b/packages/components/src/components/CodeEditor/useSubmitExtension.ts
@@ -4,7 +4,7 @@ import { useReactiveExtension } from "./codemirrorHooks.js";
 
 export function useSubmitExtension(
   view: EditorView | undefined,
-  onSubmit: (() => void) | undefined
+  onSubmit: () => void
 ) {
   return useReactiveExtension(
     view,

--- a/packages/components/src/components/CodeEditor/useSubmitExtension.ts
+++ b/packages/components/src/components/CodeEditor/useSubmitExtension.ts
@@ -4,7 +4,7 @@ import { useReactiveExtension } from "./codemirrorHooks.js";
 
 export function useSubmitExtension(
   view: EditorView | undefined,
-  onSubmit: () => void
+  onSubmit?: () => void
 ) {
   return useReactiveExtension(
     view,

--- a/packages/components/src/components/DynamicSquiggleViewer.tsx
+++ b/packages/components/src/components/DynamicSquiggleViewer.tsx
@@ -3,6 +3,7 @@ import { FC, forwardRef, ReactNode, useState } from "react";
 import { result, SqError, SqValue, SqValuePath } from "@quri/squiggle-lang";
 import {
   Button,
+  CodeBracketIcon,
   Dropdown,
   DropdownMenu,
   DropdownMenuActionItem,
@@ -106,14 +107,21 @@ export const DynamicSquiggleViewer = forwardRef<SquiggleViewerHandle, Props>(
             render={({ close }) => (
               <DropdownMenu>
                 <DropdownMenuActionItem
-                  title="Variables"
+                  icon={CodeBracketIcon}
+                  title={
+                    "Variables" +
+                    (resultVariables?.ok
+                      ? ` (${resultVariables.value.value.entries().length})`
+                      : "")
+                  }
                   onClick={() => {
                     setMode("variables");
                     close();
                   }}
                 />
                 <DropdownMenuActionItem
-                  title="Result"
+                  icon={CodeBracketIcon}
+                  title={"Result" + (hasResult ? "" : " (empty)")}
                   onClick={() => {
                     setMode("result");
                     close();

--- a/packages/components/src/components/DynamicSquiggleViewer.tsx
+++ b/packages/components/src/components/DynamicSquiggleViewer.tsx
@@ -1,6 +1,12 @@
-import { forwardRef } from "react";
+import { FC, forwardRef, ReactNode, useState } from "react";
 
-import { SqValuePath } from "@quri/squiggle-lang";
+import { result, SqError, SqValue, SqValuePath } from "@quri/squiggle-lang";
+import {
+  Button,
+  Dropdown,
+  DropdownMenu,
+  DropdownMenuActionItem,
+} from "@quri/ui";
 
 import { SquiggleViewer } from "../index.js";
 import { SquiggleOutput } from "../lib/hooks/useSquiggle.js";
@@ -10,45 +16,83 @@ import { ErrorBoundary } from "./ErrorBoundary.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
 import { SquiggleViewerHandle } from "./SquiggleViewer/index.js";
 
+const DynamicSquiggleViewerLayout: FC<{
+  viewer: ReactNode;
+  menu: ReactNode;
+  indicator: string;
+}> = ({ viewer, menu, indicator }) => {
+  return (
+    // `flex flex-col` helps to fit this in playground right panel and doesn't hurt otherwise
+    <div className="flex flex-col overflow-y-auto">
+      <div className="flex justify-between items-center px-2 h-8 mb-1">
+        {menu}
+        <div className="px-2 text-zinc-400 text-sm whitespace-nowrap">
+          {indicator}
+        </div>
+      </div>
+      <div
+        className="flex-1 overflow-auto px-2 pb-1"
+        data-testid="dynamic-viewer-result"
+      >
+        {viewer}
+      </div>
+    </div>
+  );
+};
+
 type Props = {
-  squiggleOutput: SquiggleOutput | undefined;
+  squiggleOutput: SquiggleOutput;
   isRunning: boolean;
-  showHeader?: boolean;
   editor?: CodeEditorHandle;
   rootPathOverride?: SqValuePath;
 } & PartialPlaygroundSettings;
 
 /* Wrapper for SquiggleViewer that shows the rendering stats and isRunning state. */
 export const DynamicSquiggleViewer = forwardRef<SquiggleViewerHandle, Props>(
-  function DynamicSquiggleViewer(
-    {
-      squiggleOutput,
-      isRunning,
-      showHeader = true,
-      editor,
-      rootPathOverride,
-      ...settings
-    },
+  (
+    { squiggleOutput, isRunning, editor, rootPathOverride, ...settings },
     viewerRef
-  ) {
-    const squiggleViewer = squiggleOutput?.code ? (
-      <div className="relative">
-        {isRunning && (
-          // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
-          <div className="absolute z-10 inset-0 bg-white opacity-50" />
-        )}
-        <ErrorBoundary>
-          <SquiggleViewer
-            {...settings}
-            ref={viewerRef}
-            resultVariables={getResultVariables(squiggleOutput)}
-            resultItem={getResultValue(squiggleOutput)}
-            editor={editor}
-            rootPathOverride={rootPathOverride}
-          />
-        </ErrorBoundary>
-      </div>
-    ) : null;
+  ) => {
+    const resultItem = getResultValue(squiggleOutput);
+    const resultVariables = getResultVariables(squiggleOutput);
+
+    const hasResult = Boolean(resultItem?.ok);
+    // const hasVariables =
+    //   resultVariables.ok &&
+    //   nonHiddenDictEntries(resultVariables.value.value).length > 0;
+
+    const [mode, setMode] = useState<"variables" | "result">(
+      hasResult ? "result" : "variables"
+    );
+
+    let squiggleViewer: JSX.Element | null = null;
+    if (squiggleOutput.code) {
+      let usedValue: result<SqValue, SqError> | undefined;
+      switch (mode) {
+        case "result":
+          usedValue = resultItem;
+          break;
+        case "variables":
+          usedValue = resultVariables;
+      }
+      squiggleViewer = (
+        <div className="relative">
+          {isRunning && (
+            // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
+            <div className="absolute z-10 inset-0 bg-white opacity-50" />
+          )}
+          <ErrorBoundary>
+            <SquiggleViewer
+              {...settings}
+              ref={viewerRef}
+              value={usedValue}
+              editor={editor}
+              rootPathOverride={rootPathOverride}
+            />
+          </ErrorBoundary>
+        </div>
+      );
+    }
 
     const showTime = (executionTime: number) =>
       executionTime > 1000
@@ -56,26 +100,45 @@ export const DynamicSquiggleViewer = forwardRef<SquiggleViewerHandle, Props>(
         : `${executionTime}ms`;
 
     return (
-      // `flex flex-col` helps to fit this in playground right panel and doesn't hurt otherwise
-      <div className="flex flex-col overflow-y-auto">
-        {showHeader && (
-          <div className="mb-1 h-8 p-2 flex justify-end text-zinc-400 text-sm whitespace-nowrap">
-            {isRunning
-              ? "rendering..."
-              : squiggleOutput
-              ? `render #${squiggleOutput.executionId} in ${showTime(
-                  squiggleOutput.executionTime
-                )}`
-              : null}
-          </div>
-        )}
-        <div
-          className="flex-1 overflow-auto px-2 pb-1"
-          data-testid="dynamic-viewer-result"
-        >
-          {squiggleViewer}
-        </div>
-      </div>
+      <DynamicSquiggleViewerLayout
+        menu={
+          <Dropdown
+            render={({ close }) => (
+              <DropdownMenu>
+                <DropdownMenuActionItem
+                  title="Variables"
+                  onClick={() => {
+                    setMode("variables");
+                    close();
+                  }}
+                />
+                <DropdownMenuActionItem
+                  title="Result"
+                  onClick={() => {
+                    setMode("result");
+                    close();
+                  }}
+                />
+              </DropdownMenu>
+            )}
+          >
+            <Button size="small">
+              {mode === "variables" ? "Variables" : "Result"}
+            </Button>
+          </Dropdown>
+        }
+        indicator={
+          isRunning
+            ? "rendering..."
+            : squiggleOutput
+            ? `render #${squiggleOutput.executionId} in ${showTime(
+                squiggleOutput.executionTime
+              )}`
+            : ""
+        }
+        viewer={squiggleViewer}
+      />
     );
   }
 );
+DynamicSquiggleViewer.displayName = "DynamicSquiggleViewer";

--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -68,7 +68,7 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
         return <MessageAlert heading="Value is not defined" />;
       }
 
-      return <SquiggleViewer value={{ ok: true, value }} />;
+      return <SquiggleViewer value={value} />;
     } else {
       return (
         <SquiggleOutputViewer

--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -3,18 +3,22 @@ import { FC, memo } from "react";
 import { SqValuePath } from "@quri/squiggle-lang";
 import { RefreshIcon } from "@quri/ui";
 
+import { SquiggleViewer } from "../index.js";
 import { useRunnerState } from "../lib/hooks/useRunnerState.js";
 import {
   ProjectExecutionProps,
   StandaloneExecutionProps,
   useSquiggle,
 } from "../lib/hooks/useSquiggle.js";
+import { getResultValue, getResultVariables } from "../lib/utility.js";
+import { MessageAlert } from "./Alert.js";
 import { DynamicSquiggleViewer } from "./DynamicSquiggleViewer.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
+import { SquiggleErrorAlert } from "./SquiggleErrorAlert.js";
+import { useGetSubvalueByPath } from "./SquiggleViewer/utils.js";
 
 export type SquiggleChartProps = {
   code: string;
-  showHeader?: boolean;
   rootPathOverride?: SqValuePath; // Note: This should be static. We don't support rootPathOverride to change once set.
 } & (StandaloneExecutionProps | ProjectExecutionProps) &
   // `environment` is passed through StandaloneExecutionProps; this way we guarantee that it's not compatible with `project` prop
@@ -23,7 +27,6 @@ export type SquiggleChartProps = {
 export const SquiggleChart: FC<SquiggleChartProps> = memo(
   function SquiggleChart({
     code,
-    showHeader = false,
     project,
     continues,
     environment,
@@ -41,18 +44,40 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
       ...(project ? { project, continues } : { environment }),
     });
 
+    // TODO - if `<ViewerProvider>` is not set up (which is very possible) then calculator paths won't be resolved.
+    const getSubvalueByPath = useGetSubvalueByPath();
+
     if (!squiggleOutput) {
       return <RefreshIcon className="animate-spin" />;
     }
 
-    return (
-      <DynamicSquiggleViewer
-        rootPathOverride={rootPathOverride}
-        squiggleOutput={squiggleOutput}
-        isRunning={isRunning}
-        environment={environment}
-        {...settings}
-      />
-    );
+    if (rootPathOverride) {
+      const rootValue =
+        rootPathOverride.root === "result"
+          ? getResultValue(squiggleOutput)
+          : getResultVariables(squiggleOutput);
+      if (!rootValue) {
+        return <MessageAlert heading="Value is not defined" />;
+      }
+      if (!rootValue.ok) {
+        return <SquiggleErrorAlert error={rootValue.value} />;
+      }
+
+      const value = getSubvalueByPath(rootValue.value, rootPathOverride);
+      if (!value) {
+        return <MessageAlert heading="Value is not defined" />;
+      }
+
+      return <SquiggleViewer value={{ ok: true, value }} />;
+    } else {
+      return (
+        <DynamicSquiggleViewer
+          squiggleOutput={squiggleOutput}
+          isRunning={isRunning}
+          environment={environment}
+          {...settings}
+        />
+      );
+    }
   }
 );

--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -12,9 +12,9 @@ import {
 } from "../lib/hooks/useSquiggle.js";
 import { getResultValue, getResultVariables } from "../lib/utility.js";
 import { MessageAlert } from "./Alert.js";
-import { DynamicSquiggleViewer } from "./DynamicSquiggleViewer.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
 import { SquiggleErrorAlert } from "./SquiggleErrorAlert.js";
+import { SquiggleOutputViewer } from "./SquiggleOutputViewer/index.js";
 import { useGetSubvalueByPath } from "./SquiggleViewer/utils.js";
 
 export type SquiggleChartProps = {
@@ -71,7 +71,7 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
       return <SquiggleViewer value={{ ok: true, value }} />;
     } else {
       return (
-        <DynamicSquiggleViewer
+        <SquiggleOutputViewer
           squiggleOutput={squiggleOutput}
           isRunning={isRunning}
           environment={environment}

--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -50,7 +50,6 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
         rootPathOverride={rootPathOverride}
         squiggleOutput={squiggleOutput}
         isRunning={isRunning}
-        showHeader={showHeader}
         environment={environment}
         {...settings}
       />

--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -5,8 +5,8 @@ import { useRunnerState } from "../lib/hooks/useRunnerState.js";
 import { useSquiggle } from "../lib/hooks/useSquiggle.js";
 import { getErrors } from "../lib/utility.js";
 import { CodeEditor, CodeEditorHandle } from "./CodeEditor/index.js";
-import { DynamicSquiggleViewer } from "./DynamicSquiggleViewer.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
+import { SquiggleOutputViewer } from "./SquiggleOutputViewer/index.js";
 import { SquiggleCodeProps } from "./types.js";
 
 export type SquiggleEditorProps = SquiggleCodeProps & {
@@ -62,7 +62,7 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
         />
       </div>
       {hideViewer || !squiggleOutput?.code ? null : (
-        <DynamicSquiggleViewer
+        <SquiggleOutputViewer
           squiggleOutput={squiggleOutput}
           isRunning={isRunning}
           editor={editorRef.current ?? undefined}

--- a/packages/components/src/components/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/SquiggleErrorAlert.tsx
@@ -1,3 +1,4 @@
+import { clsx } from "clsx";
 import { FC, PropsWithChildren } from "react";
 
 import {
@@ -25,8 +26,8 @@ const LocationLine: FC<{
 
   return (
     <span
-      className="cursor-pointer hover:underline text-blue-500"
-      onClick={findInEditor}
+      className={clsx(editor && "cursor-pointer hover:underline text-blue-500")}
+      onClick={editor ? findInEditor : undefined}
     >
       line {location.start.line}, column {location.start.column}
     </span>

--- a/packages/components/src/components/SquiggleOutputViewer/Indicator.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/Indicator.tsx
@@ -1,0 +1,21 @@
+import { FC } from "react";
+
+import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
+
+export const Indicator: FC<{ output: SquiggleOutput; isRunning: boolean }> = ({
+  output,
+  isRunning,
+}) => {
+  const showTime = (executionTime: number) =>
+    executionTime > 1000
+      ? `${(executionTime / 1000).toFixed(2)}s`
+      : `${executionTime}ms`;
+
+  return (
+    <div className="text-zinc-400 text-sm whitespace-nowrap">
+      {isRunning
+        ? "rendering..."
+        : `render #${output.executionId} in ${showTime(output.executionTime)}`}
+    </div>
+  );
+};

--- a/packages/components/src/components/SquiggleOutputViewer/Layout.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/Layout.tsx
@@ -1,0 +1,23 @@
+import { FC, ReactNode } from "react";
+
+export const Layout: FC<{
+  viewer: ReactNode;
+  menu: ReactNode;
+  indicator: ReactNode;
+}> = ({ viewer, menu, indicator }) => {
+  return (
+    // `flex flex-col` helps to fit this in playground right panel and doesn't hurt otherwise
+    <div className="flex flex-col overflow-y-auto">
+      <div className="flex justify-between items-center px-2 h-8 mb-1">
+        {menu}
+        {indicator}
+      </div>
+      <div
+        className="flex-1 overflow-auto px-2 pb-1"
+        data-testid="dynamic-viewer-result"
+      >
+        {viewer}
+      </div>
+    </div>
+  );
+};

--- a/packages/components/src/components/SquiggleOutputViewer/index.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/index.tsx
@@ -16,6 +16,7 @@ import { getResultValue, getResultVariables } from "../../lib/utility.js";
 import { CodeEditorHandle } from "../CodeEditor/index.js";
 import { ErrorBoundary } from "../ErrorBoundary.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
+import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { SquiggleViewerHandle } from "../SquiggleViewer/index.js";
 import { Indicator } from "./Indicator.js";
 import { Layout } from "./Layout.js";
@@ -60,32 +61,35 @@ export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
 
     let squiggleViewer: JSX.Element | null = null;
     if (squiggleOutput.code) {
-      let usedValue: result<SqValue, SqError> | undefined;
+      let usedResult: result<SqValue, SqError> | undefined;
       switch (mode) {
         case "result":
-          usedValue = resultItem;
+          usedResult = resultItem;
           break;
         case "variables":
-          usedValue = resultVariables;
+          usedResult = resultVariables;
       }
-      squiggleViewer = (
-        <div className="relative">
-          {isRunning && (
-            // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
-            <div className="absolute z-10 inset-0 bg-white opacity-50" />
-          )}
-          {usedValue ? (
+
+      if (usedResult) {
+        squiggleViewer = usedResult.ok ? (
+          <div className="relative">
+            {isRunning && (
+              // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
+              <div className="absolute z-10 inset-0 bg-white opacity-50" />
+            )}
             <ErrorBoundary>
               <SquiggleViewer
                 {...settings}
                 ref={viewerRef}
-                value={usedValue}
+                value={usedResult.value}
                 editor={editor}
               />
             </ErrorBoundary>
-          ) : null}
-        </div>
-      );
+          </div>
+        ) : (
+          <SquiggleErrorAlert error={usedResult.value} />
+        );
+      }
     }
 
     return (

--- a/packages/components/src/components/SquiggleOutputViewer/index.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/index.tsx
@@ -74,14 +74,16 @@ export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
             // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
             <div className="absolute z-10 inset-0 bg-white opacity-50" />
           )}
-          <ErrorBoundary>
-            <SquiggleViewer
-              {...settings}
-              ref={viewerRef}
-              value={usedValue}
-              editor={editor}
-            />
-          </ErrorBoundary>
+          {usedValue ? (
+            <ErrorBoundary>
+              <SquiggleViewer
+                {...settings}
+                ref={viewerRef}
+                value={usedValue}
+                editor={editor}
+              />
+            </ErrorBoundary>
+          ) : null}
         </div>
       );
     }

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -11,12 +11,12 @@ import { SqLinker, SqProject } from "@quri/squiggle-lang";
 import { RefreshIcon } from "@quri/ui";
 
 import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
-import { DynamicSquiggleViewer } from "../DynamicSquiggleViewer.js";
 import {
   defaultPlaygroundSettings,
   PartialPlaygroundSettings,
   type PlaygroundSettings,
 } from "../PlaygroundSettings.js";
+import { SquiggleOutputViewer } from "../SquiggleOutputViewer/index.js";
 import { SquiggleViewerHandle } from "../SquiggleViewer/index.js";
 import {
   LeftPlaygroundPanel,
@@ -161,7 +161,7 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
 
   const renderRight = () =>
     output.output ? (
-      <DynamicSquiggleViewer
+      <SquiggleOutputViewer
         squiggleOutput={output.output}
         isRunning={output.isRunning}
         // FIXME - this will cause viewer to be rendered twice on initial render

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 
 import { SqLinker, SqProject } from "@quri/squiggle-lang";
+import { RefreshIcon } from "@quri/ui";
 
 import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
 import { DynamicSquiggleViewer } from "../DynamicSquiggleViewer.js";
@@ -158,16 +159,21 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
     />
   );
 
-  const renderRight = () => (
-    <DynamicSquiggleViewer
-      squiggleOutput={output.output}
-      isRunning={output.isRunning}
-      // FIXME - this will cause viewer to be rendered twice on initial render
-      editor={leftPanelRef.current?.getEditor() ?? undefined}
-      ref={rightPanelRef}
-      {...settings}
-    />
-  );
+  const renderRight = () =>
+    output.output ? (
+      <DynamicSquiggleViewer
+        squiggleOutput={output.output}
+        isRunning={output.isRunning}
+        // FIXME - this will cause viewer to be rendered twice on initial render
+        editor={leftPanelRef.current?.getEditor() ?? undefined}
+        ref={rightPanelRef}
+        {...settings}
+      />
+    ) : (
+      <div className="grid place-items-center h-full">
+        <RefreshIcon className="animate-spin text-slate-400" size={24} />
+      </div>
+    );
 
   return (
     <PlaygroundContext.Provider value={{ getLeftPanelElement }}>

--- a/packages/components/src/components/SquiggleViewer/ValueViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueViewer.tsx
@@ -6,15 +6,15 @@ import { valueHasContext } from "../../lib/utility.js";
 import { MessageAlert } from "../Alert.js";
 import { ValueWithContextViewer } from "./ValueWithContextViewer.js";
 
-type Props = {
+// Same props as in `ValueWithContextViewer`, but no guarantee that value has context.
+type Props = Omit<Parameters<typeof ValueWithContextViewer>[0], "value"> & {
   value: SqValue;
-  parentValue?: SqValue;
 };
 
-export const ValueViewer: React.FC<Props> = ({ value, parentValue }) => {
+export const ValueViewer: React.FC<Props> = ({ value, ...rest }) => {
   if (!valueHasContext(value)) {
     return <MessageAlert heading="Can't display pathless value" />;
   }
 
-  return <ValueWithContextViewer value={value} parentValue={parentValue} />;
+  return <ValueWithContextViewer value={value} {...rest} />;
 };

--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -112,9 +112,7 @@ const ValueViewerBody: FC<Props> = ({ value, size = "normal" }) => {
 export const ValueWithContextViewer: FC<Props> = ({
   value,
   parentValue,
-  collapsible = true,
-  header: propsHeader,
-  size = "normal",
+  ...props
 }) => {
   const { tag } = value;
   const { path } = value.context;
@@ -129,7 +127,9 @@ export const ValueWithContextViewer: FC<Props> = ({
   const taggedName = value.tags.name();
 
   // root header is always hidden (unless forced, but we probably won't need it)
-  const header = propsHeader ?? (isRoot ? "hide" : "show");
+  const header = props.header ?? (isRoot ? "hide" : "show");
+  const collapsible = header === "hide" ? false : props.collapsible ?? true;
+  const size = props.size ?? "normal";
 
   const toggleCollapsed = () => {
     toggleCollapsed_(path);

--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -22,7 +22,6 @@ import {
 } from "./utils.js";
 import {
   useFocus,
-  useIsFocused,
   useMergedSettings,
   useRegisterAsItemViewer,
   useToggleCollapsed,
@@ -49,6 +48,9 @@ const CommentIconForValue: FC<{ value: SqValueWithContext }> = ({ value }) => {
 type Props = {
   value: SqValueWithContext;
   parentValue?: SqValue;
+  collapsible?: boolean;
+  header?: "normal" | "large" | "hide";
+  size?: "normal" | "large";
 };
 
 const WithComment: FC<PropsWithChildren<Props>> = ({ value, children }) => {
@@ -89,19 +91,16 @@ const WithComment: FC<PropsWithChildren<Props>> = ({ value, children }) => {
   );
 };
 
-const ValueViewerBody: FC<Props> = ({ value }) => {
+const ValueViewerBody: FC<Props> = ({ value, size = "normal" }) => {
   const { path } = value.context;
-  const isFocused = useIsFocused(path);
-  const isRoot = path.isRoot();
-
   const mergedSettings = useMergedSettings(path);
   const adjustedMergedSettings = useMemo(() => {
     const { chartHeight } = mergedSettings;
     return {
       ...mergedSettings,
-      chartHeight: isFocused || isRoot ? chartHeight * 4 : chartHeight,
+      chartHeight: size === "large" ? chartHeight * 4 : chartHeight,
     };
-  }, [isFocused, isRoot, mergedSettings]);
+  }, [size, mergedSettings]);
 
   return (
     <WithComment value={value}>
@@ -110,7 +109,13 @@ const ValueViewerBody: FC<Props> = ({ value }) => {
   );
 };
 
-export const ValueWithContextViewer: FC<Props> = ({ value, parentValue }) => {
+export const ValueWithContextViewer: FC<Props> = ({
+  value,
+  parentValue,
+  collapsible = true,
+  header: propsHeader,
+  size = "normal",
+}) => {
   const { tag } = value;
   const { path } = value.context;
 
@@ -120,10 +125,11 @@ export const ValueWithContextViewer: FC<Props> = ({ value, parentValue }) => {
   const { itemStore } = useViewerContext();
   const itemState = itemStore.getStateOrInitialize(value);
 
-  const isFocused = useIsFocused(path);
-
   const isRoot = path.isRoot();
   const taggedName = value.tags.name();
+
+  // root header is always hidden (unless forced, but we probably won't need it)
+  const header = propsHeader ?? (isRoot ? "hide" : "show");
 
   const toggleCollapsed = () => {
     toggleCollapsed_(path);
@@ -131,13 +137,16 @@ export const ValueWithContextViewer: FC<Props> = ({ value, parentValue }) => {
 
   const ref = useRegisterAsItemViewer(path);
 
-  const isOpen = isFocused || !itemState.collapsed;
-  const _focus = () => !isFocused && !isRoot && focus(path);
+  // TODO - check that we're not in a situation where `isOpen` is false and `header` is hidden?
+  // In that case, the output would look broken (empty).
+  const isOpen = !collapsible || !itemState.collapsed;
+
+  const _focus = () => focus(path);
 
   const triangleToggle = () => {
-    const Icon = isOpen ? ExpandedIcon : CollapsedIcon;
+    const Icon = itemState.collapsed ? CollapsedIcon : ExpandedIcon;
     const _hasExtraContentToShow = hasExtraContentToShow(value);
-    //Only show triangle if there is content to show, that's not in the header.
+    // Only show triangle if there is content to show, that's not in the header.
     if (_hasExtraContentToShow) {
       return (
         <div
@@ -155,48 +164,49 @@ export const ValueWithContextViewer: FC<Props> = ({ value, parentValue }) => {
     }
   };
 
-  const getHeaderColor = () => {
-    let color = "text-orange-900";
-    const parentTag = parentValue?.tag;
-    if (parentTag === "Array") {
-      color = "text-stone-400";
-    } else if (path.items.length > 1) {
-      color = "text-teal-700";
-    }
-    return color;
+  const headerName = () => {
+    const name = pathToShortName(path);
+
+    // We want to show colons after the keys, for dicts/arrays.
+    const showColon = header !== "large" && path.items.length > 1;
+
+    const getHeaderColor = () => {
+      let color = "text-orange-900";
+      const parentTag = parentValue?.tag;
+      if (parentTag === "Array") {
+        color = "text-stone-400";
+      } else if (path.items.length > 1) {
+        color = "text-teal-700";
+      }
+      return color;
+    };
+
+    const headerColor = getHeaderColor();
+
+    const headerClasses = () => {
+      if (header === "large") {
+        return clsx("text-md font-bold ml-1", headerColor);
+      } else if (isRoot) {
+        return "text-sm text-stone-600 font-semibold";
+      } else {
+        return clsx("text-sm cursor-pointer hover:underline", headerColor);
+      }
+    };
+
+    return (
+      <div className={clsx("leading-3", showColon || "mr-3")}>
+        <span
+          className={clsx(!taggedName && "font-mono", headerClasses())}
+          onClick={_focus}
+        >
+          {taggedName || name}
+        </span>
+        {showColon && <span className="text-gray-400 font-mono">:</span>}
+      </div>
+    );
   };
-
-  const headerColor = getHeaderColor();
-
-  const headerClasses = () => {
-    if (isFocused) {
-      return clsx("text-md font-bold ml-1", headerColor);
-    } else if (isRoot) {
-      return "text-sm text-stone-600 font-semibold";
-    } else {
-      return clsx("text-sm cursor-pointer hover:underline", headerColor);
-    }
-  };
-
-  //We want to show colons after the keys, for dicts/arrays.
-  const showColon = !isFocused && path.items.length > 1;
-  const name = pathToShortName(path);
-  const headerName = (
-    <div className="leading-3">
-      <span
-        className={clsx(!taggedName && "font-mono", headerClasses())}
-        onClick={_focus}
-      >
-        {taggedName ? taggedName : name}
-      </span>
-      {showColon && <span className={"text-gray-400 font-mono"}>:</span>}
-    </div>
-  );
 
   const leftCollapseBorder = () => {
-    if (isRoot) {
-      return null;
-    }
     const isDictOrList = tag === "Dict" || tag === "Array";
     if (isDictOrList) {
       return (
@@ -208,39 +218,36 @@ export const ValueWithContextViewer: FC<Props> = ({ value, parentValue }) => {
         </div>
       );
     } else {
-      // non-root leaf elements have unclickable padding to align with dict/list elements
+      // Non-root leaf elements have unclickable padding to align with dict/list elements.
       return <div className="flex w-4 min-w-[1rem]" />; // min-w-1rem = w-4
     }
   };
 
   return (
     <ErrorBoundary>
-      <div ref={ref} className={clsx(isFocused && "px-2")}>
-        <header
-          className={clsx(
-            "flex justify-between group pr-0.5",
-            isFocused ? "mb-2" : "hover:bg-stone-100 rounded-sm"
-          )}
-        >
-          <div className="inline-flex items-center">
-            {!isFocused && triangleToggle()}
-            {headerName}
-            {!isFocused && !isOpen && (
-              <div
-                className={clsx(
-                  "text-sm text-blue-800",
-                  showColon ? "ml-2" : "ml-5"
-                )}
-              >
-                <SquiggleValuePreview value={value} />
-              </div>
+      <div ref={ref}>
+        {header !== "hide" && (
+          <header
+            className={clsx(
+              "flex justify-between group pr-0.5",
+              header === "large" ? "mb-2" : "hover:bg-stone-100 rounded-sm"
             )}
-            {!isFocused && !isOpen && <CommentIconForValue value={value} />}
-          </div>
-          <div className="inline-flex space-x-1 items-center">
-            <SquiggleValueMenu value={value} />
-          </div>
-        </header>
+          >
+            <div className="inline-flex items-center">
+              {collapsible && triangleToggle()}
+              {headerName()}
+              {!isOpen && (
+                <div className="text-sm text-blue-800 ml-2">
+                  <SquiggleValuePreview value={value} />
+                </div>
+              )}
+              {!isOpen && <CommentIconForValue value={value} />}
+            </div>
+            <div className="inline-flex space-x-1 items-center">
+              <SquiggleValueMenu value={value} />
+            </div>
+          </header>
+        )}
         {isOpen && (
           <div
             className={clsx(
@@ -248,9 +255,9 @@ export const ValueWithContextViewer: FC<Props> = ({ value, parentValue }) => {
               Boolean(getValueComment(value)) && "py-2"
             )}
           >
-            {!isFocused && leftCollapseBorder()}
+            {collapsible && leftCollapseBorder()}
             <div className="grow">
-              <ValueViewerBody value={value} />
+              <ValueViewerBody value={value} size={size} />
             </div>
           </div>
         )}

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -303,7 +303,6 @@ export const ViewerProvider = forwardRef<
     partialPlaygroundSettings: PartialPlaygroundSettings;
     editor?: CodeEditorHandle;
     beginWithVariablesCollapsed?: boolean;
-    rootPathOverride?: SqValuePath;
   }>
 >(
   (
@@ -311,7 +310,6 @@ export const ViewerProvider = forwardRef<
       partialPlaygroundSettings,
       editor,
       beginWithVariablesCollapsed,
-      rootPathOverride,
       children,
     },
     ref
@@ -326,9 +324,7 @@ export const ViewerProvider = forwardRef<
       },
     }));
 
-    const [focused, setFocused] = useState<SqValuePath | undefined>(
-      rootPathOverride
-    );
+    const [focused, setFocused] = useState<SqValuePath | undefined>();
 
     const globalSettings = useMemo(() => {
       return merge({}, defaultPlaygroundSettings, partialPlaygroundSettings);

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -258,8 +258,17 @@ export function useHasLocalSettings(path: SqValuePath) {
 }
 
 export function useFocus() {
-  const { setFocused } = useViewerContext();
-  return (value: SqValuePath) => setFocused(value);
+  const { focused, setFocused } = useViewerContext();
+  return (path: SqValuePath) => {
+    if (focused && pathAsString(focused) === pathAsString(path)) {
+      return; // nothing to do
+    }
+    if (path.isRoot()) {
+      setFocused(undefined); // focusing on root nodes is not allowed
+    } else {
+      setFocused(path);
+    }
+  };
 }
 
 export function useUnfocus() {

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -52,7 +52,9 @@ const FocusedNavigation: FC<{
 
   return (
     <div className="flex items-center mb-3 pl-3">
-      {!rootPath && <FocusedNavigationItem onClick={unfocus} text="Home" />}
+      {!rootPath?.items.length && (
+        <FocusedNavigationItem onClick={unfocus} text="Home" />
+      )}
 
       {focusedPath
         .itemsAsValuePaths({ includeRoot: false })

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Fragment, memo, useImperativeHandle } from "react";
+import { FC, forwardRef, Fragment, memo } from "react";
 
 import {
   result,
@@ -40,14 +40,12 @@ export type SquiggleViewerProps = {
   rootPathOverride?: SqValuePath;
 } & PartialPlaygroundSettings;
 
-const SquiggleViewerOuter = forwardRef<
-  SquiggleViewerHandle,
-  SquiggleViewerProps
->(function SquiggleViewerOuter(
-  { resultVariables, resultItem, rootPathOverride },
-  ref
-) {
-  const { focused, itemStore } = useViewerContext();
+const SquiggleViewerOuter: FC<SquiggleViewerProps> = ({
+  resultVariables,
+  resultItem,
+  rootPathOverride,
+}) => {
+  const { focused } = useViewerContext();
   const unfocus = useUnfocus();
   const focus = useFocus();
 
@@ -58,7 +56,7 @@ const SquiggleViewerOuter = forwardRef<
     focused && rootPathOverride && pathIsEqual(focused, rootPathOverride);
 
   // If we're focused on the root path override, we need to adjust the focused path accordingly when presenting the navigation, so that it begins with the root path intead. This is a bit confusing.
-  const rootPathFocusedAdjustment: number = rootPathOverride
+  const rootPathFocusedAdjustment = rootPathOverride
     ? rootPathOverride.items.length - 1
     : 0;
 
@@ -87,12 +85,6 @@ const SquiggleViewerOuter = forwardRef<
         ))}
     </div>
   );
-
-  useImperativeHandle(ref, () => ({
-    viewValuePath(path: SqValuePath) {
-      itemStore.scrollToPath(path);
-    },
-  }));
 
   const resultVariableLength = resultVariables.ok
     ? nonHiddenDictEntries(resultVariables.value.value).length
@@ -140,7 +132,7 @@ const SquiggleViewerOuter = forwardRef<
       {body()}
     </div>
   );
-});
+};
 
 const innerComponent = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
   function SquiggleViewer(
@@ -161,21 +153,23 @@ const innerComponent = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
     const stablePartialPlaygroundSettings = useStabilizeObjectIdentity(
       partialPlaygroundSettings
     );
+
     const hasResultVariables =
       resultVariables.ok &&
       nonHiddenDictEntries(resultVariables.value.value).length > 0;
+
     return (
       <ViewerProvider
         partialPlaygroundSettings={stablePartialPlaygroundSettings}
         editor={editor}
         beginWithVariablesCollapsed={resultItem?.ok && hasResultVariables}
         rootPathOverride={rootPathOverride}
+        ref={ref}
       >
         <SquiggleViewerOuter
           resultVariables={resultVariables}
           resultItem={resultItem}
           rootPathOverride={rootPathOverride}
-          ref={ref}
         />
       </ViewerProvider>
     );

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -1,13 +1,12 @@
 import { FC, forwardRef, memo } from "react";
 
-import { result, SqError, SqValue, SqValuePath } from "@quri/squiggle-lang";
+import { SqValue, SqValuePath } from "@quri/squiggle-lang";
 import { ChevronRightIcon } from "@quri/ui";
 
 import { useStabilizeObjectIdentity } from "../../lib/hooks/useStabilizeObject.js";
 import { MessageAlert } from "../Alert.js";
 import { CodeEditorHandle } from "../CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
-import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { pathIsEqual, pathItemFormat, useGetSubvalueByPath } from "./utils.js";
 import { ValueViewer } from "./ValueViewer.js";
 import {
@@ -75,7 +74,7 @@ export type SquiggleViewerHandle = {
 };
 
 export type SquiggleViewerProps = {
-  value: result<SqValue, SqError>;
+  value: SqValue;
   editor?: CodeEditorHandle;
 } & PartialPlaygroundSettings;
 
@@ -85,16 +84,8 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({ value }) => {
   const getSubvalueByPath = useGetSubvalueByPath();
 
   let focusedItem: SqValue | undefined;
-  if (focused && value.ok) {
-    focusedItem = getSubvalueByPath(value.value, focused);
-  }
-
-  if (!value.ok) {
-    return (
-      <div className="px-1">
-        <SquiggleErrorAlert error={value.value} />
-      </div>
-    );
+  if (focused) {
+    focusedItem = getSubvalueByPath(value, focused);
   }
 
   const body = () => {
@@ -114,7 +105,7 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({ value }) => {
         return <MessageAlert heading="Focused variable is not defined" />;
       }
     } else {
-      return <ValueViewer value={value.value} />;
+      return <ValueViewer value={value} />;
     }
   };
 
@@ -123,7 +114,7 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({ value }) => {
       {focused && (
         <FocusedNavigation
           focusedPath={focused}
-          rootPath={value.value.context?.path}
+          rootPath={value.context?.path}
         />
       )}
       {body()}

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -50,7 +50,7 @@ const FocusedNavigation: FC<{
 
   return (
     <div className="flex items-center mb-3 pl-3">
-      {!rootPath && <FocusedNavigationItem onClick={unfocus} text="Root" />}
+      {!rootPath && <FocusedNavigationItem onClick={unfocus} text="Home" />}
 
       {focusedPath
         .itemsAsValuePaths({ includeRoot: false })
@@ -100,7 +100,16 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({
       );
     } else if (focused) {
       if (focusedItem) {
-        return <ValueViewer value={focusedItem} />;
+        return (
+          <div className="px-2">
+            <ValueViewer
+              value={focusedItem}
+              collapsible={false}
+              header="large"
+              size="large"
+            />
+          </div>
+        );
       } else {
         return <MessageAlert heading="Focused variable is not defined" />;
       }

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -34,7 +34,7 @@ const FocusedNavigationItem: FC<{
 
 const FocusedNavigation: FC<{
   focusedPath: SqValuePath;
-  rootPath: SqValuePath | undefined;
+  rootPath?: SqValuePath | undefined;
 }> = ({ focusedPath, rootPath }) => {
   const unfocus = useUnfocus();
   const focus = useFocus();
@@ -46,7 +46,9 @@ const FocusedNavigation: FC<{
   }
 
   // If we're focused on the root path override, we need to adjust the focused path accordingly when presenting the navigation, so that it begins with the root path intead. This is a bit confusing.
-  const rootPathFocusedAdjustment = rootPath ? rootPath.items.length - 1 : 0;
+  const rootPathFocusedAdjustment = rootPath?.items.length
+    ? rootPath.items.length - 1
+    : 0;
 
   return (
     <div className="flex items-center mb-3 pl-3">
@@ -73,14 +75,10 @@ export type SquiggleViewerHandle = {
 export type SquiggleViewerProps = {
   value: result<SqValue, SqError> | undefined; // "undefined" is an error, it means that we failed to provide the value
   editor?: CodeEditorHandle;
-  rootPathOverride?: SqValuePath;
 } & PartialPlaygroundSettings;
 
-const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({
-  value,
-  rootPathOverride,
-}) => {
-  const { focused = rootPathOverride } = useViewerContext();
+const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({ value }) => {
+  const { focused } = useViewerContext();
 
   const getSubvalueByPath = useGetSubvalueByPath();
 
@@ -89,16 +87,18 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({
     focusedItem = getSubvalueByPath(value.value, focused);
   }
 
+  if (!value) {
+    return <MessageAlert heading="Value is not defined" />;
+  } else if (!value.ok) {
+    return (
+      <div className="px-1">
+        <SquiggleErrorAlert error={value.value} />
+      </div>
+    );
+  }
+
   const body = () => {
-    if (!value) {
-      return <MessageAlert heading="Value is not defined" />;
-    } else if (!value.ok) {
-      return (
-        <div className="px-1">
-          <SquiggleErrorAlert error={value.value} />
-        </div>
-      );
-    } else if (focused) {
+    if (focused) {
       if (focusedItem) {
         return (
           <div className="px-2">
@@ -121,7 +121,10 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({
   return (
     <div>
       {focused && (
-        <FocusedNavigation focusedPath={focused} rootPath={rootPathOverride} />
+        <FocusedNavigation
+          focusedPath={focused}
+          rootPath={value.value.context?.path}
+        />
       )}
       {body()}
     </div>
@@ -130,7 +133,7 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({
 
 const component = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
   function SquiggleViewer(
-    { value, editor, rootPathOverride, ...partialPlaygroundSettings },
+    { value, editor, ...partialPlaygroundSettings },
     ref
   ) {
     /**
@@ -148,10 +151,7 @@ const component = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
         editor={editor}
         ref={ref}
       >
-        <SquiggleViewerWithoutProvider
-          value={value}
-          rootPathOverride={rootPathOverride}
-        />
+        <SquiggleViewerWithoutProvider value={value} />
       </ViewerProvider>
     );
   }

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -75,7 +75,7 @@ export type SquiggleViewerHandle = {
 };
 
 export type SquiggleViewerProps = {
-  value: result<SqValue, SqError> | undefined; // "undefined" is an error, it means that we failed to provide the value
+  value: result<SqValue, SqError>;
   editor?: CodeEditorHandle;
 } & PartialPlaygroundSettings;
 
@@ -85,13 +85,11 @@ const SquiggleViewerWithoutProvider: FC<SquiggleViewerProps> = ({ value }) => {
   const getSubvalueByPath = useGetSubvalueByPath();
 
   let focusedItem: SqValue | undefined;
-  if (focused && value?.ok) {
+  if (focused && value.ok) {
     focusedItem = getSubvalueByPath(value.value, focused);
   }
 
-  if (!value) {
-    return <MessageAlert heading="Value is not defined" />;
-  } else if (!value.ok) {
+  if (!value.ok) {
     return (
       <div className="px-1">
         <SquiggleErrorAlert error={value.value} />

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -89,10 +89,14 @@ export function useGetSubvalueByPath() {
   };
 
   return (value: SqValue, path: SqValuePath): SqValue | undefined => {
-    if (!value.context) {
+    const { context } = value;
+    if (!context) {
       return;
     }
-    const { context } = value;
+    if (context.path.root !== path.root) {
+      return;
+    }
+
     for (const pathItem of path.itemsAsValuePaths({ includeRoot: false })) {
       const key = pathItem.items[pathItem.items.length - 1];
       let nextValue: SqValue | undefined;

--- a/packages/components/src/components/SquiggleViewer/utils.ts
+++ b/packages/components/src/components/SquiggleViewer/utils.ts
@@ -43,7 +43,7 @@ export function pathIsEqual(path1: SqValuePath, path2: SqValuePath) {
   return pathAsString(path1) === pathAsString(path2);
 }
 
-export function pathToShortName(path: SqValuePath): string | undefined {
+export function pathToShortName(path: SqValuePath): string {
   if (isTopLevel(path)) {
     return topLevelName(path);
   } else {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -20,6 +20,8 @@ export {
 export { SquiggleViewer } from "./components/SquiggleViewer/index.js";
 export { ToolbarItem as PlaygroundToolbarItem } from "./components/ui/PanelWithToolbar/ToolbarItem.js";
 
+export { SquiggleErrorAlert } from "./components/SquiggleErrorAlert.js";
+
 export { RelativeValueCell } from "./widgets/PlotWidget/RelativeValuesGridChart/RelativeValueCell.js";
 
 // for use in relative values

--- a/packages/components/src/stories/InternalComponents/FnDocumentation.stories.tsx
+++ b/packages/components/src/stories/InternalComponents/FnDocumentation.stories.tsx
@@ -6,7 +6,7 @@ import {
   getFunctionDocumentation,
 } from "@quri/squiggle-lang";
 
-import { FnDocumentation as Component } from "../components/ui/FnDocumentation.js";
+import { FnDocumentation as Component } from "../../components/ui/FnDocumentation.js";
 
 /**
  * Internal UI component. Used in `SquigglePlayground`.

--- a/packages/components/src/stories/InternalComponents/PanelWithToolbar.stories.tsx
+++ b/packages/components/src/stories/InternalComponents/PanelWithToolbar.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { Button } from "@quri/ui";
 
-import { PanelWithToolbar } from "../components/ui/PanelWithToolbar/index.js";
-import { ToolbarItem } from "../components/ui/PanelWithToolbar/ToolbarItem.js";
+import { PanelWithToolbar } from "../../components/ui/PanelWithToolbar/index.js";
+import { ToolbarItem } from "../../components/ui/PanelWithToolbar/ToolbarItem.js";
 
 /**
  * Internal UI component. Used in `SquigglePlayground`.

--- a/packages/components/src/stories/Intro.mdx
+++ b/packages/components/src/stories/Intro.mdx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/blocks";
+import LinkTo from '@storybook/addon-links/react';
 
 <Meta title="Squiggle/Introduction" />
 
@@ -6,3 +7,10 @@ import { Meta } from "@storybook/blocks";
 
 This is the component library for Squiggle. These are React
 components, and can be used in any application that you see fit.
+
+# What do you need?
+
+- <LinkTo kind="Squiggle/SquiggleEditor" story="Docs">\<SquiggleEditor\></LinkTo> — Squiggle code editor that shows its output
+- <LinkTo kind="Squiggle/SquigglePlayground" story="Docs">\<SquiglgePlayground\></LinkTo> — Opinionated playground component
+- <LinkTo kind="Squiggle/SquiggleChart" story="Docs">\<SquiggleChart\></LinkTo> — Display the output of a given Squiggle code string
+- <LinkTo kind="Squiggle/SquiggleViewer" story="Docs">\<SquiggleViewer\></LinkTo> — Display `SqValue` that you've obtained through `squiggle-lang` APIs

--- a/packages/components/src/stories/Intro.mdx
+++ b/packages/components/src/stories/Intro.mdx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/blocks";
-import LinkTo from '@storybook/addon-links/react';
+import LinkTo from "@storybook/addon-links/react";
 
 <Meta title="Squiggle/Introduction" />
 

--- a/packages/components/src/stories/SquiggleChart.stories.tsx
+++ b/packages/components/src/stories/SquiggleChart.stories.tsx
@@ -5,7 +5,7 @@ import { SqValuePath } from "@quri/squiggle-lang";
 import { SquiggleChart } from "../components/SquiggleChart.js";
 
 /**
- * Squiggle chart evaluates Squiggle code, and then displays the output.
+ * `<SquiggleChart>` evaluates Squiggle code, and then displays the output.
  *
  * By default, it will give access to both "Variables" and "Result", but this can be controlled with `rootPathOverride` parameter. Using it will limit the output to a single value.
  */

--- a/packages/components/src/stories/SquiggleChart.stories.tsx
+++ b/packages/components/src/stories/SquiggleChart.stories.tsx
@@ -1,11 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { SqValuePath } from "@quri/squiggle-lang";
+
 import { SquiggleChart } from "../components/SquiggleChart.js";
 
 /**
- * Squiggle chart evaluates squiggle expressions, and then displays the resulting squiggle value.
+ * Squiggle chart evaluates Squiggle code, and then displays the output.
  *
- * A squiggle value can be a nested tree of arrays and dicts. Possible leaf types are a distribution, a constant, and a function.
+ * By default, it will give access to both "Variables" and "Result", but this can be controlled with `rootPathOverride` parameter. Using it will limit the output to a single value.
  */
 const meta = {
   component: SquiggleChart,
@@ -25,13 +27,6 @@ export const Nested: Story = {
   },
 };
 
-export const WithHeader: Story = {
-  args: {
-    ...Nested.args,
-    showHeader: true,
-  },
-};
-
 export const Array: Story = {
   args: {
     code: "[normal(5,2), normal(10,1), normal(40,2), 400000]",
@@ -47,5 +42,15 @@ export const Error: Story = {
 export const Dict: Story = {
   args: {
     code: "{foo: 35 to 50, bar: [1,2,3]}",
+  },
+};
+
+export const RootPathOverride: Story = {
+  args: {
+    code: "{foo: 35 to 50, bar: [1,2,3]}",
+    rootPathOverride: new SqValuePath({
+      root: "result",
+      items: [{ type: "string", value: "bar" }],
+    }),
   },
 };

--- a/packages/components/src/stories/SquiggleErrorAlert.stories.tsx
+++ b/packages/components/src/stories/SquiggleErrorAlert.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { run } from "@quri/squiggle-lang";
+
+import { SquiggleErrorAlert as Component } from "../components/SquiggleErrorAlert.js";
+
+/**
+ * `<SquiggleErrorAlert>` displays an `SqError` value.
+ */
+const meta = {
+  component: Component,
+} satisfies Meta<typeof Component>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+async function getErrorFromCode(code: string) {
+  const result = await run(code);
+  if (result.ok) {
+    throw new Error("Expected an error");
+  }
+  return result.value;
+}
+
+export const CompileError: Story = {
+  args: { error: await getErrorFromCode("2+") },
+};
+
+export const RuntimeError: Story = {
+  args: { error: await getErrorFromCode('2+"foo"') },
+};

--- a/packages/components/src/stories/SquiggleViewer.stories.tsx
+++ b/packages/components/src/stories/SquiggleViewer.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { run } from "@quri/squiggle-lang";
+
+import { SquiggleViewer as Component } from "../components/SquiggleViewer/index.js";
+
+/**
+ * `<SquiggleViewer>` can display an `SqValue`, that you usually obtain by calling `@quri/squiggle-lang` APIs, e.g. `SqProject.getResult` or `SqProject.getBindings`.
+ *
+ * If you want to display the output of Squiggle source code, try `<SquiggleChart>`.
+ */
+const meta: Meta<typeof Component> = { component: Component };
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const runResult = await run("[1, { dist: 2 to 3 }]");
+
+if (!runResult.ok) {
+  throw new Error("Expected an ok result");
+}
+
+const value = { ok: true, value: runResult.value.result } as const;
+
+export const Basic: Story = {
+  args: { value },
+};

--- a/packages/components/src/stories/SquiggleViewer.stories.tsx
+++ b/packages/components/src/stories/SquiggleViewer.stories.tsx
@@ -19,8 +19,6 @@ if (!runResult.ok) {
   throw new Error("Expected an ok result");
 }
 
-const value = { ok: true, value: runResult.value.result } as const;
-
 export const Basic: Story = {
-  args: { value },
+  args: { value: runResult.value.result },
 };

--- a/packages/components/vite.config.js
+++ b/packages/components/vite.config.js
@@ -1,4 +1,5 @@
 import { createRequire } from "node:module";
+
 const require = createRequire(import.meta.url);
 
 // via https://github.com/nuxt/vite/issues/160#issuecomment-983080874

--- a/packages/hub/src/app/models/[owner]/[slug]/exports/[variableName]/ModelExportPage.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/exports/[variableName]/ModelExportPage.tsx
@@ -53,7 +53,6 @@ const SquiggleModelExportPage: FC<{
     <VersionedSquiggleChart
       version={checkedVersion}
       code={content.code}
-      showHeader={false}
       rootPathOverride={rootPath}
       project={project}
     />

--- a/packages/ui/src/components/Dropdown/DropdownMenuItemLayout.tsx
+++ b/packages/ui/src/components/Dropdown/DropdownMenuItemLayout.tsx
@@ -1,12 +1,12 @@
 import { clsx } from "clsx";
-import { FC } from "react";
+import { FC, ReactNode } from "react";
 
 import { IconProps } from "../../icons/Icon.js";
 import { RefreshIcon } from "../../icons/RefreshIcon.js";
 
 export type ItemLayoutProps = {
   icon?: FC<IconProps>;
-  title: string;
+  title: string | ReactNode; // if title is JSX, you should consider text color in normal and hovered state
   acting?: boolean;
 };
 
@@ -32,7 +32,7 @@ export const DropdownMenuItemLayout: FC<ItemLayoutProps> = ({
   return (
     <div className="m-1 rounded px-2 py-1.5 flex items-center gap-2 group hover:bg-blue-100 transition-colors duration-75 cursor-pointer">
       {iconDisplay(icon, acting)}
-      <div className="text-slate-700 group-hover:text-slate-900 text-sm font-medium">
+      <div className="text-slate-700 group-hover:text-slate-900 text-sm font-medium flex-1">
         {title}
       </div>
     </div>


### PR DESCRIPTION
- Change `SquiggleViewer` props; only `SquiggleChart` supports `rootPathOverride` now, while `SquiggleViewer` takes the plain `SqValue`
- Renamed `DynamicSquiggleViewer` to `SquiggleOutputViewer` and change the top level navigation to a dropdown
- export `SquiggleErrorAlert` (no one needs it now but since we expose `SquiggleViewer`, we should expose it too)
  - also fix a small bug in it where it had links to the editor even if the editor was missing
- reorganize some stories

There might be other minor changes here and bugfixes that I've forgot about.