### PR TITLE
Adds versionAdded to Docs

### DIFF
--- a/.changeset/popular-fireants-boil.md
+++ b/.changeset/popular-fireants-boil.md
@@ -1,0 +1,6 @@
+---
+"@quri/squiggle-lang": patch
+"@quri/squiggle-components": patch
+---
+
+Adds versionAdded flag for functions, to tag with version information in documentation.

--- a/packages/components/src/components/ui/FnDocumentation.tsx
+++ b/packages/components/src/components/ui/FnDocumentation.tsx
@@ -69,6 +69,7 @@ export const FnDocumentation: FC<{
     definitions,
     examples,
     interactiveExamples,
+    versionAdded,
   } = documentation;
   const textSize = size === "small" ? "text-xs" : "text-sm";
   const fullName = `${nameSpace ? nameSpace + "." : ""}${name}`;
@@ -102,7 +103,11 @@ export const FnDocumentation: FC<{
           </div>
         </Section>
       )}
-      {(isUnit || shorthand || isExperimental || !requiresNamespace) && (
+      {(isUnit ||
+        shorthand ||
+        isExperimental ||
+        !requiresNamespace ||
+        versionAdded) && (
         <Section>
           <div className="flex gap-3">
             {isUnit && (
@@ -126,6 +131,11 @@ export const FnDocumentation: FC<{
             {!requiresNamespace && (
               <div className={clsx("bg-purple-50 text-slate-600", tagCss)}>
                 {`Namespace optional`}
+              </div>
+            )}
+            {versionAdded && (
+              <div className={clsx("bg-purple-50 text-slate-600", tagCss)}>
+                v{versionAdded}
               </div>
             )}
           </div>

--- a/packages/components/src/stories/InternalComponents/FnDocumentation.stories.tsx
+++ b/packages/components/src/stories/InternalComponents/FnDocumentation.stories.tsx
@@ -83,6 +83,7 @@ Plot.scatter({
   shorthand: { type: "unary", symbol: "-" },
   description: `**Lorem Ipsum**
 More content *here*`,
+  versionAdded: "0.9.0",
 };
 
 export const Simple: Story = {

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -25,6 +25,7 @@ export type FRFunction = {
   isUnit?: boolean;
   shorthand?: Shorthand;
   displaySection?: string;
+  versionAdded?: string;
 };
 
 type FnNameDict = Map<string, FnDefinition[]>;
@@ -42,6 +43,7 @@ export type FnDocumentation = Pick<
   | "isUnit"
   | "shorthand"
   | "displaySection"
+  | "versionAdded"
 > & { signatures: string[] };
 
 export class Registry {


### PR DESCRIPTION
Very simple, just adds a flag for future FR Library additions. 

Right now, new functions are shown in the documentation, but some of these are only available in ``next``, which readers have no way of telling. 

This is obviously very simple functionality, just to make sure the basics are here. 