### PR TITLE
ViewerProvider is a singleton now

### DIFF
--- a/packages/components/src/components/SquiggleOutputViewer/index.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/index.tsx
@@ -19,6 +19,7 @@ import { ErrorBoundary } from "../ErrorBoundary.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { SquiggleViewerHandle } from "../SquiggleViewer/index.js";
+import { ViewerProvider } from "../SquiggleViewer/ViewerProvider.js";
 import { Layout } from "./Layout.js";
 import { RenderingIndicator } from "./RenderingIndicator.js";
 
@@ -79,12 +80,8 @@ export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
               <div className="absolute z-10 inset-0 bg-white opacity-50" />
             )}
             <ErrorBoundary>
-              <SquiggleViewer
-                {...settings}
-                ref={viewerRef}
-                value={usedResult.value}
-                editor={editor}
-              />
+              {/* we don't pass settings or editor here because they're already configured in `<ViewerProvider>`; hopefully `<SquiggleViewer>` itself won't need to rely on settings, otherwise things might break */}
+              <SquiggleViewer ref={viewerRef} value={usedResult.value} />
             </ErrorBoundary>
           </div>
         ) : (
@@ -94,53 +91,58 @@ export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
     }
 
     return (
-      <Layout
-        menu={
-          <Dropdown
-            render={({ close }) => (
-              <DropdownMenu>
-                <DropdownMenuActionItem
-                  icon={CodeBracketIcon}
-                  title={
-                    <MenuItemTitle
-                      title="Variables"
-                      type={variablesCount ? `{}${variablesCount}` : null}
-                    />
-                  }
-                  onClick={() => {
-                    setMode("variables");
-                    close();
-                  }}
-                />
-                <DropdownMenuActionItem
-                  icon={CodeBracketIcon}
-                  title={
-                    <MenuItemTitle
-                      title="Result"
-                      type={hasResult ? "" : null}
-                    />
-                  }
-                  onClick={() => {
-                    setMode("result");
-                    close();
-                  }}
-                />
-              </DropdownMenu>
-            )}
-          >
-            <Button size="small">
-              <div className="flex items-center space-x-1.5">
-                <span>{mode === "variables" ? "Variables" : "Result"}</span>
-                <TriangleIcon className="rotate-180 text-slate-400" size={10} />
-              </div>
-            </Button>
-          </Dropdown>
-        }
-        indicator={
-          <RenderingIndicator isRunning={isRunning} output={squiggleOutput} />
-        }
-        viewer={squiggleViewer}
-      />
+      <ViewerProvider partialPlaygroundSettings={settings} editor={editor}>
+        <Layout
+          menu={
+            <Dropdown
+              render={({ close }) => (
+                <DropdownMenu>
+                  <DropdownMenuActionItem
+                    icon={CodeBracketIcon}
+                    title={
+                      <MenuItemTitle
+                        title="Variables"
+                        type={variablesCount ? `{}${variablesCount}` : null}
+                      />
+                    }
+                    onClick={() => {
+                      setMode("variables");
+                      close();
+                    }}
+                  />
+                  <DropdownMenuActionItem
+                    icon={CodeBracketIcon}
+                    title={
+                      <MenuItemTitle
+                        title="Result"
+                        type={hasResult ? "" : null}
+                      />
+                    }
+                    onClick={() => {
+                      setMode("result");
+                      close();
+                    }}
+                  />
+                </DropdownMenu>
+              )}
+            >
+              <Button size="small">
+                <div className="flex items-center space-x-1.5">
+                  <span>{mode === "variables" ? "Variables" : "Result"}</span>
+                  <TriangleIcon
+                    className="rotate-180 text-slate-400"
+                    size={10}
+                  />
+                </div>
+              </Button>
+            </Dropdown>
+          }
+          indicator={
+            <RenderingIndicator isRunning={isRunning} output={squiggleOutput} />
+          }
+          viewer={squiggleViewer}
+        />
+      </ViewerProvider>
     );
   }
 );

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -3,7 +3,6 @@ import { FC, forwardRef, memo } from "react";
 import { SqValue, SqValuePath } from "@quri/squiggle-lang";
 import { ChevronRightIcon } from "@quri/ui";
 
-import { useStabilizeObjectIdentity } from "../../lib/hooks/useStabilizeObject.js";
 import { MessageAlert } from "../Alert.js";
 import { CodeEditorHandle } from "../CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
@@ -127,18 +126,9 @@ const component = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
     { value, editor, ...partialPlaygroundSettings },
     ref
   ) {
-    /**
-     * Because we obtain `partialPlaygroundSettings` with spread syntax, its identity changes on each render, which could
-     * cause extra unnecessary re-renders of widgets, in some cases.
-     * Related discussion: https://github.com/quantified-uncertainty/squiggle/pull/2525#discussion_r1393398447
-     */
-    const stablePartialPlaygroundSettings = useStabilizeObjectIdentity(
-      partialPlaygroundSettings
-    );
-
     return (
       <ViewerProvider
-        partialPlaygroundSettings={stablePartialPlaygroundSettings}
+        partialPlaygroundSettings={partialPlaygroundSettings}
         editor={editor}
         ref={ref}
       >


### PR DESCRIPTION
This PR:
- fixes #2936 and a related issue with focus resetting
- prepares the codebase for #2776, because we will need to configure `<ViewerProvider>` on top level, which is hard when `<SquiggleViewer>` adds it too
