### PR TITLE
Imports tooltips

### DIFF
--- a/.changeset/grumpy-owls-clean.md
+++ b/.changeset/grumpy-owls-clean.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Tooltips for import strings can be injected with `renderImportTooltip` prop

--- a/packages/components/src/components/CodeEditor/index.tsx
+++ b/packages/components/src/components/CodeEditor/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, ReactNode, useImperativeHandle } from "react";
 
 import { SqError, SqProject, SqValuePath } from "@quri/squiggle-lang";
 
@@ -18,6 +18,10 @@ export type CodeEditorProps = {
   sourceId: string;
   fontSize?: number;
   project: SqProject;
+  renderImportTooltip?: (params: {
+    project: SqProject;
+    importId: string;
+  }) => ReactNode;
 };
 
 export type CodeEditorHandle = {

--- a/packages/components/src/components/CodeEditor/useSquiggleEditorView.ts
+++ b/packages/components/src/components/CodeEditor/useSquiggleEditorView.ts
@@ -113,6 +113,7 @@ export function useSquiggleEditorExtensions(
   const tooltipsExtension = useTooltipsExtension(view, {
     project: params.project,
     sourceId: params.sourceId,
+    renderImportTooltip: params.renderImportTooltip,
   });
 
   const highPrioritySquiggleExtensions = [

--- a/packages/components/src/components/CodeEditor/useTooltipsExtension.tsx
+++ b/packages/components/src/components/CodeEditor/useTooltipsExtension.tsx
@@ -1,7 +1,7 @@
 import { syntaxTree } from "@codemirror/language";
 import { EditorView, hoverTooltip, repositionTooltips } from "@codemirror/view";
 import { SyntaxNode } from "@lezer/common";
-import { FC, PropsWithChildren, useEffect } from "react";
+import { FC, PropsWithChildren, ReactNode, useEffect } from "react";
 
 import {
   getFunctionDocumentation,
@@ -73,6 +73,15 @@ const HoverTooltip: FC<{ hover: Hover; view: EditorView }> = ({
   </TooltipBox>
 );
 
+function nodeTooltip(syntaxNode: SyntaxNode, reactNode: ReactNode) {
+  return {
+    pos: syntaxNode.from,
+    end: syntaxNode.to,
+    above: true,
+    create: () => reactAsDom(reactNode),
+  };
+}
+
 // Based on https://codemirror.net/examples/tooltip/#hover-tooltips
 // See also: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
 function buildWordHoverExtension({
@@ -96,24 +105,7 @@ function buildWordHoverExtension({
         return null;
       }
 
-      return {
-        pos: node.from,
-        end: node.to,
-        above: true,
-        create: () => reactAsDom(<HoverTooltip hover={hover} view={view} />),
-      };
-    };
-
-    const createTopLevelVariableNameTooltip = (
-      node: SyntaxNode,
-      value: SqValue
-    ) => {
-      return {
-        pos: node.from,
-        end: node.to,
-        above: true,
-        create: () => reactAsDom(<ValueTooltip value={value} view={view} />),
-      };
+      return nodeTooltip(node, <HoverTooltip hover={hover} view={view} />);
     };
 
     switch (cursor.name) {
@@ -170,7 +162,7 @@ function buildWordHoverExtension({
           valueAst.variable.location.start.offset === node.from &&
           valueAst.variable.location.end.offset === node.to
         ) {
-          return createTopLevelVariableNameTooltip(node, value);
+          return nodeTooltip(node, <ValueTooltip value={value} view={view} />);
         }
       }
     }

--- a/packages/components/src/components/SquigglePlayground/LeftPlaygroundPanel/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/LeftPlaygroundPanel/index.tsx
@@ -7,7 +7,7 @@ import {
   useRef,
 } from "react";
 
-import { SqProject, SqValuePath } from "@quri/squiggle-lang";
+import { SqProject } from "@quri/squiggle-lang";
 import {
   AdjustmentsVerticalIcon,
   Bars3CenterLeftIcon,
@@ -25,7 +25,11 @@ import {
   useUncontrolledCode,
 } from "../../../lib/hooks/index.js";
 import { altKey, getErrors } from "../../../lib/utility.js";
-import { CodeEditor, CodeEditorHandle } from "../../CodeEditor/index.js";
+import {
+  CodeEditor,
+  CodeEditorHandle,
+  CodeEditorProps,
+} from "../../CodeEditor/index.js";
 import { PlaygroundSettings } from "../../PlaygroundSettings.js";
 import { PanelWithToolbar } from "../../ui/PanelWithToolbar/index.js";
 import { ToolbarItem } from "../../ui/PanelWithToolbar/ToolbarItem.js";
@@ -54,8 +58,7 @@ type Props = {
   /* Allows to inject extra items to the left panel's dropdown menu. */
   renderExtraDropdownItems?: RenderExtraControls;
   renderExtraModal?: Parameters<typeof PanelWithToolbar>[0]["renderModal"];
-  onViewValuePath?: (path: SqValuePath) => void;
-};
+} & Pick<CodeEditorProps, "onViewValuePath" | "renderImportTooltip">;
 
 // for interactions with this component from outside
 export type LeftPlaygroundPanelHandle = {
@@ -164,8 +167,9 @@ export const LeftPlaygroundPanel = forwardRef<LeftPlaygroundPanelHandle, Props>(
           showGutter={true}
           lineWrapping={props.settings.editorSettings.lineWrapping}
           onChange={setCode}
-          onViewValuePath={props.onViewValuePath}
           onSubmit={runnerState.run}
+          onViewValuePath={props.onViewValuePath}
+          renderImportTooltip={props.renderImportTooltip}
         />
       </div>
     );

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -53,7 +53,10 @@ export type SquigglePlaygroundProps = {
   height?: CSSProperties["height"];
 } & Pick<
   Parameters<typeof LeftPlaygroundPanel>[0],
-  "renderExtraControls" | "renderExtraDropdownItems" | "renderExtraModal"
+  | "renderExtraControls"
+  | "renderExtraDropdownItems"
+  | "renderExtraModal"
+  | "renderImportTooltip"
 > &
   PartialPlaygroundSettings;
 
@@ -77,6 +80,7 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
     renderExtraControls,
     renderExtraDropdownItems,
     renderExtraModal,
+    renderImportTooltip,
     height = 500,
     sourceId,
     ...defaultSettings
@@ -155,6 +159,7 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
       renderExtraDropdownItems={renderExtraDropdownItems}
       renderExtraModal={renderExtraModal}
       onViewValuePath={(path) => rightPanelRef.current?.viewValuePath(path)}
+      renderImportTooltip={renderImportTooltip}
       ref={leftPanelRef}
     />
   );

--- a/packages/hub/src/app/RootLayout.tsx
+++ b/packages/hub/src/app/RootLayout.tsx
@@ -11,7 +11,7 @@ import { isModelRoute, isModelSubroute } from "@/routes";
 
 import { PageFooter } from "../components/layout/RootLayout/PageFooter";
 import { PageMenu } from "../components/layout/RootLayout/PageMenu";
-import { ClientApp } from "./ClientApp";
+import { ReactRoot } from "../components/ReactRoot";
 
 import { RootLayoutQuery } from "@/__generated__/RootLayoutQuery.graphql";
 
@@ -53,8 +53,8 @@ export const RootLayout: FC<
   }>
 > = ({ session, children }) => {
   return (
-    <ClientApp session={session}>
+    <ReactRoot session={session}>
       <InnerRootLayout>{children}</InnerRootLayout>
-    </ClientApp>
+    </ReactRoot>
   );
 };

--- a/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditSquiggleSnippetModel.tsx
@@ -1,3 +1,4 @@
+import { useSession } from "next-auth/react";
 import { BaseSyntheticEvent, FC, useMemo, useState } from "react";
 import { FormProvider, useFieldArray, useForm } from "react-hook-form";
 import { graphql, useFragment } from "react-relay";
@@ -22,13 +23,16 @@ import {
   VersionedSquigglePlayground,
   versionSupportsDropdownMenu,
   versionSupportsExports,
+  versionSupportsImportTooltip,
 } from "@quri/versioned-squiggle-components";
 
 import { EditModelExports } from "@/components/exports/EditModelExports";
+import { ReactRoot } from "@/components/ReactRoot";
 import { FormModal } from "@/components/ui/FormModal";
 import { useAvailableHeight } from "@/hooks/useAvailableHeight";
 import { useMutationForm } from "@/hooks/useMutationForm";
 import { extractFromGraphqlErrorUnion } from "@/lib/graphqlHelpers";
+import { ImportTooltip } from "@/squiggle/components/ImportTooltip";
 import {
   serializeSourceId,
   squiggleHubLinker,
@@ -122,6 +126,8 @@ export const EditSquiggleSnippetModel: FC<Props> = ({
   modelRef,
   forceVersionPicker,
 }) => {
+  const { data: session } = useSession();
+
   const model = useFragment(
     graphql`
       fragment EditSquiggleSnippetModel on Model {
@@ -373,6 +379,14 @@ export const EditSquiggleSnippetModel: FC<Props> = ({
     playgroundProps.onExportsChange = (exports) => {
       form.setValue("exports", exports);
     };
+  }
+
+  if (versionSupportsImportTooltip.props(playgroundProps)) {
+    playgroundProps.renderImportTooltip = ({ importId }) => (
+      <ReactRoot session={session}>
+        <ImportTooltip importId={importId} />
+      </ReactRoot>
+    );
   }
 
   return (

--- a/packages/hub/src/app/models/[owner]/[slug]/exports/[variableName]/SquiggleModelExportPage.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/exports/[variableName]/SquiggleModelExportPage.tsx
@@ -35,6 +35,7 @@ const VersionedSquiggleModelExportPage: FC<
     const project = new squiggleLang.SqProject({
       linker: squiggleHubLinker,
     });
+
     const rootPath = new squiggleLang.SqValuePath({
       root: "bindings",
       items: [{ type: "string", value: variableName }],

--- a/packages/hub/src/app/models/[owner]/[slug]/relative-values/[variableName]/RelativeValuesModelLayout.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/relative-values/[variableName]/RelativeValuesModelLayout.tsx
@@ -154,7 +154,7 @@ export const RelativeValuesModelLayout: FC<
       <div className="mb-6 py-2 px-2 flex justify-between">
         <div className="flex items-center">
           <ScaleIcon className="text-gray-700 mr-2 opacity-40" size={22} />
-          <div className="flex text-md font-mono font-bold text-gray-700">
+          <div className="flex font-mono font-bold text-gray-700">
             {variableName}
           </div>
         </div>

--- a/packages/hub/src/components/EntityCard.tsx
+++ b/packages/hub/src/components/EntityCard.tsx
@@ -36,7 +36,7 @@ export const EntityCard: FC<Props> = ({
         <div className="w-full">
           <Link className="group" href={href}>
             <div className="flex items-center gap-1 mb-1">
-              <div className="text-md font-semibold text-blue-500 group-hover:underline">
+              <div className="font-semibold text-blue-500 group-hover:underline">
                 {showOwner ? ownerName + "/" : ""}
                 {slug}
               </div>

--- a/packages/hub/src/components/ReactRoot.tsx
+++ b/packages/hub/src/components/ReactRoot.tsx
@@ -9,7 +9,9 @@ import { WithToasts } from "@quri/ui";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { getCurrentEnvironment } from "@/relay/environment";
 
-export const ClientApp: FC<PropsWithChildren<{ session: Session | null }>> = ({
+// This component is used in the app's root layout to configure all common providers and wrappers.
+// It's also useful when you want to mount a separate React root. One example is CodeMirror tooltips, which are mounted as separate DOM elements.
+export const ReactRoot: FC<PropsWithChildren<{ session: Session | null }>> = ({
   session,
   children,
 }) => {

--- a/packages/hub/src/relative-values/components/views/ListView/sidebar.tsx
+++ b/packages/hub/src/relative-values/components/views/ListView/sidebar.tsx
@@ -24,7 +24,7 @@ const TableRow: React.FC<TableRowProps> = ({ label, number }) => (
     <div className="text-slate-400 py-1 mt-1 font-normal text-left text-xs col-span-1">
       {label}
     </div>
-    <div className="py-1 pl-2 text-left text-slate-600 text-md col-span-2">
+    <div className="py-1 pl-2 text-left text-slate-600 col-span-2">
       <NumberShower number={number} precision={2} />
     </div>
   </Fragment>
@@ -124,9 +124,7 @@ export const ItemSideBar: FC<Props> = ({
     return (
       <div>
         <div className="mt-2 mb-6 flex overflow-x-auto items-center p-1">
-          <span className="text-slate-500 text-md whitespace-nowrap mr-1">
-            value
-          </span>
+          <span className="text-slate-500 whitespace-nowrap mr-1">value</span>
           <span className="text-slate-300 text-xl whitespace-nowrap">(</span>
           <span className="text-sm bg-slate-200 font-semibold bg-opacity-80 rounded-sm text-slate-900 px-1 text-center whitespace-pre-wrap mr-2 ml-2">
             {numeratorItem.name}

--- a/packages/hub/src/squiggle/components/ImportTooltip.tsx
+++ b/packages/hub/src/squiggle/components/ImportTooltip.tsx
@@ -1,0 +1,52 @@
+import clsx from "clsx";
+import { FC } from "react";
+import { graphql, useLazyLoadQuery } from "react-relay";
+
+import { ModelCard } from "@/models/components/ModelCard";
+
+import { parseSourceId } from "./linker";
+
+import { ImportTooltipQuery } from "@/__generated__/ImportTooltipQuery.graphql";
+
+type Props = {
+  importId: string;
+};
+
+export const ImportTooltip: FC<Props> = ({ importId }) => {
+  const { owner, slug } = parseSourceId(importId);
+
+  const { model } = useLazyLoadQuery<ImportTooltipQuery>(
+    graphql`
+      query ImportTooltipQuery($input: QueryModelInput!) {
+        model(input: $input) {
+          __typename
+          ... on Model {
+            ...ModelCard
+          }
+        }
+      }
+    `,
+    { input: { owner, slug } }
+  );
+
+  if (model.__typename !== "Model") {
+    return (
+      <div>
+        {"Couldn't load "}
+        {owner}/{slug}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={clsx(
+        "min-w-72",
+        // reset font size from code editor; should this be done in <TooltipBox> from squiggle-components instead?
+        "text-base"
+      )}
+    >
+      <ModelCard modelRef={model} />
+    </div>
+  );
+};

--- a/packages/hub/src/squiggle/components/linker.ts
+++ b/packages/hub/src/squiggle/components/linker.ts
@@ -13,7 +13,7 @@ type ParsedSourceId = {
 
 const PREFIX = "hub";
 
-function parseSourceId(sourceId: string): ParsedSourceId {
+export function parseSourceId(sourceId: string): ParsedSourceId {
   const match = sourceId.match(/^(\w+):([\w-]+)\/([\w-]+)$/);
 
   if (!match) {

--- a/packages/versioned-components/src/index.ts
+++ b/packages/versioned-components/src/index.ts
@@ -10,6 +10,7 @@ export {
   squiggleVersions,
   versionSupportsDropdownMenu,
   versionSupportsExports,
+  versionSupportsImportTooltip,
   versionSupportsSquiggleChart,
 } from "./versions.js";
 

--- a/packages/versioned-components/src/versions.ts
+++ b/packages/versioned-components/src/versions.ts
@@ -65,3 +65,16 @@ function excludeVersions<
 export const versionSupportsDropdownMenu = excludeVersions(["0.8.5"]);
 export const versionSupportsExports = excludeVersions(["0.8.5", "0.8.6"]);
 export const versionSupportsSquiggleChart = excludeVersions(["0.8.5", "0.8.6"]);
+export const versionSupportsImportTooltip = excludeVersions([
+  "0.8.5",
+  "0.8.6",
+  "0.9.0",
+  "0.9.2",
+]);
+
+export const versionSupportsSqPathV2 = excludeVersions([
+  "0.8.5",
+  "0.8.6",
+  "0.9.0",
+  "0.9.2",
+]);


### PR DESCRIPTION
<img width="439" alt="Screenshot 2024-01-20 at 13 52 48" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/09fb1580-b8f8-411c-b29d-e6dd90e6b8c3">

Tooltips are injectable through the new `renderImportTooltip` playground prop.