### PR TITLE
Remove broken TextTooltip from value menu icon

### DIFF
--- a/packages/components/src/components/SquiggleViewer/SquiggleValueMenu.tsx
+++ b/packages/components/src/components/SquiggleViewer/SquiggleValueMenu.tsx
@@ -10,7 +10,6 @@ import {
   DropdownMenuActionItem,
   DropdownMenuHeader,
   FocusIcon,
-  TextTooltip,
   useCloseDropdown,
 } from "@quri/ui";
 
@@ -148,40 +147,38 @@ export const SquiggleValueMenu: FC<{
   const hasLocalSettings = useHasLocalSettings(value.context.path);
 
   return (
-    <TextTooltip text="Settings" placement="bottom-end">
-      <Dropdown
-        render={() => (
-          <DropdownMenu>
-            {widgetHeading && (
-              <DropdownMenuHeader>{widgetHeading}</DropdownMenuHeader>
-            )}
-            <FindInEditorItem value={value} />
-            <FocusItem value={value} />
-            <SetChildrenCollapsedStateItem
-              value={value}
-              title="Collapse Children"
-              collapsed={true}
-            />
-            <SetChildrenCollapsedStateItem
-              value={value}
-              title="Expand Children"
-              collapsed={false}
-            />
-            {widget?.Menu && <widget.Menu value={value} />}
-            <LogToConsoleItem value={value} />
-          </DropdownMenu>
-        )}
-      >
-        <Cog8ToothIcon
-          size={16}
-          className={clsx(
-            "cursor-pointer transition",
-            hasLocalSettings
-              ? "text-indigo-300 hover:!text-indigo-500 group-hover:text-indigo-400"
-              : "opacity-0 hover:!text-stone-500 group-hover:text-stone-400 group-hover:opacity-100"
+    <Dropdown
+      render={() => (
+        <DropdownMenu>
+          {widgetHeading && (
+            <DropdownMenuHeader>{widgetHeading}</DropdownMenuHeader>
           )}
-        />
-      </Dropdown>
-    </TextTooltip>
+          <FindInEditorItem value={value} />
+          <FocusItem value={value} />
+          <SetChildrenCollapsedStateItem
+            value={value}
+            title="Collapse Children"
+            collapsed={true}
+          />
+          <SetChildrenCollapsedStateItem
+            value={value}
+            title="Expand Children"
+            collapsed={false}
+          />
+          {widget?.Menu && <widget.Menu value={value} />}
+          <LogToConsoleItem value={value} />
+        </DropdownMenu>
+      )}
+    >
+      <Cog8ToothIcon
+        size={16}
+        className={clsx(
+          "cursor-pointer transition",
+          hasLocalSettings
+            ? "text-indigo-300 hover:!text-indigo-500 group-hover:text-indigo-400"
+            : "opacity-0 hover:!text-stone-500 group-hover:text-stone-400 group-hover:opacity-100"
+        )}
+      />
+    </Dropdown>
   );
 };


### PR DESCRIPTION
In `<SquiggleValueMenu>`, we had a tooltip that said "Settings", but it was broken for a while because `<Dropdown>` doesn't `forwardRef`. This caused annoying warnings in dev console.

The tooltip wasn't not very useful, so I just removed it for now.

<img width="1373" alt="Screenshot 2024-01-10 at 13 43 06" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/d41e32bc-0c31-49b2-bb39-b5027f4140ef">
