### PR TITLE
SquiggleOutputViewer refactorings and empty results

### DIFF
--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -10,7 +10,6 @@ import {
   StandaloneExecutionProps,
   useSquiggle,
 } from "../lib/hooks/useSquiggle.js";
-import { getResultValue, getResultVariables } from "../lib/utility.js";
 import { MessageAlert } from "./Alert.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
 import { SquiggleErrorAlert } from "./SquiggleErrorAlert.js";
@@ -52,23 +51,21 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
     }
 
     if (rootPathOverride) {
+      const { output } = squiggleOutput;
+      if (!output.ok) {
+        return <SquiggleErrorAlert error={output.value} />;
+      }
       const rootValue =
         rootPathOverride.root === "result"
-          ? getResultValue(squiggleOutput)
-          : getResultVariables(squiggleOutput);
-      if (!rootValue) {
+          ? output.value.result
+          : output.value.bindings.asValue();
+
+      const value = getSubvalueByPath(rootValue, rootPathOverride);
+      if (value) {
+        return <SquiggleViewer value={value} />;
+      } else {
         return <MessageAlert heading="Value is not defined" />;
       }
-      if (!rootValue.ok) {
-        return <SquiggleErrorAlert error={rootValue.value} />;
-      }
-
-      const value = getSubvalueByPath(rootValue.value, rootPathOverride);
-      if (!value) {
-        return <MessageAlert heading="Value is not defined" />;
-      }
-
-      return <SquiggleViewer value={value} />;
     } else {
       return (
         <SquiggleOutputViewer

--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -64,7 +64,7 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
           onSubmit={() => runnerState.run()}
         />
       </div>
-      {hideViewer || !squiggleOutput?.code ? null : (
+      {hideViewer || !squiggleOutput ? null : (
         <SquiggleOutputViewer
           squiggleOutput={squiggleOutput}
           isRunning={isRunning}

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
@@ -15,11 +15,7 @@ type Props = {
 };
 
 export const ViewerBody: FC<Props> = ({ squiggleOutput, mode, isRunning }) => {
-  const { output, code } = squiggleOutput;
-
-  if (!code) {
-    return null;
-  }
+  const { output } = squiggleOutput;
 
   if (!output.ok) {
     return <SquiggleErrorAlert error={output.value} />;

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 
 import { SqValue } from "@quri/squiggle-lang";
 
-import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
+import { SqOutputResult } from "../../../../squiggle-lang/src/public/types.js";
 import { ErrorBoundary } from "../ErrorBoundary.js";
 import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { SquiggleViewer } from "../SquiggleViewer/index.js";
@@ -10,13 +10,11 @@ import { ViewerMode } from "./index.js";
 
 type Props = {
   mode: ViewerMode;
-  squiggleOutput: SquiggleOutput;
+  output: SqOutputResult;
   isRunning: boolean;
 };
 
-export const ViewerBody: FC<Props> = ({ squiggleOutput, mode, isRunning }) => {
-  const { output } = squiggleOutput;
-
+export const ViewerBody: FC<Props> = ({ output, mode, isRunning }) => {
   if (!output.ok) {
     return <SquiggleErrorAlert error={output.value} />;
   }

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
@@ -1,0 +1,61 @@
+import { FC } from "react";
+
+import { SqValue } from "@quri/squiggle-lang";
+
+import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
+import { ErrorBoundary } from "../ErrorBoundary.js";
+import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
+import { SquiggleViewer } from "../SquiggleViewer/index.js";
+import { ViewerMode } from "./index.js";
+
+type Props = {
+  mode: ViewerMode;
+  squiggleOutput: SquiggleOutput;
+  isRunning: boolean;
+};
+
+export const ViewerBody: FC<Props> = ({ squiggleOutput, mode, isRunning }) => {
+  const { output, code } = squiggleOutput;
+
+  if (!code) {
+    return null;
+  }
+
+  if (!output.ok) {
+    return <SquiggleErrorAlert error={output.value} />;
+  }
+
+  const sqOutput = output.value;
+  let usedValue: SqValue | undefined;
+  switch (mode) {
+    case "Result":
+      usedValue =
+        sqOutput.result.tag === "Void" ? undefined : output.value.result;
+      break;
+    case "Variables":
+      usedValue = sqOutput.bindings.asValue();
+      break;
+    case "Imports":
+      usedValue = sqOutput.imports.asValue();
+      break;
+    case "Exports":
+      usedValue = sqOutput.exports.asValue();
+  }
+
+  if (!usedValue) {
+    return null;
+  }
+
+  return (
+    <div className="relative">
+      {isRunning && (
+        // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
+        <div className="absolute z-10 inset-0 bg-white opacity-50" />
+      )}
+      <ErrorBoundary>
+        {/* we don't pass settings or editor here because they're already configured in `<ViewerProvider>`; hopefully `<SquiggleViewer>` itself won't need to rely on settings, otherwise things might break */}
+        <SquiggleViewer value={usedValue} />
+      </ErrorBoundary>
+    </div>
+  );
+};

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerBody.tsx
@@ -29,8 +29,7 @@ export const ViewerBody: FC<Props> = ({ squiggleOutput, mode, isRunning }) => {
   let usedValue: SqValue | undefined;
   switch (mode) {
     case "Result":
-      usedValue =
-        sqOutput.result.tag === "Void" ? undefined : output.value.result;
+      usedValue = output.value.result;
       break;
     case "Variables":
       usedValue = sqOutput.bindings.asValue();

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerMenu.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerMenu.tsx
@@ -10,7 +10,7 @@ import {
   TriangleIcon,
 } from "@quri/ui";
 
-import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
+import { SqOutputResult } from "../../../../squiggle-lang/src/public/types.js";
 import { ViewerMode } from "./index.js";
 
 const MenuItemTitle: FC<{ title: string; type: string | null }> = ({
@@ -33,14 +33,10 @@ const MenuItemTitle: FC<{ title: string; type: string | null }> = ({
 type Props = {
   mode: ViewerMode;
   setMode: (mode: ViewerMode) => void;
-  output: SquiggleOutput;
+  output: SqOutputResult;
 };
 
-export const ViewerMenu: FC<Props> = ({
-  mode,
-  setMode,
-  output: { output },
-}) => {
+export const ViewerMenu: FC<Props> = ({ mode, setMode, output }) => {
   const hasResult = output.ok && output.value.result.tag !== "Void";
   const variablesCount = output.ok ? output.value.bindings.size() : 0;
   const importsCount = output.ok ? output.value.imports.size() : 0;

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerMenu.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerMenu.tsx
@@ -11,12 +11,6 @@ import {
 } from "@quri/ui";
 
 import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
-import {
-  getResultExports,
-  getResultImports,
-  getResultValue,
-  getResultVariables,
-} from "../../lib/utility.js";
 import { ViewerMode } from "./index.js";
 
 const MenuItemTitle: FC<{ title: string; type: string | null }> = ({
@@ -42,22 +36,15 @@ type Props = {
   output: SquiggleOutput;
 };
 
-export const ViewerMenu: FC<Props> = ({ mode, setMode, output }) => {
-  const resultItem = getResultValue(output);
-  const resultExports = getResultExports(output);
-  const resultVariables = getResultVariables(output);
-  const resultImports = getResultImports(output);
-
-  const hasResult = Boolean(resultItem?.ok);
-  const variablesCount = resultVariables?.ok
-    ? resultVariables.value.value.entries().length
-    : 0;
-  const importsCount = resultImports?.ok
-    ? resultImports.value.value.entries().length
-    : 0;
-  const exportsCount = resultExports?.ok
-    ? resultExports.value.value.entries().length
-    : 0;
+export const ViewerMenu: FC<Props> = ({
+  mode,
+  setMode,
+  output: { output },
+}) => {
+  const hasResult = output.ok && output.value.result.tag !== "Void";
+  const variablesCount = output.ok ? output.value.bindings.size() : 0;
+  const importsCount = output.ok ? output.value.imports.size() : 0;
+  const exportsCount = output.ok ? output.value.exports.size() : 0;
 
   return (
     <Dropdown

--- a/packages/components/src/components/SquiggleOutputViewer/ViewerMenu.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/ViewerMenu.tsx
@@ -1,0 +1,132 @@
+import clsx from "clsx";
+import { FC } from "react";
+
+import {
+  Button,
+  CodeBracketIcon,
+  Dropdown,
+  DropdownMenu,
+  DropdownMenuActionItem,
+  TriangleIcon,
+} from "@quri/ui";
+
+import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
+import {
+  getResultExports,
+  getResultImports,
+  getResultValue,
+  getResultVariables,
+} from "../../lib/utility.js";
+import { ViewerMode } from "./index.js";
+
+const MenuItemTitle: FC<{ title: string; type: string | null }> = ({
+  title,
+  type,
+}) => {
+  const isEmpty = type === null;
+  return (
+    <div className="flex justify-between">
+      <span className={clsx(isEmpty && "text-slate-400")}>{title}</span>
+      {isEmpty ? (
+        <span className="text-slate-300">Empty</span>
+      ) : (
+        <span className="text-blue-800">{type}</span>
+      )}
+    </div>
+  );
+};
+
+type Props = {
+  mode: ViewerMode;
+  setMode: (mode: ViewerMode) => void;
+  output: SquiggleOutput;
+};
+
+export const ViewerMenu: FC<Props> = ({ mode, setMode, output }) => {
+  const resultItem = getResultValue(output);
+  const resultExports = getResultExports(output);
+  const resultVariables = getResultVariables(output);
+  const resultImports = getResultImports(output);
+
+  const hasResult = Boolean(resultItem?.ok);
+  const variablesCount = resultVariables?.ok
+    ? resultVariables.value.value.entries().length
+    : 0;
+  const importsCount = resultImports?.ok
+    ? resultImports.value.value.entries().length
+    : 0;
+  const exportsCount = resultExports?.ok
+    ? resultExports.value.value.entries().length
+    : 0;
+
+  return (
+    <Dropdown
+      render={({ close }) => (
+        <DropdownMenu>
+          {Boolean(importsCount) && (
+            <DropdownMenuActionItem
+              icon={CodeBracketIcon}
+              title={
+                <MenuItemTitle
+                  title="Imports"
+                  type={importsCount ? `{}${importsCount}` : null}
+                />
+              }
+              onClick={() => {
+                setMode("Imports");
+                close();
+              }}
+            />
+          )}
+          {Boolean(variablesCount) && (
+            <DropdownMenuActionItem
+              icon={CodeBracketIcon}
+              title={
+                <MenuItemTitle
+                  title="Variables"
+                  type={variablesCount ? `{}${variablesCount}` : null}
+                />
+              }
+              onClick={() => {
+                setMode("Variables");
+                close();
+              }}
+            />
+          )}
+          {Boolean(exportsCount) && (
+            <DropdownMenuActionItem
+              icon={CodeBracketIcon}
+              title={
+                <MenuItemTitle
+                  title="Exports"
+                  type={exportsCount ? `{}${exportsCount}` : null}
+                />
+              }
+              onClick={() => {
+                setMode("Exports");
+                close();
+              }}
+            />
+          )}
+          <DropdownMenuActionItem
+            icon={CodeBracketIcon}
+            title={
+              <MenuItemTitle title="Result" type={hasResult ? "" : null} />
+            }
+            onClick={() => {
+              setMode("Result");
+              close();
+            }}
+          />
+        </DropdownMenu>
+      )}
+    >
+      <Button size="small">
+        <div className="flex items-center space-x-1.5">
+          <span>{mode}</span>
+          <TriangleIcon className="rotate-180 text-slate-400" size={10} />
+        </div>
+      </Button>
+    </Dropdown>
+  );
+};

--- a/packages/components/src/components/SquiggleOutputViewer/index.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/index.tsx
@@ -41,7 +41,8 @@ function useMode(outputResult: SqOutputResult) {
 /* Wrapper for SquiggleViewer that shows the rendering stats and isRunning state. */
 export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
   ({ squiggleOutput, isRunning, editor, ...settings }, viewerRef) => {
-    const [mode, setMode] = useMode(squiggleOutput.output);
+    const { output } = squiggleOutput;
+    const [mode, setMode] = useMode(output);
 
     return (
       <ViewerProvider
@@ -50,18 +51,12 @@ export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
         ref={viewerRef}
       >
         <Layout
-          menu={
-            <ViewerMenu mode={mode} setMode={setMode} output={squiggleOutput} />
-          }
+          menu={<ViewerMenu mode={mode} setMode={setMode} output={output} />}
           indicator={
             <RenderingIndicator isRunning={isRunning} output={squiggleOutput} />
           }
           viewer={
-            <ViewerBody
-              mode={mode}
-              squiggleOutput={squiggleOutput}
-              isRunning={isRunning}
-            />
+            <ViewerBody mode={mode} output={output} isRunning={isRunning} />
           }
         />
       </ViewerProvider>

--- a/packages/components/src/components/SquiggleOutputViewer/index.tsx
+++ b/packages/components/src/components/SquiggleOutputViewer/index.tsx
@@ -1,49 +1,15 @@
-import clsx from "clsx";
-import { FC, forwardRef, useState } from "react";
+import { forwardRef, useState } from "react";
 
-import { result, SqError, SqValue } from "@quri/squiggle-lang";
-import {
-  Button,
-  CodeBracketIcon,
-  Dropdown,
-  DropdownMenu,
-  DropdownMenuActionItem,
-  TriangleIcon,
-} from "@quri/ui";
-
-import { SquiggleViewer } from "../../index.js";
 import { SquiggleOutput } from "../../lib/hooks/useSquiggle.js";
-import {
-  getResultExports,
-  getResultImports,
-  getResultValue,
-  getResultVariables,
-} from "../../lib/utility.js";
+import { getResultExports, getResultValue } from "../../lib/utility.js";
 import { CodeEditorHandle } from "../CodeEditor/index.js";
-import { ErrorBoundary } from "../ErrorBoundary.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
-import { SquiggleErrorAlert } from "../SquiggleErrorAlert.js";
 import { SquiggleViewerHandle } from "../SquiggleViewer/index.js";
 import { ViewerProvider } from "../SquiggleViewer/ViewerProvider.js";
 import { Layout } from "./Layout.js";
 import { RenderingIndicator } from "./RenderingIndicator.js";
-
-const MenuItemTitle: FC<{ title: string; type: string | null }> = ({
-  title,
-  type,
-}) => {
-  const isEmpty = type === null;
-  return (
-    <div className="flex justify-between">
-      <span className={clsx(isEmpty && "text-slate-400")}>{title}</span>
-      {isEmpty ? (
-        <span className="text-slate-300">Empty</span>
-      ) : (
-        <span className="text-blue-800">{type}</span>
-      )}
-    </div>
-  );
-};
+import { ViewerBody } from "./ViewerBody.js";
+import { ViewerMenu } from "./ViewerMenu.js";
 
 type Props = {
   squiggleOutput: SquiggleOutput;
@@ -51,150 +17,46 @@ type Props = {
   editor?: CodeEditorHandle;
 } & PartialPlaygroundSettings;
 
+export type ViewerMode = "Imports" | "Exports" | "Variables" | "Result";
+
 /* Wrapper for SquiggleViewer that shows the rendering stats and isRunning state. */
 export const SquiggleOutputViewer = forwardRef<SquiggleViewerHandle, Props>(
   ({ squiggleOutput, isRunning, editor, ...settings }, viewerRef) => {
     const resultItem = getResultValue(squiggleOutput);
-    const resultVariables = getResultVariables(squiggleOutput);
-    const resultImports = getResultImports(squiggleOutput);
     const resultExports = getResultExports(squiggleOutput);
 
     const hasResult = Boolean(resultItem?.ok);
-    const variablesCount = resultVariables?.ok
-      ? resultVariables.value.value.entries().length
-      : 0;
-    const importsCount = resultImports?.ok
-      ? resultImports.value.value.entries().length
-      : 0;
     const exportsCount = resultExports?.ok
       ? resultExports.value.value.entries().length
       : 0;
 
-    const [mode, setMode] = useState<
-      "Imports" | "Exports" | "Variables" | "Result"
-    >(hasResult ? "Result" : exportsCount > 0 ? "Exports" : "Variables");
-
-    let squiggleViewer: JSX.Element | null = null;
-    if (squiggleOutput.code) {
-      let usedResult: result<SqValue, SqError> | undefined;
-      switch (mode) {
-        case "Result":
-          usedResult = resultItem;
-          break;
-        case "Variables":
-          usedResult = resultVariables;
-          break;
-        case "Imports":
-          usedResult = resultImports;
-          break;
-        case "Exports":
-          usedResult = resultExports;
-      }
-
-      if (usedResult) {
-        squiggleViewer = usedResult.ok ? (
-          <div className="relative">
-            {isRunning && (
-              // `opacity-0 squiggle-semi-appear` would be better, but won't work reliably until we move Squiggle evaluation to Web Workers
-              <div className="absolute z-10 inset-0 bg-white opacity-50" />
-            )}
-            <ErrorBoundary>
-              {/* we don't pass settings or editor here because they're already configured in `<ViewerProvider>`; hopefully `<SquiggleViewer>` itself won't need to rely on settings, otherwise things might break */}
-              <SquiggleViewer ref={viewerRef} value={usedResult.value} />
-            </ErrorBoundary>
-          </div>
-        ) : (
-          <SquiggleErrorAlert error={usedResult.value} />
-        );
-      }
-    }
+    const [mode, setMode] = useState<ViewerMode>(
+      hasResult ? "Result" : exportsCount > 0 ? "Exports" : "Variables"
+    );
 
     return (
-      <ViewerProvider partialPlaygroundSettings={settings} editor={editor}>
+      <ViewerProvider
+        partialPlaygroundSettings={settings}
+        editor={editor}
+        ref={viewerRef}
+      >
         <Layout
           menu={
-            <Dropdown
-              render={({ close }) => (
-                <DropdownMenu>
-                  {Boolean(importsCount) && (
-                    <DropdownMenuActionItem
-                      icon={CodeBracketIcon}
-                      title={
-                        <MenuItemTitle
-                          title="Imports"
-                          type={importsCount ? `{}${importsCount}` : null}
-                        />
-                      }
-                      onClick={() => {
-                        setMode("Imports");
-                        close();
-                      }}
-                    />
-                  )}
-                  {Boolean(variablesCount) && (
-                    <DropdownMenuActionItem
-                      icon={CodeBracketIcon}
-                      title={
-                        <MenuItemTitle
-                          title="Variables"
-                          type={variablesCount ? `{}${variablesCount}` : null}
-                        />
-                      }
-                      onClick={() => {
-                        setMode("Variables");
-                        close();
-                      }}
-                    />
-                  )}
-                  {Boolean(exportsCount) && (
-                    <DropdownMenuActionItem
-                      icon={CodeBracketIcon}
-                      title={
-                        <MenuItemTitle
-                          title="Exports"
-                          type={exportsCount ? `{}${exportsCount}` : null}
-                        />
-                      }
-                      onClick={() => {
-                        setMode("Exports");
-                        close();
-                      }}
-                    />
-                  )}
-                  <DropdownMenuActionItem
-                    icon={CodeBracketIcon}
-                    title={
-                      <MenuItemTitle
-                        title="Result"
-                        type={hasResult ? "" : null}
-                      />
-                    }
-                    onClick={() => {
-                      setMode("Result");
-                      close();
-                    }}
-                  />
-                </DropdownMenu>
-              )}
-            >
-              <Button size="small">
-                <div className="flex items-center space-x-1.5">
-                  <span>{mode}</span>
-                  <TriangleIcon
-                    className="rotate-180 text-slate-400"
-                    size={10}
-                  />
-                </div>
-              </Button>
-            </Dropdown>
+            <ViewerMenu mode={mode} setMode={setMode} output={squiggleOutput} />
           }
           indicator={
             <RenderingIndicator isRunning={isRunning} output={squiggleOutput} />
           }
-          viewer={squiggleViewer}
+          viewer={
+            <ViewerBody
+              mode={mode}
+              squiggleOutput={squiggleOutput}
+              isRunning={isRunning}
+            />
+          }
         />
       </ViewerProvider>
     );
   }
 );
-SquiggleOutputViewer.displayName = "DynamicSquiggleViewer";
+SquiggleOutputViewer.displayName = "SquiggleOutputViewer";

--- a/packages/components/src/lib/hooks/useSquiggle.ts
+++ b/packages/components/src/lib/hooks/useSquiggle.ts
@@ -53,7 +53,7 @@ export type UseSquiggleOutput = [
   {
     project: SqProject;
     isRunning: boolean;
-    sourceId: string;
+    sourceId: string; // if you don't provide `sourceId` in `SquiggleArgs` then it will be picked randomly
   },
 ];
 

--- a/packages/components/src/lib/hooks/useSquiggle.ts
+++ b/packages/components/src/lib/hooks/useSquiggle.ts
@@ -1,14 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 
-import {
-  Env,
-  result,
-  SqDict,
-  SqError,
-  SqProject,
-  SqValue,
-} from "@quri/squiggle-lang";
+import { Env, SqProject } from "@quri/squiggle-lang";
 
+import { SqOutputResult } from "../../../../squiggle-lang/src/public/types.js";
 import { WINDOW_VARIABLE_NAME } from "../constants.js";
 
 // Props needed for a standalone execution.
@@ -33,16 +27,9 @@ export type SquiggleArgs = {
   executionId?: number;
 } & (StandaloneExecutionProps | ProjectExecutionProps);
 
+// TODO - think of a better name, `SquiggleOutput` is too similar to `SqOutput`
 export type SquiggleOutput = {
-  output: result<
-    {
-      exports: SqDict;
-      result: SqValue;
-      imports: SqDict;
-      bindings: SqDict;
-    },
-    SqError
-  >;
+  output: SqOutputResult;
   code: string;
   executionId: number;
   executionTime: number;

--- a/packages/components/src/lib/utility.ts
+++ b/packages/components/src/lib/utility.ts
@@ -1,10 +1,4 @@
-import {
-  result,
-  resultMap,
-  SqDictValue,
-  SqError,
-  SqValue,
-} from "@quri/squiggle-lang";
+import { result, SqValue } from "@quri/squiggle-lang";
 
 import { SquiggleOutput } from "./hooks/useSquiggle.js";
 
@@ -40,35 +34,6 @@ export function all(arr: boolean[]): boolean {
 
 export function some(arr: boolean[]): boolean {
   return arr.reduce((x, y) => x || y, false);
-}
-
-export function getResultVariables({
-  output,
-}: SquiggleOutput): result<SqDictValue, SqError> {
-  return resultMap(output, (value) => value.bindings.asValue());
-}
-
-export function getResultImports({
-  output,
-}: SquiggleOutput): result<SqDictValue, SqError> {
-  return resultMap(output, (value) => value.imports.asValue());
-}
-
-export function getResultExports({
-  output,
-}: SquiggleOutput): result<SqDictValue, SqError> {
-  return resultMap(output, (value) => value.exports.asValue());
-}
-
-export function getResultValue({
-  output,
-}: SquiggleOutput): result<SqValue, SqError> | undefined {
-  if (output.ok) {
-    const isResult = output.value.result.tag !== "Void";
-    return isResult ? { ok: true, value: output.value.result } : undefined;
-  } else {
-    return output;
-  }
 }
 
 export function getErrors(result: SquiggleOutput["output"]) {

--- a/packages/components/src/widgets/VoidWidget.tsx
+++ b/packages/components/src/widgets/VoidWidget.tsx
@@ -1,0 +1,6 @@
+import { widgetRegistry } from "./registry.js";
+
+widgetRegistry.register("Void", {
+  Preview: () => "Empty value",
+  Chart: () => <div className="italic text-slate-400 text-sm">Empty value</div>,
+});

--- a/packages/components/src/widgets/index.ts
+++ b/packages/components/src/widgets/index.ts
@@ -10,3 +10,4 @@ import "./PlotWidget/index.js";
 import "./StringWidget.js";
 import "./TableChartWidget.js";
 import "./DurationWidget.js";
+import "./VoidWidget.js";

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -6,6 +6,11 @@ import {
 } from "../helpers/reducerHelpers.js";
 
 describe("Peggy parse", () => {
+  describe("empty", () => {
+    testParse("", "(Program)");
+    testParse("// comment", "(Program)");
+  });
+
   describe("float", () => {
     test.each([
       ["1.", { integer: 1, fractional: null, exponent: null }],

--- a/packages/squiggle-lang/src/ast/peggyParser.peggy
+++ b/packages/squiggle-lang/src/ast/peggyParser.peggy
@@ -23,6 +23,8 @@ outerBlock
   / imports:importStatementsList
     finalExpression:expression
     { return h.nodeProgram(imports, [finalExpression], location()); }
+  / imports:importStatementsList
+    { return h.nodeProgram(imports, [], location()); }
 
 importStatementsList = (@importStatement __nl)*
 

--- a/packages/squiggle-lang/src/public/SqProject/index.ts
+++ b/packages/squiggle-lang/src/public/SqProject/index.ts
@@ -237,12 +237,10 @@ export class SqProject {
     const hasEndExpression =
       !!lastStatement && !isBindingStatement(lastStatement);
 
-    const _this = this;
-
-    function newContext(root: Root) {
+    const newContext = (root: Root) => {
       const isResult = root === "result";
       return new SqValueContext({
-        project: _this,
+        project: this,
         sourceId,
         source: source!,
         ast,
@@ -253,11 +251,11 @@ export class SqProject {
           items: [],
         }),
       });
-    }
+    };
 
-    function wrapSqDict(innerDict: VDict, root: Root): SqDict {
+    const wrapSqDict = (innerDict: VDict, root: Root): SqDict => {
       return new SqDict(innerDict, newContext(root));
-    }
+    };
 
     const { result, bindings, exports, externals } = internalOutputR.value;
 

--- a/packages/squiggle-lang/src/public/SqValue/SqDict.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqDict.ts
@@ -37,4 +37,12 @@ export class SqDict {
   asValue() {
     return new SqDictValue(this._value, this.context);
   }
+
+  isEmpty() {
+    return this._value.isEmpty();
+  }
+
+  size() {
+    return this._value.size();
+  }
 }

--- a/packages/squiggle-lang/src/value/VDict.ts
+++ b/packages/squiggle-lang/src/value/VDict.ts
@@ -68,6 +68,14 @@ export class VDict extends BaseValue implements Indexable {
 
     return true;
   }
+
+  isEmpty(): boolean {
+    return this.value.isEmpty();
+  }
+
+  size(): number {
+    return this.value.size;
+  }
 }
 
 export const vDict = (v: ValueMap) => new VDict(v);


### PR DESCRIPTION
This PR is mostly refactorings (it splits out `ViewerBody` and `ViewerMenu` from `SquiggleOutputViewer`).

I wanted to add some debugging views to the viewer, but got distracted by cleanups.

It includes two small user-facing changes:
1. Empty Squiggle programs are now valid; previously, we checked for `code === ""` on the components side, but an empty program with a comment [still failed](https://www.squiggle-language.com/playground?v=0.9.2#code=eNqrVkpJTUsszSlxzk9JVbJS0tdXKEktLlGqBQBwMAhZ); now empty programs are allowed in Peggy grammar
2. `VoidWidget`; now empty result page doesn't look broken:
<img width="612" alt="Screenshot 2024-01-18 at 19 49 38" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/c4645417-2653-4776-8c0a-3a84c59be74e">

Another internal change is that `SqDict` now exposes `isEmpty()` and `size()`. I couldn't resist removing `getResultVariables` and so on, they looked too trivial and copy-pasted to me; so I replaced them with direct lookups on `SqOutput`.