### PR TITLE
Use rng initialized with seedrandom (alea)

### DIFF
--- a/.changeset/two-toes-grab.md
+++ b/.changeset/two-toes-grab.md
@@ -1,0 +1,6 @@
+---
+"@quri/squiggle-components": patch
+"@quri/squiggle-lang": patch
+---
+
+Use a custom PRNG ([alea](https://github.com/macmcmeans/aleaPRNG/tree/master))

--- a/packages/components/src/widgets/PlotWidget/ScatterChart/index.tsx
+++ b/packages/components/src/widgets/PlotWidget/ScatterChart/index.tsx
@@ -3,7 +3,6 @@ import { FC, useCallback, useMemo } from "react";
 
 import { Env, SqScale, SqScatterPlot } from "@quri/squiggle-lang";
 
-import { ErrorAlert } from "../../../components/Alert.js";
 import { sqScaleToD3 } from "../../../lib/d3/index.js";
 import {
   drawAxes,
@@ -25,36 +24,32 @@ type Props = {
   environment: Env;
 };
 
-export const ScatterChart: FC<Props> = ({ plot, height, environment }) => {
+export const ScatterChart: FC<Props> = ({ plot, height }) => {
   const { cursor, initCursor } = useCanvasCursor();
 
   const { xDist, yDist } = useMemo(
     () => ({
-      xDist: plot.xDist(environment),
-      yDist: plot.yDist(environment),
+      xDist: plot.xDist(),
+      yDist: plot.yDist(),
     }),
-    [plot, environment]
+    [plot]
   );
   const draw = useCallback(
     ({ context, width }: DrawContext) => {
-      if (!xDist.ok || !yDist.ok) {
-        return;
-      }
-
-      const points = SqScatterPlot.zipToPoints(xDist.value, yDist.value);
+      const points = SqScatterPlot.zipToPoints(xDist, yDist);
 
       const xSqScale = plot.xScale ?? SqScale.linearDefault();
       const xScale = sqScaleToD3(xSqScale);
       xScale.domain([
-        xSqScale.min ?? d3.min(xDist.value.getSamples()) ?? 0,
-        xSqScale.max ?? d3.max(xDist.value.getSamples()) ?? 0,
+        xSqScale.min ?? d3.min(xDist.getSamples()) ?? 0,
+        xSqScale.max ?? d3.max(xDist.getSamples()) ?? 0,
       ]);
 
       const ySqScale = plot.yScale ?? SqScale.linearDefault();
       const yScale = sqScaleToD3(ySqScale);
       yScale.domain([
-        ySqScale.min ?? d3.min(yDist.value.getSamples()) ?? 0,
-        ySqScale.max ?? d3.max(yDist.value.getSamples()) ?? 0,
+        ySqScale.min ?? d3.min(yDist.getSamples()) ?? 0,
+        ySqScale.max ?? d3.max(yDist.getSamples()) ?? 0,
       ]);
 
       const { frame } = drawAxes({
@@ -112,13 +107,6 @@ export const ScatterChart: FC<Props> = ({ plot, height, environment }) => {
       <canvas ref={ref} className={canvasClasses}>
         Chart for {plot.toString()}
       </canvas>
-      {[xDist, yDist].map((dist, i) =>
-        dist.ok ? null : (
-          <ErrorAlert key={i} heading="Conversion error">
-            {dist.value.toString()}
-          </ErrorAlert>
-        )
-      )}
     </div>
   );
 };

--- a/packages/squiggle-lang/__tests__/dist/Dotwise_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/Dotwise_test.ts
@@ -1,4 +1,5 @@
 import * as fc from "fast-check";
+import seedrandom from "seedrandom";
 
 import { binaryOperations } from "../../src/dist/distOperations/index.js";
 import { DivisionByZeroError } from "../../src/operationError.js";
@@ -9,6 +10,8 @@ import {
   unpackResult,
 } from "../helpers/distHelpers.js";
 
+const rng = seedrandom();
+
 describe("dotSubtract", () => {
   test("mean of normal minus exponential (unit)", () => {
     const mean = 0;
@@ -17,7 +20,7 @@ describe("dotSubtract", () => {
       binaryOperations.pointwiseSubtract(
         mkNormal(mean, 1.0),
         mkExponential(rate),
-        { env }
+        { env, rng }
       )
     );
     const meanValue = dotDifference.mean();
@@ -38,7 +41,7 @@ describe("dotSubtract", () => {
           const dotDifferenceR = binaryOperations.pointwiseSubtract(
             mkNormal(mean, 1.0),
             mkExponential(rate),
-            { env }
+            { env, rng }
           );
           if (!dotDifferenceR.ok) {
             const err = dotDifferenceR.value;

--- a/packages/squiggle-lang/__tests__/dist/GenericDist_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/GenericDist_test.ts
@@ -1,3 +1,5 @@
+import seedrandom from "seedrandom";
+
 import { BaseDist } from "../../src/dist/BaseDist.js";
 import { DistError } from "../../src/dist/DistError.js";
 import { SampleSetDist } from "../../src/dist/SampleSetDist/index.js";
@@ -22,6 +24,7 @@ const env: Env = {
   sampleCount: 100,
   xyPointLength: 100,
 };
+const rng = seedrandom();
 
 describe("toPointSet", () => {
   test("on symbolic normal distribution", () => {
@@ -35,7 +38,7 @@ describe("toPointSet", () => {
   const pointSet = unpackResult(
     Result.bind(
       Result.bind(normalDist5.toPointSetDist(env), (pointSet) =>
-        SampleSetDist.fromDist(pointSet, env)
+        SampleSetDist.fromDist(pointSet, env, rng)
       ),
       (sampleSet) => sampleSet.toPointSetDist(env)
     )

--- a/packages/squiggle-lang/__tests__/dist/Invariants/AlgebraicCombination_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/Invariants/AlgebraicCombination_test.ts
@@ -5,6 +5,8 @@ when things substantially change.
 Also, there are some open comments in https://github.com/quantified-uncertainty/squiggle/pull/232 that haven't been addressed.
 */
 
+import seedrandom from "seedrandom";
+
 import { binaryOperations } from "../../../src/dist/distOperations/index.js";
 import * as Result from "../../../src/utility/result.js";
 import {
@@ -16,19 +18,22 @@ import {
 } from "../../fixtures/distFixtures.js";
 import { env, unpackResult } from "../../helpers/distHelpers.js";
 
+const rng = seedrandom();
 const { algebraicAdd } = binaryOperations;
 
 describe("(Algebraic) addition of distributions", () => {
   describe("mean", () => {
     test("normal(mean=5) + normal(mean=20)", () => {
       expect(
-        unpackResult(algebraicAdd(normalDist5, normalDist20, { env })).mean()
+        unpackResult(
+          algebraicAdd(normalDist5, normalDist20, { env, rng })
+        ).mean()
       ).toBe(2.5e1);
     });
 
     test("uniform(low=9, high=10) + beta(alpha=2, beta=5)", () => {
       const received = unpackResult(
-        algebraicAdd(uniformDist, betaDist, { env })
+        algebraicAdd(uniformDist, betaDist, { env, rng })
       ).mean();
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
       // sometimes it works with ~digits=2.
@@ -36,7 +41,7 @@ describe("(Algebraic) addition of distributions", () => {
     });
     test("beta(alpha=2, beta=5) + uniform(low=9, high=10)", () => {
       const received = unpackResult(
-        algebraicAdd(betaDist, uniformDist, { env })
+        algebraicAdd(betaDist, uniformDist, { env, rng })
       ).mean();
 
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
@@ -51,8 +56,9 @@ describe("(Algebraic) addition of distributions", () => {
       (x) => {
         const received = unpackResult(normalDist10.pdf(x)); // this should be normal(10, sqrt(8))
         const calculated: number = unpackResult(
-          Result.bind(algebraicAdd(normalDist5, normalDist5, { env }), (d) =>
-            d.pdf(x, { env })
+          Result.bind(
+            algebraicAdd(normalDist5, normalDist5, { env, rng }),
+            (d) => d.pdf(x, { env })
           )
         );
 
@@ -63,8 +69,9 @@ describe("(Algebraic) addition of distributions", () => {
     test("(normal(mean=10) + normal(mean=10)).pdf(1.9e1)", () => {
       const received = unpackResult(normalDist20.pdf(1.9e1));
       const calculated: number = unpackResult(
-        Result.bind(algebraicAdd(normalDist10, normalDist10, { env }), (d) =>
-          d.pdf(1.9e1, { env })
+        Result.bind(
+          algebraicAdd(normalDist10, normalDist10, { env, rng }),
+          (d) => d.pdf(1.9e1, { env })
         )
       );
 
@@ -72,7 +79,7 @@ describe("(Algebraic) addition of distributions", () => {
     });
     test("(uniform(low=9, high=10) + beta(alpha=2, beta=5)).pdf(10)", () => {
       const received: number = unpackResult(
-        Result.bind(algebraicAdd(uniformDist, betaDist, { env }), (d) =>
+        Result.bind(algebraicAdd(uniformDist, betaDist, { env, rng }), (d) =>
           d.pdf(1e1, { env })
         )
       );
@@ -84,7 +91,7 @@ describe("(Algebraic) addition of distributions", () => {
     });
     test("(beta(alpha=2, beta=5) + uniform(low=9, high=10)).pdf(10)", () => {
       const received = unpackResult(
-        Result.bind(algebraicAdd(betaDist, uniformDist, { env }), (d) =>
+        Result.bind(algebraicAdd(betaDist, uniformDist, { env, rng }), (d) =>
           d.pdf(1e1, { env })
         )
       );
@@ -99,7 +106,7 @@ describe("(Algebraic) addition of distributions", () => {
       (x) => {
         const received = normalDist10.cdf(x);
         const calculated = unpackResult(
-          algebraicAdd(normalDist5, normalDist5, { env })
+          algebraicAdd(normalDist5, normalDist5, { env, rng })
         ).cdf(x);
 
         expect(received).toBeCloseTo(calculated, 0);
@@ -110,14 +117,14 @@ describe("(Algebraic) addition of distributions", () => {
       const received = normalDist20.cdf(1.25e1);
 
       const calculated = unpackResult(
-        algebraicAdd(normalDist10, normalDist10, { env })
+        algebraicAdd(normalDist10, normalDist10, { env, rng })
       ).cdf(1.25e1);
 
       expect(received).toBeCloseTo(calculated, 2);
     });
     test("(uniform(low=9, high=10) + beta(alpha=2, beta=5)).cdf(10)", () => {
       const received = unpackResult(
-        algebraicAdd(uniformDist, betaDist, { env })
+        algebraicAdd(uniformDist, betaDist, { env, rng })
       ).cdf(1e1);
 
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
@@ -126,7 +133,7 @@ describe("(Algebraic) addition of distributions", () => {
     });
     test("(beta(alpha=2, beta=5) + uniform(low=9, high=10)).cdf(10)", () => {
       const received = unpackResult(
-        algebraicAdd(betaDist, uniformDist, { env })
+        algebraicAdd(betaDist, uniformDist, { env, rng })
       ).cdf(1e1);
 
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
@@ -142,7 +149,7 @@ describe("(Algebraic) addition of distributions", () => {
         const received = normalDist10.inv(x);
 
         const calculated = unpackResult(
-          algebraicAdd(normalDist5, normalDist5, { env })
+          algebraicAdd(normalDist5, normalDist5, { env, rng })
         ).inv(x);
 
         expect(received).toBeCloseTo(calculated, -1);
@@ -152,14 +159,14 @@ describe("(Algebraic) addition of distributions", () => {
       const received = normalDist20.inv(1e-1);
 
       const calculated = unpackResult(
-        algebraicAdd(normalDist10, normalDist10, { env })
+        algebraicAdd(normalDist10, normalDist10, { env, rng })
       ).inv(1e-1);
 
       expect(received).toBeCloseTo(calculated, -1);
     });
     test("(uniform(low=9, high=10) + beta(alpha=2, beta=5)).inv(2e-2)", () => {
       const received = unpackResult(
-        algebraicAdd(uniformDist, betaDist, { env })
+        algebraicAdd(uniformDist, betaDist, { env, rng })
       ).inv(2e-2);
 
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.
@@ -168,7 +175,7 @@ describe("(Algebraic) addition of distributions", () => {
     });
     test("(beta(alpha=2, beta=5) + uniform(low=9, high=10)).inv(2e-2)", () => {
       const received = unpackResult(
-        algebraicAdd(betaDist, uniformDist, { env })
+        algebraicAdd(betaDist, uniformDist, { env, rng })
       ).inv(2e-2);
 
       // This is nondeterministic, we could be in a situation where ci fails but you click rerun and it passes, which is bad.

--- a/packages/squiggle-lang/__tests__/dist/Invariants/Means_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/Invariants/Means_test.ts
@@ -8,6 +8,8 @@ Details in https://squiggle-language.com/docs/internal/invariants/
 Note: epsilon of 1e3 means the invariants are, in general, not being satisfied. 
 */
 
+import seedrandom from "seedrandom";
+
 import { BaseDist } from "../../../src/dist/BaseDist.js";
 import {
   BinaryOperation,
@@ -28,6 +30,7 @@ import {
 import { expectErrorToBeBounded } from "../../helpers/helpers.js";
 
 const epsilon = 5e1;
+const rng = seedrandom();
 
 const distributions = [
   mkNormal(4, 1),
@@ -58,7 +61,7 @@ const testOperationMean = (
   dist2: BaseDist,
   { epsilon, env }: { epsilon: number; env: Env }
 ) => {
-  const received = unpackResult(distOp(dist1, dist2, { env })).mean();
+  const received = unpackResult(distOp(dist1, dist2, { env, rng })).mean();
 
   const expected = floatOp(dist1.mean(), dist2.mean());
 

--- a/packages/squiggle-lang/__tests__/dist/Mixture_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/Mixture_test.ts
@@ -1,3 +1,5 @@
+import seedrandom from "seedrandom";
+
 import { mixture } from "../../src/dist/distOperations/index.js";
 import {
   env,
@@ -8,6 +10,8 @@ import {
   mkUniform,
   unpackResult,
 } from "../helpers/distHelpers.js";
+
+const rng = seedrandom();
 
 describe("mixture", () => {
   test.each([
@@ -23,7 +27,7 @@ describe("mixture", () => {
           [mkNormal(mean1, 9e-1), 0.5],
           [mkNormal(mean2, 9e-1), 0.5],
         ],
-        { env }
+        { env, rng }
       )
     ).mean();
     expect(meanValue).toBeCloseTo((mean1 + mean2) / 2, -1);
@@ -45,7 +49,7 @@ describe("mixture", () => {
           [mkBeta(alpha, beta), betaWeight],
           [mkExponential(rate), exponentialWeight],
         ],
-        { env }
+        { env, rng }
       )
     ).mean();
     const betaMean = 1 / (1 + beta / alpha);
@@ -81,7 +85,7 @@ describe("mixture", () => {
             [mkUniform(low, high), uniformWeight],
             [mkLognormal(mu, sigma), lognormalWeight],
           ],
-          { env }
+          { env, rng }
         )
       ).mean();
       const uniformMean = (low + high) / 2;

--- a/packages/squiggle-lang/__tests__/dist/Scoring/KlDivergence_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/Scoring/KlDivergence_test.ts
@@ -1,3 +1,4 @@
+import seedrandom from "seedrandom";
 import { BaseDist } from "../../../src/dist/BaseDist.js";
 import { distErrorToString } from "../../../src/dist/DistError.js";
 import {
@@ -19,6 +20,8 @@ import {
   mkUniform,
   unpackResult,
 } from "../../helpers/distHelpers.js";
+
+const rng = seedrandom();
 
 const klDivergence = (prediction: BaseDist, answer: BaseDist): number => {
   const result = logScoreDistAnswer({
@@ -106,7 +109,7 @@ describe("klDivergence: discrete -> discrete -> float", () => {
         [point1, 1],
         [point2, 1],
       ],
-      { env }
+      { env, rng }
     )
   );
   const b = unpackResult(
@@ -116,7 +119,7 @@ describe("klDivergence: discrete -> discrete -> float", () => {
         [point2, 1],
         [point3, 1],
       ],
-      { env }
+      { env, rng }
     )
   );
 
@@ -143,7 +146,7 @@ describe("klDivergence: mixed -> mixed -> float", () => {
         [point1, 1.0],
         [uniformDist, 1.0],
       ],
-      { env }
+      { env, rng }
     )
   );
   const b = unpackResult(
@@ -153,7 +156,7 @@ describe("klDivergence: mixed -> mixed -> float", () => {
         [floatDist, 1.0],
         [normalDist10, 1.0],
       ],
-      { env }
+      { env, rng }
     )
   );
   const c = unpackResult(
@@ -164,7 +167,7 @@ describe("klDivergence: mixed -> mixed -> float", () => {
         [point3, 1.0],
         [uniformDist, 1.0],
       ],
-      { env }
+      { env, rng }
     )
   );
   const d = unpackResult(
@@ -176,7 +179,7 @@ describe("klDivergence: mixed -> mixed -> float", () => {
         [floatDist, 1.0],
         [uniformDist2, 1.0],
       ],
-      { env }
+      { env, rng }
     )
   );
 

--- a/packages/squiggle-lang/__tests__/dist/Scoring/WithScalarAnswer_test.ts
+++ b/packages/squiggle-lang/__tests__/dist/Scoring/WithScalarAnswer_test.ts
@@ -1,8 +1,12 @@
+import seedrandom from "seedrandom";
+
 import {
   logScoreScalarAnswer,
   mixture,
 } from "../../../src/dist/distOperations/index.js";
 import { env, mkPointMass, unpackResult } from "../../helpers/distHelpers.js";
+
+const rng = seedrandom();
 
 describe("WithScalarAnswer: discrete -> scalar -> score", () => {
   const pointA = mkPointMass(3.0);
@@ -19,7 +23,7 @@ describe("WithScalarAnswer: discrete -> scalar -> score", () => {
           [pointC, 0.25],
           [pointD, 0.25],
         ],
-        { env }
+        { env, rng }
       )
     );
 
@@ -42,7 +46,7 @@ describe("WithScalarAnswer: discrete -> scalar -> score", () => {
           [pointA, 0.75],
           [pointB, 0.25],
         ],
-        { env }
+        { env, rng }
       )
     );
 
@@ -65,7 +69,7 @@ describe("WithScalarAnswer: discrete -> scalar -> score", () => {
           [pointA, 0.5],
           [pointB, 0.5],
         ],
-        { env }
+        { env, rng }
       )
     );
     const prediction = unpackResult(
@@ -74,7 +78,7 @@ describe("WithScalarAnswer: discrete -> scalar -> score", () => {
           [pointA, 0.75],
           [pointB, 0.25],
         ],
-        { env }
+        { env, rng }
       )
     );
 

--- a/packages/squiggle-lang/__tests__/reducer/seeds_test.ts
+++ b/packages/squiggle-lang/__tests__/reducer/seeds_test.ts
@@ -1,0 +1,50 @@
+import { SqProject } from "../../src/index.js";
+
+const SAMPLE_COUNT = 100;
+
+async function getSamplesForSeed(seed?: string | undefined) {
+  const project = new SqProject({
+    environment: {
+      sampleCount: SAMPLE_COUNT,
+      xyPointLength: 100,
+      seed,
+    },
+  });
+  project.setSource("main", "2 to 3");
+  await project.run("main");
+  const result = project.getResult("main");
+  if (!result.ok) {
+    throw new Error("Run failed");
+  }
+  const samples = result.value.asJS();
+  if (!Array.isArray(samples)) {
+    throw new Error("Expected an array");
+  }
+  return samples as number[];
+}
+
+describe("seeds", () => {
+  test("Sample sets with identical seeds are identical", async () => {
+    const samples = await getSamplesForSeed("test");
+    expect(samples.length).toEqual(SAMPLE_COUNT);
+
+    const samples2 = await getSamplesForSeed("test");
+    expect(samples).toEqual(samples2);
+  });
+
+  test("Sample sets with different seeds are different", async () => {
+    const samples = await getSamplesForSeed("test");
+    expect(samples.length).toEqual(SAMPLE_COUNT);
+
+    const samples2 = await getSamplesForSeed("test2");
+    expect(samples).not.toEqual(samples2);
+  });
+
+  test("Sample sets without explcit seeds are different", async () => {
+    const samples = await getSamplesForSeed();
+    expect(samples.length).toEqual(SAMPLE_COUNT);
+
+    const samples2 = await getSamplesForSeed();
+    expect(samples).not.toEqual(samples2);
+  });
+});

--- a/packages/squiggle-lang/__tests__/utility/math_test.ts
+++ b/packages/squiggle-lang/__tests__/utility/math_test.ts
@@ -1,16 +1,21 @@
 import uniq from "lodash/uniq.js";
+import seedrandom from "seedrandom";
 
 import { random_sample } from "../../src/utility/math.js";
+
+const rng = seedrandom();
 
 describe("random_sample", () => {
   test("Length of random_sample", () => {
     expect(
-      random_sample([1.0, 2.0], { probs: [0.5, 0.5], size: 10 }).length
+      random_sample([1.0, 2.0], { probs: [0.5, 0.5], size: 10, rng }).length
     ).toEqual(10);
   });
   test("Random.sample returns elements from input array (will fail with very slim probability)", () => {
     expect(
-      uniq(random_sample([1.0, 2.0], { probs: [0.5, 0.5], size: 10 })).sort()
+      uniq(
+        random_sample([1.0, 2.0], { probs: [0.5, 0.5], size: 10, rng })
+      ).sort()
     ).toEqual([1, 2]);
   });
 });

--- a/packages/squiggle-lang/package.json
+++ b/packages/squiggle-lang/package.json
@@ -34,15 +34,17 @@
     "immutable": "^4.3.4",
     "jstat": "^1.9.6",
     "lodash": "^4.17.21",
-    "open": "^10.0.2"
+    "open": "^10.0.2",
+    "seedrandom": "^3.0.5"
   },
   "devDependencies": {
-    "@quri/configs": "workspace:*",
     "@babel/preset-typescript": "^7.23.3",
     "@jest/globals": "^29.7.0",
+    "@quri/configs": "workspace:*",
     "@types/jest": "^29.5.10",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.10.6",
+    "@types/seedrandom": "^3.0.8",
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "codecov": "^3.8.3",

--- a/packages/squiggle-lang/src/PointSet/Discrete.ts
+++ b/packages/squiggle-lang/src/PointSet/Discrete.ts
@@ -1,3 +1,5 @@
+import { PRNG } from "seedrandom";
+
 import { epsilon_float } from "../magicNumbers.js";
 import { random_sample } from "../utility/math.js";
 import * as Result from "../utility/result.js";
@@ -300,7 +302,7 @@ export const combineAlgebraically = (
   });
 };
 
-export const sampleN = (t: DiscreteShape, n: number): number[] => {
+export const sampleN = (t: DiscreteShape, n: number, rng: PRNG): number[] => {
   const normalized = t.normalize().xyShape;
-  return random_sample(normalized.xs, { probs: normalized.ys, size: n });
+  return random_sample(normalized.xs, { probs: normalized.ys, size: n, rng });
 };

--- a/packages/squiggle-lang/src/XYShape.ts
+++ b/packages/squiggle-lang/src/XYShape.ts
@@ -81,6 +81,9 @@ const interpolate = (
   yMax: number,
   xIntended: number
 ): number => {
+  if (yMin === yMax) {
+    return yMin;
+  }
   const minProportion = (xMax - xIntended) / (xMax - xMin);
   const maxProportion = (xIntended - xMin) / (xMax - xMin);
   return yMin * minProportion + yMax * maxProportion;

--- a/packages/squiggle-lang/src/custom-types/index.d.ts
+++ b/packages/squiggle-lang/src/custom-types/index.d.ts
@@ -1,4 +1,5 @@
 declare module "jstat" {
+  export function setRandom(rng: () => number): void;
   export namespace normal {
     export function pdf(x: number, mu: number, sigma: number): number;
     export function cdf(x: number, mu: number, sigma: number): number;

--- a/packages/squiggle-lang/src/dist/BaseDist.ts
+++ b/packages/squiggle-lang/src/dist/BaseDist.ts
@@ -1,3 +1,5 @@
+import { PRNG } from "seedrandom";
+
 import * as magicNumbers from "../magicNumbers.js";
 import * as Result from "../utility/result.js";
 import { result } from "../utility/result.js";
@@ -11,8 +13,8 @@ export abstract class BaseDist {
   abstract max(): number;
   abstract mean(): number;
 
-  abstract sample(): number;
-  abstract sampleN(n: number): number[];
+  abstract sample(rng: PRNG): number;
+  abstract sampleN(n: number, rng: PRNG): number[];
 
   abstract normalize(): BaseDist;
   isNormalized(): boolean {
@@ -22,7 +24,7 @@ export abstract class BaseDist {
   abstract truncate(
     left: number | undefined,
     right: number | undefined,
-    opts?: { env: Env } // needed for SymbolicDists
+    opts: { env: Env; rng: PRNG } // `env` is needed for symbolic dists, and `rng` for sample set dists
   ): result<BaseDist, DistError>;
 
   abstract integralSum(): number;

--- a/packages/squiggle-lang/src/dist/PointSetDist.ts
+++ b/packages/squiggle-lang/src/dist/PointSetDist.ts
@@ -1,3 +1,5 @@
+import { PRNG } from "seedrandom";
+
 import { ContinuousShape } from "../PointSet/Continuous.js";
 import * as Mixed from "../PointSet/Mixed.js";
 import { MixedShape } from "../PointSet/Mixed.js";
@@ -36,14 +38,14 @@ export class PointSetDist extends BaseDist {
     return new PointSetDist(this.pointSet.downsample(n));
   }
 
-  sample() {
-    const randomItem = Math.random();
+  sample(rng: PRNG) {
+    const randomItem = rng();
     return this.pointSet.integralYtoX(randomItem);
   }
-  sampleN(n: number) {
+  sampleN(n: number, rng: PRNG) {
     const items: number[] = new Array(n).fill(0);
     for (let i = 0; i < n; i++) {
-      items[i] = this.sample();
+      items[i] = this.sample(rng);
     }
     return items;
   }

--- a/packages/squiggle-lang/src/dist/SymbolicDist.ts
+++ b/packages/squiggle-lang/src/dist/SymbolicDist.ts
@@ -1,5 +1,6 @@
 import jstat from "jstat";
 import sum from "lodash/sum.js";
+import { PRNG } from "seedrandom";
 
 import * as magicNumbers from "../magicNumbers.js";
 import * as Operation from "../operation.js";
@@ -134,10 +135,10 @@ export abstract class SymbolicDist extends BaseDist {
     return this.inv(SymbolicDist.maxCdfValue);
   }
 
-  sampleN(n: number) {
+  sampleN(n: number, rng: PRNG) {
     const result: number[] = new Array(n);
     for (let i = 0; i < n; i++) {
-      result[i] = this.sample();
+      result[i] = this.sample(rng);
     }
     return result;
   }
@@ -875,8 +876,8 @@ export class Logistic extends SymbolicDist {
     if (this.scale === 0) return this.location;
     return this.location + this.scale * Math.log(p / (1 - p));
   }
-  sample() {
-    const s = Math.random();
+  sample(rng: PRNG) {
+    const s = rng();
     return this.inv(s);
   }
   mean() {
@@ -927,8 +928,8 @@ export class Bernoulli extends SymbolicDist {
   mean() {
     return this.p;
   }
-  sample() {
-    const s = Math.random();
+  sample(rng: PRNG) {
+    const s = rng();
     return this.inv(s);
   }
   _isEqual(other: Bernoulli) {
@@ -1116,12 +1117,12 @@ export class Binomial extends SymbolicDist {
     return Ok(this.n * this.p * (1 - this.p));
   }
 
-  sample() {
+  sample(rng: PRNG) {
     const bernoulli = Bernoulli.make(this.p);
     if (bernoulli.ok) {
       // less space efficient than adding a bunch of draws, but cleaner. Taken from Guesstimate.
       return sum(
-        Array.from({ length: this.n }, () => bernoulli.value.sample())
+        Array.from({ length: this.n }, () => bernoulli.value.sample(rng))
       );
     } else {
       throw new Error("Binomial sampling failed");

--- a/packages/squiggle-lang/src/dist/distOperations/algebraicCombination.ts
+++ b/packages/squiggle-lang/src/dist/distOperations/algebraicCombination.ts
@@ -1,3 +1,5 @@
+import { PRNG } from "seedrandom";
+
 import * as magicNumbers from "../../magicNumbers.js";
 import * as Operation from "../../operation.js";
 import { AlgebraicOperation } from "../../operation.js";
@@ -55,6 +57,7 @@ type CombinationArgs = {
   t1: BaseDist;
   t2: BaseDist;
   env: Env;
+  rng: PRNG;
   arithmeticOperation: AlgebraicOperation;
 };
 
@@ -110,13 +113,14 @@ const convolutionStrategy: StrategyImplementation = ({
 
 const monteCarloStrategy: StrategyImplementation = ({
   env,
+  rng,
   arithmeticOperation,
   t1,
   t2,
 }) => {
   const fn = Operation.Algebraic.toFn(arithmeticOperation);
-  const s1r = SampleSetDist.SampleSetDist.fromDist(t1, env);
-  const s2r = SampleSetDist.SampleSetDist.fromDist(t2, env);
+  const s1r = SampleSetDist.SampleSetDist.fromDist(t1, env, rng);
+  const s2r = SampleSetDist.SampleSetDist.fromDist(t2, env, rng);
   if (!s1r.ok) {
     return s1r;
   }

--- a/packages/squiggle-lang/src/dist/env.ts
+++ b/packages/squiggle-lang/src/dist/env.ts
@@ -3,6 +3,7 @@ import * as magicNumbers from "../magicNumbers.js";
 export type Env = {
   sampleCount: number; // int
   xyPointLength: number; // int
+  seed?: number; // for seedrandom
 };
 
 export const defaultEnv: Env = {

--- a/packages/squiggle-lang/src/dist/env.ts
+++ b/packages/squiggle-lang/src/dist/env.ts
@@ -3,7 +3,7 @@ import * as magicNumbers from "../magicNumbers.js";
 export type Env = {
   sampleCount: number; // int
   xyPointLength: number; // int
-  seed?: number; // for seedrandom
+  seed?: string; // for seedrandom
 };
 
 export const defaultEnv: Env = {

--- a/packages/squiggle-lang/src/fr/dist.ts
+++ b/packages/squiggle-lang/src/fr/dist.ts
@@ -38,8 +38,7 @@ function makeCIDist<K1 extends string, K2 extends string>(
   return makeDefinition(
     [frDict([lowKey, frNumber], [highKey, frNumber])],
     frSampleSetDist,
-    ([dict], { environment }) =>
-      twoVarSample(dict[lowKey], dict[highKey], environment, fn)
+    ([dict], context) => twoVarSample(dict[lowKey], dict[highKey], context, fn)
   );
 }
 
@@ -52,8 +51,7 @@ function makeMeanStdevDist(
   return makeDefinition(
     [frDict(["mean", frNumber], ["stdev", frNumber])],
     frSampleSetDist,
-    ([{ mean, stdev }], { environment }) =>
-      twoVarSample(mean, stdev, environment, fn)
+    ([{ mean, stdev }], context) => twoVarSample(mean, stdev, context, fn)
   );
 }
 
@@ -285,12 +283,12 @@ Note: If you want to pass in over 5 distributions, you must use the list syntax.
           frNamed("max", frNumber),
         ],
         frSampleSetDist,
-        ([low, medium, high], { environment }) => {
+        ([low, medium, high], context) => {
           const result = SymbolicDist.Triangular.make({ low, medium, high });
           if (!result.ok) {
             throw new REDistributionError(otherError(result.value));
           }
-          return makeSampleSet(result.value, environment);
+          return makeSampleSet(result.value, context);
         }
       ),
     ],

--- a/packages/squiggle-lang/src/fr/list.ts
+++ b/packages/squiggle-lang/src/fr/list.ts
@@ -722,7 +722,7 @@ List.reduceWhile(
       makeDefinition(
         [frArray(frAny({ genericName: "A" }))],
         frArray(frAny({ genericName: "A" })),
-        ([arr]) => shuffle(arr)
+        ([arr], context) => shuffle(arr, context.rng)
       ),
     ],
   }),

--- a/packages/squiggle-lang/src/fr/mixture.ts
+++ b/packages/squiggle-lang/src/fr/mixture.ts
@@ -1,7 +1,6 @@
 import { BaseDist } from "../dist/BaseDist.js";
 import { argumentError } from "../dist/DistError.js";
 import * as distOperations from "../dist/distOperations/index.js";
-import { Env } from "../dist/env.js";
 import { REDistributionError } from "../errors/messages.js";
 import { makeDefinition } from "../library/registry/fnDefinition.js";
 import {
@@ -17,28 +16,35 @@ import {
   parseDistFromDistOrNumber,
   unwrapDistResult,
 } from "../library/registry/helpers.js";
+import { ReducerContext } from "../reducer/context.js";
 import * as E_A from "../utility/E_A.js";
 
 function mixtureWithGivenWeights(
   distributions: BaseDist[],
   weights: readonly number[],
-  env: Env
+  context: ReducerContext
 ): BaseDist {
   return unwrapDistResult(
-    distOperations.mixture(E_A.zip(distributions, weights), { env })
+    distOperations.mixture(E_A.zip(distributions, weights), {
+      env: context.environment,
+      rng: context.rng,
+    })
   );
 }
 
-function mixtureWithDefaultWeights(distributions: BaseDist[], env: Env) {
+function mixtureWithDefaultWeights(
+  distributions: BaseDist[],
+  context: ReducerContext
+) {
   const length = distributions.length;
   const weights = new Array(length).fill(1 / length);
-  return mixtureWithGivenWeights(distributions, weights, env);
+  return mixtureWithGivenWeights(distributions, weights, context);
 }
 
 const asArrays = makeDefinition(
   [frArray(frDistOrNumber), frNamed("weights", frOptional(frArray(frNumber)))],
   frDist,
-  ([dists, weights], { environment }) => {
+  ([dists, weights], context) => {
     if (weights) {
       if (dists.length !== weights.length) {
         throw new REDistributionError(
@@ -50,23 +56,20 @@ const asArrays = makeDefinition(
       return mixtureWithGivenWeights(
         dists.map(parseDistFromDistOrNumber),
         weights,
-        environment
+        context
       );
     } else {
       return mixtureWithDefaultWeights(
         dists.map(parseDistFromDistOrNumber),
-        environment
+        context
       );
     }
   }
 );
 
 const asArguments = [
-  makeDefinition([frDistOrNumber], frDist, ([dist1], { environment }) =>
-    mixtureWithDefaultWeights(
-      [dist1].map(parseDistFromDistOrNumber),
-      environment
-    )
+  makeDefinition([frDistOrNumber], frDist, ([dist1], context) =>
+    mixtureWithDefaultWeights([dist1].map(parseDistFromDistOrNumber), context)
   ),
   makeDefinition(
     [
@@ -75,16 +78,16 @@ const asArguments = [
       frNamed("weights", frOptional(frTuple(frNumber, frNumber))),
     ],
     frDist,
-    ([dist1, dist2, weights], { environment }) =>
+    ([dist1, dist2, weights], context) =>
       weights
         ? mixtureWithGivenWeights(
             [dist1, dist2].map(parseDistFromDistOrNumber),
             weights,
-            environment
+            context
           )
         : mixtureWithDefaultWeights(
             [dist1, dist2].map(parseDistFromDistOrNumber),
-            environment
+            context
           )
   ),
   makeDefinition(
@@ -95,16 +98,16 @@ const asArguments = [
       frNamed("weights", frOptional(frTuple(frNumber, frNumber, frNumber))),
     ],
     frDist,
-    ([dist1, dist2, dist3, weights], { environment }) =>
+    ([dist1, dist2, dist3, weights], context) =>
       weights
         ? mixtureWithGivenWeights(
             [dist1, dist2, dist3].map(parseDistFromDistOrNumber),
             weights,
-            environment
+            context
           )
         : mixtureWithDefaultWeights(
             [dist1, dist2, dist3].map(parseDistFromDistOrNumber),
-            environment
+            context
           )
   ),
   makeDefinition(
@@ -119,16 +122,16 @@ const asArguments = [
       ),
     ],
     frDist,
-    ([dist1, dist2, dist3, dist4, weights], { environment }) =>
+    ([dist1, dist2, dist3, dist4, weights], context) =>
       weights
         ? mixtureWithGivenWeights(
             [dist1, dist2, dist3, dist4].map(parseDistFromDistOrNumber),
             weights,
-            environment
+            context
           )
         : mixtureWithDefaultWeights(
             [dist1, dist2, dist3, dist4].map(parseDistFromDistOrNumber),
-            environment
+            context
           )
   ),
   makeDefinition(
@@ -144,16 +147,16 @@ const asArguments = [
       ),
     ],
     frDist,
-    ([dist1, dist2, dist3, dist4, dist5, weights], { environment }) =>
+    ([dist1, dist2, dist3, dist4, dist5, weights], context) =>
       weights
         ? mixtureWithGivenWeights(
             [dist1, dist2, dist3, dist4, dist5].map(parseDistFromDistOrNumber),
             weights,
-            environment
+            context
           )
         : mixtureWithDefaultWeights(
             [dist1, dist2, dist3, dist4, dist5].map(parseDistFromDistOrNumber),
-            environment
+            context
           )
   ),
 ];

--- a/packages/squiggle-lang/src/fr/sampleset.ts
+++ b/packages/squiggle-lang/src/fr/sampleset.ts
@@ -33,8 +33,10 @@ const maker = new FnFactory({
 const fromDist = makeDefinition(
   [frDist],
   frSampleSetDist,
-  ([dist], { environment }) =>
-    unwrapDistResult(SampleSetDist.SampleSetDist.fromDist(dist, environment))
+  ([dist], { environment, rng }) =>
+    unwrapDistResult(
+      SampleSetDist.SampleSetDist.fromDist(dist, environment, rng)
+    )
 );
 
 const fromNumber = makeDefinition(

--- a/packages/squiggle-lang/src/public/SqValue/SqDistribution/index.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqDistribution/index.ts
@@ -40,15 +40,6 @@ export abstract class SqAbstractDistribution<T extends BaseDist> {
     );
   }
 
-  asSampleSetDist(env: Env) {
-    const innerResult = SampleSetDist.fromDist(this._value, env);
-    return Result.fmap2(
-      innerResult,
-      (dist) => new SqSampleSetDistribution(dist),
-      (e: DistError) => new SqDistributionError(e)
-    );
-  }
-
   toString() {
     return this._value.toString();
   }

--- a/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
@@ -1,8 +1,5 @@
-import { Env } from "../../dist/env.js";
 import { clamp, sort, uniq } from "../../utility/E_A_Floats.js";
-import * as Result from "../../utility/result.js";
 import { Plot, vPlot } from "../../value/VPlot.js";
-import { SqError } from "../SqError.js";
 import { SqValueContext } from "../SqValueContext.js";
 import { SqPlotValue } from "./index.js";
 import {
@@ -258,11 +255,11 @@ export class SqDistFnPlot extends SqAbstractPlot<"distFn"> {
 export class SqScatterPlot extends SqAbstractPlot<"scatter"> {
   tag = "scatter" as const;
 
-  xDist(env: Env): Result.result<SqSampleSetDistribution, SqError> {
-    return Result.Ok(new SqSampleSetDistribution(this._value.xDist));
+  xDist(): SqSampleSetDistribution {
+    return new SqSampleSetDistribution(this._value.xDist);
   }
-  yDist(env: Env): Result.result<SqSampleSetDistribution, SqError> {
-    return Result.Ok(new SqSampleSetDistribution(this._value.yDist));
+  yDist(): SqSampleSetDistribution {
+    return new SqSampleSetDistribution(this._value.yDist);
   }
 
   get xScale(): SqScale | undefined {

--- a/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqPlot.ts
@@ -1,10 +1,8 @@
-import { BaseDist } from "../../dist/BaseDist.js";
 import { Env } from "../../dist/env.js";
-import { SampleSetDist } from "../../dist/SampleSetDist/index.js";
 import { clamp, sort, uniq } from "../../utility/E_A_Floats.js";
 import * as Result from "../../utility/result.js";
 import { Plot, vPlot } from "../../value/VPlot.js";
-import { SqError, SqOtherError } from "../SqError.js";
+import { SqError } from "../SqError.js";
 import { SqValueContext } from "../SqValueContext.js";
 import { SqPlotValue } from "./index.js";
 import {
@@ -260,22 +258,11 @@ export class SqDistFnPlot extends SqAbstractPlot<"distFn"> {
 export class SqScatterPlot extends SqAbstractPlot<"scatter"> {
   tag = "scatter" as const;
 
-  private buildSampleSetDist(
-    dist: BaseDist,
-    env: Env
-  ): Result.result<SqSampleSetDistribution, SqError> {
-    const sampleSetResult = SampleSetDist.fromDist(dist, env);
-    if (!sampleSetResult.ok) {
-      return Result.Err(new SqOtherError("Conversion to SampleSet failed"));
-    }
-    return Result.Ok(new SqSampleSetDistribution(sampleSetResult.value));
-  }
-
   xDist(env: Env): Result.result<SqSampleSetDistribution, SqError> {
-    return this.buildSampleSetDist(this._value.xDist, env);
+    return Result.Ok(new SqSampleSetDistribution(this._value.xDist));
   }
   yDist(env: Env): Result.result<SqSampleSetDistribution, SqError> {
-    return this.buildSampleSetDist(this._value.yDist, env);
+    return Result.Ok(new SqSampleSetDistribution(this._value.yDist));
   }
 
   get xScale(): SqScale | undefined {

--- a/packages/squiggle-lang/src/reducer/context.ts
+++ b/packages/squiggle-lang/src/reducer/context.ts
@@ -1,3 +1,5 @@
+import seedrandom from "seedrandom";
+
 import { Env } from "../dist/env.js";
 import { FrameStack, topFrameName } from "./frameStack.js";
 import { evaluate, ReducerFn } from "./index.js";
@@ -10,6 +12,7 @@ export type ReducerContext = Readonly<{
   frameStack: FrameStack;
   evaluate: ReducerFn;
   inFunction: BaseLambda | undefined;
+  rng: seedrandom.PRNG;
 }>;
 
 export function createContext(environment: Env): ReducerContext {
@@ -19,6 +22,9 @@ export function createContext(environment: Env): ReducerContext {
     frameStack: FrameStack.make(),
     evaluate,
     inFunction: undefined,
+    rng: seedrandom.alea(
+      environment.seed === undefined ? undefined : String(environment.seed)
+    ),
   };
 }
 

--- a/packages/squiggle-lang/src/reducer/context.ts
+++ b/packages/squiggle-lang/src/reducer/context.ts
@@ -16,15 +16,17 @@ export type ReducerContext = Readonly<{
 }>;
 
 export function createContext(environment: Env): ReducerContext {
+  const seed = environment.seed
+    ? String(environment.seed)
+    : String(seedrandom()());
+
   return {
     stack: Stack.make(),
     environment,
     frameStack: FrameStack.make(),
     evaluate,
     inFunction: undefined,
-    rng: seedrandom.alea(
-      environment.seed === undefined ? undefined : String(environment.seed)
-    ),
+    rng: seedrandom.alea(seed),
   };
 }
 

--- a/packages/squiggle-lang/src/reducer/index.ts
+++ b/packages/squiggle-lang/src/reducer/index.ts
@@ -1,3 +1,5 @@
+import jstat from "jstat";
+
 import { ASTNode, parse } from "../ast/parse.js";
 import { defaultEnv } from "../dist/env.js";
 import {
@@ -59,6 +61,7 @@ function throwFrom(
  * `context.evaluate` can inject additional behaviors, e.g. delay for pseudo-async evaluation.
  */
 export const evaluate: ReducerFn = (expression, context) => {
+  jstat.setRandom(context.rng);
   const ast = expression.ast;
   switch (expression.type) {
     case "Block":
@@ -160,6 +163,7 @@ const evaluateAssign: SubReducerFn<"Assign"> = (expressionValue, context) => {
       frameStack: context.frameStack,
       evaluate: context.evaluate,
       inFunction: context.inFunction,
+      rng: context.rng,
     },
   ];
 };

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -60,6 +60,7 @@ export abstract class BaseLambda {
       ),
       evaluate: context.evaluate,
       inFunction: this,
+      rng: context.rng,
     };
 
     try {
@@ -111,6 +112,7 @@ export class UserDefinedLambda extends BaseLambda {
         frameStack: context.frameStack,
         evaluate: context.evaluate,
         inFunction: context.inFunction,
+        rng: context.rng,
       };
 
       const [value] = context.evaluate(body, lambdaContext);

--- a/packages/squiggle-lang/src/utility/E_A.ts
+++ b/packages/squiggle-lang/src/utility/E_A.ts
@@ -1,3 +1,5 @@
+import { type PRNG } from "seedrandom";
+
 import { Ok, result } from "./result.js";
 
 export const zip = <A, B>(xs: readonly A[], ys: readonly B[]): [A, B][] => {
@@ -95,10 +97,10 @@ export const makeBy = <T>(n: number, fn: (i: number) => T): T[] => {
   return result;
 };
 
-export function shuffle<T>(array: readonly T[]): T[] {
+export function shuffle<T>(array: readonly T[], rng: PRNG): T[] {
   const shuffledArray = [...array];
   for (let i = shuffledArray.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
+    const j = Math.floor(rng() * (i + 1));
     [shuffledArray[i], shuffledArray[j]] = [shuffledArray[j], shuffledArray[i]];
   }
   return shuffledArray;

--- a/packages/squiggle-lang/src/utility/math.ts
+++ b/packages/squiggle-lang/src/utility/math.ts
@@ -1,3 +1,5 @@
+import { PRNG } from "seedrandom";
+
 /**
  * Searches for a first element in `arr` greater than `value`
  * For more info:
@@ -14,9 +16,9 @@ function binsearchFirstGreater(arr: number[], value: number): number {
 
 export function random_sample(
   dist: number[],
-  args: { probs: number[]; size: number }
+  args: { probs: number[]; size: number; rng: PRNG }
 ): number[] {
-  const { probs, size } = args;
+  const { probs, size, rng } = args;
   const sample: number[] = Array(size);
 
   let accum = 0;
@@ -27,10 +29,7 @@ export function random_sample(
   const sum = probPrefixSums[probPrefixSums.length - 1];
 
   for (let index = 0; index < size; index++) {
-    const selection = binsearchFirstGreater(
-      probPrefixSums,
-      Math.random() * sum
-    );
+    const selection = binsearchFirstGreater(probPrefixSums, rng() * sum);
     sample[index] = dist[selection];
   }
   return sample;

--- a/packages/squiggle-lang/src/value/VPlot.ts
+++ b/packages/squiggle-lang/src/value/VPlot.ts
@@ -1,4 +1,5 @@
 import { BaseDist } from "../dist/BaseDist.js";
+import { SampleSetDist } from "../dist/SampleSetDist/index.js";
 import { REOther } from "../errors/messages.js";
 import { Lambda } from "../reducer/lambda.js";
 import { BaseValue } from "./BaseValue.js";
@@ -42,8 +43,8 @@ export type Plot = CommonPlotArgs &
       }
     | {
         type: "scatter";
-        xDist: BaseDist;
-        yDist: BaseDist;
+        xDist: SampleSetDist;
+        yDist: SampleSetDist;
         xScale: Scale;
         yScale: Scale;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,9 @@ importers:
       open:
         specifier: ^10.0.2
         version: 10.0.2
+      seedrandom:
+        specifier: ^3.0.5
+        version: 3.0.5
     devDependencies:
       '@babel/preset-typescript':
         specifier: ^7.23.3
@@ -613,6 +616,9 @@ importers:
       '@types/node':
         specifier: ^20.10.6
         version: 20.10.6
+      '@types/seedrandom':
+        specifier: ^3.0.8
+        version: 3.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.16.0
         version: 6.16.0(@typescript-eslint/parser@6.16.0)(eslint@8.56.0)(typescript@5.3.3)
@@ -7792,6 +7798,10 @@ packages:
 
   /@types/scheduler@0.16.5:
     resolution: {integrity: sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==}
+
+  /@types/seedrandom@3.0.8:
+    resolution: {integrity: sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==}
+    dev: true
 
   /@types/semver@7.5.3:
     resolution: {integrity: sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==}
@@ -17925,6 +17935,10 @@ packages:
     dependencies:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
+    dev: false
+
+  /seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
     dev: false
 
   /semver@2.3.2:


### PR DESCRIPTION
Fixes #248.

Seed is optional in `environment`, and not exposed to the UI yet. Tests are still random too.

`seedrandom.alea` is faster than `Math.random()` in Node v20 (I'm not sure about Firefox):
- Old code: **0.66s** to create 2 to 3 dist with 10M samples.
- New code: **0.58s**.