### PR TITLE
Disallow Foo.bar and Foo as variable names

### DIFF
--- a/.changeset/stupid-bananas-look.md
+++ b/.changeset/stupid-bananas-look.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Disallow capitalized variable names that we allowed by accident in 0.9.0

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -150,6 +150,8 @@ describe("Peggy parse", () => {
     testParse("x = 1", "(Program (LetStatement :x (Block 1)))");
     testParse("x", "(Program :x)");
     testParse("x = 1; x", "(Program (LetStatement :x (Block 1)) :x)");
+    testEvalError("X = 1");
+    testEvalError("Foo.bar = 1");
   });
 
   describe("functions", () => {

--- a/packages/squiggle-lang/src/ast/peggyParser.peggy
+++ b/packages/squiggle-lang/src/ast/peggyParser.peggy
@@ -73,11 +73,11 @@ statement
   / defunStatement
 
 letStatement
-  = exported:("export" __nl)? variable:variable _ assignmentOp _nl value:zeroOMoreArgumentsBlockOrExpression
+  = exported:("export" __nl)? variable:dollarIdentifier _ assignmentOp _nl value:zeroOMoreArgumentsBlockOrExpression
     { return h.nodeLetStatement(variable, value, Boolean(exported), location()); }
 
 defunStatement
-  = exported:("export" __nl)? variable:variable '(' _nl args:functionParameters _nl ')' _ assignmentOp _nl body:innerBlockOrExpression
+  = exported:("export" __nl)? variable:dollarIdentifier '(' _nl args:functionParameters _nl ')' _ assignmentOp _nl body:innerBlockOrExpression
     {
       const value = h.nodeLambda(args, body, location(), variable);
       return h.nodeDefunStatement(variable, value, Boolean(exported), location());


### PR DESCRIPTION
Discussion: https://discord.com/channels/1130609991993274510/1137447110766235690/1197699906840838214

We accidentally allowed `Foo = 1` in 0.9.0, but `Foo.bar = 1` was allowed for a while. Fortunately, no one noticed (probably).