### PR TITLE
Fixes Prettier bug where single-item dict key trailing comma would be…

### DIFF
--- a/.changeset/funny-spiders-clean.md
+++ b/.changeset/funny-spiders-clean.md
@@ -1,0 +1,5 @@
+---
+"@quri/prettier-plugin-squiggle": patch
+---
+
+"Fixes Prettier bug where trailing comma after single-element dict key would be removed"

--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -317,7 +317,10 @@ export function createSquigglePrinter(
             softline,
             "}",
           ]);
-        case "Dict":
+        case "Dict": {
+          const isSingleKeyWithoutValue =
+            node.elements.length === 1 &&
+            node.elements[0].type === "Identifier";
           return group([
             "{",
             node.elements.length
@@ -326,12 +329,13 @@ export function createSquigglePrinter(
                     line,
                     join([",", line], path.map(print, "elements")),
                   ]),
-                  ifBreak(",", ""),
+                  isSingleKeyWithoutValue ? "," : ifBreak(",", ""),
                   line,
                 ]
               : [],
             "}",
           ]);
+        }
         case "String":
           return [JSON.stringify(node.value).replaceAll("\\n", "\n")];
         case "Ternary":

--- a/packages/prettier-plugin/test/dicts.test.ts
+++ b/packages/prettier-plugin/test/dicts.test.ts
@@ -9,6 +9,22 @@ describe("dicts", () => {
     expect(await format("{foo: 5}")).toBe("{ foo: 5 }");
   });
 
+  test("one key with trailing comma", async () => {
+    expect(
+      await format(`foo=3
+{foo,}`)
+    ).toBe(`foo = 3
+{ foo, }`);
+  });
+
+  test("two keys with trailing comma", async () => {
+    expect(
+      await format(`foo=3
+{foo,foo,}`)
+    ).toBe(`foo = 3
+{ foo, foo }`);
+  });
+
   test("shorthand", async () => {
     expect(await format("{foo, bar: bar, baz}")).toBe("{ foo, bar: bar, baz }");
   });


### PR DESCRIPTION
… removed

Closes https://github.com/quantified-uncertainty/squiggle/issues/2944