### PR TITLE
Always start dist y scale from 0

### DIFF
--- a/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
+++ b/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
@@ -159,10 +159,7 @@ const InnerDistributionsChart: FC<{
     ]);
 
     const yScale = sqScaleToD3(plot.yScale);
-    yScale.domain([
-      Math.max(Math.min(...domain.map((p) => p.y)), 0), // min value, but at least 0
-      Math.max(...domain.map((p) => p.y)),
-    ]);
+    yScale.domain([0, Math.max(...domain.map((p) => p.y))]);
 
     return { xScale, yScale };
   }, [domain, plot.xScale, plot.yScale]);


### PR DESCRIPTION
Fixes #2973.

Bug was caused by this commit: https://github.com/quantified-uncertainty/squiggle/commit/944675f22e60b88bd02f937ec44a9e6feeef772b#diff-8851c71bd880ffd7487e81ac6cb185ae201ab523036f8f766a22adfffcbf6586R164

So the domain for `bernoulli(50%)` was `[probability of 0, probability of 1]`, something like `[0.480, 0.520]`.

I think always starting dist charts from `0` is fine. We won't render broken pointsets with negative values correctly, but we never really did it well.