### PR TITLE
Off-by-one fixes & other small changes: website playground, dist charts

### DIFF
--- a/.changeset/proud-lamps-hope.md
+++ b/.changeset/proud-lamps-hope.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Fix dist chart legend positioning and how it affects the chart height

--- a/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
+++ b/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
@@ -581,7 +581,7 @@ export const DistributionsChart: FC<DistributionsChartProps> = ({
                 />
               </div>
             )}
-            {anyAreNonnormalized && (
+            {anyAreNonnormalized && height > 20 && (
               <div className="flex-1 pt-2"> {nonNormalizedError()}</div>
             )}
           </div>

--- a/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
+++ b/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
@@ -127,12 +127,20 @@ const InnerDistributionsChart: FC<{
   );
 
   const legendItemHeight = 16;
+  const legendOffset = 2;
 
-  const legendHeight = isMulti ? legendItemHeight * shapes.length : 0;
+  const legendHeight = isMulti
+    ? legendItemHeight * shapes.length + legendOffset
+    : 0;
   const samplesFooterHeight = samplesBarSetting === "bottom" ? 20 : 0;
 
-  const height = innerHeight + legendHeight + samplesFooterHeight;
   const bottomPadding = (!showXAxis ? 0 : 14) + samplesFooterHeight;
+
+  // full height of canvas
+  const height = Math.max(
+    innerHeight + samplesFooterHeight,
+    legendHeight + bottomPadding
+  );
 
   const discreteRadius = distRadiusScalingFromHeight(height);
 
@@ -183,7 +191,7 @@ const InnerDistributionsChart: FC<{
         context,
         width,
         height,
-        suggestedPadding: suggestedPadding,
+        suggestedPadding,
         xScale,
         yScale,
         showYAxis: false,
@@ -192,28 +200,6 @@ const InnerDistributionsChart: FC<{
         xAxisTitle: plot.xScale.title,
         showAxisLines: false,
       });
-
-      if (isMulti) {
-        const radius = 5;
-        for (let i = 0; i < shapes.length; i++) {
-          context.save();
-          context.translate(padding.left, legendItemHeight * i);
-          context.fillStyle = getColor(i);
-          drawCircle({
-            context,
-            x: radius,
-            y: radius,
-            r: radius,
-          });
-
-          context.textAlign = "left";
-          context.textBaseline = "middle";
-          context.fillStyle = "black";
-          context.font = "12px sans-serif";
-          context.fillText(shapes[i].name, 16, radius);
-          context.restore();
-        }
-      }
 
       // samplesBar
       function samplesBarShowSettings(): { yOffset: number; color: string } {
@@ -354,6 +340,28 @@ const InnerDistributionsChart: FC<{
           setDiscreteTooltip(newDiscreteTooltip);
         }
         frame.exit();
+      }
+
+      if (isMulti) {
+        const radius = 5;
+        for (let i = 0; i < shapes.length; i++) {
+          context.save();
+          context.translate(padding.left, legendItemHeight * i + legendOffset);
+          context.fillStyle = getColor(i);
+          drawCircle({
+            context,
+            x: radius,
+            y: radius,
+            r: radius,
+          });
+
+          context.textAlign = "left";
+          context.textBaseline = "middle";
+          context.fillStyle = "black";
+          context.font = "12px sans-serif";
+          context.fillText(shapes[i].name, 16, radius);
+          context.restore();
+        }
       }
 
       {

--- a/packages/website/src/pages/playground.mdx
+++ b/packages/website/src/pages/playground.mdx
@@ -4,7 +4,7 @@ description: Squiggle Playground
 
 import { PlaygroundPage } from "../components/PlaygroundPage";
 
-<div style={{marginTop: 1 }}>
+<div style={{ marginTop: 1 }}>
   <PlaygroundPage version={props.version} />
 </div>
 

--- a/packages/website/src/pages/playground.mdx
+++ b/packages/website/src/pages/playground.mdx
@@ -4,7 +4,9 @@ description: Squiggle Playground
 
 import { PlaygroundPage } from "../components/PlaygroundPage";
 
-<PlaygroundPage version={props.version} />
+<div style={{marginTop: 1 }}>
+  <PlaygroundPage version={props.version} />
+</div>
 
 export async function getServerSideProps({ query }) {
   return { props: { version: query.v ?? null } };


### PR DESCRIPTION
- move /playground by 1px
- move legend by 2px (fixes #2834)
- change the dist legend -> chart height logic (discussed here: https://discord.com/channels/1130609991993274510/1133551706370752582/1192201085834760353)
- fix "Not Normalized" badge on dist previews