### PR TITLE
Cache versioned package promises to avoid re-suspenses

### DIFF
--- a/packages/versioned-components/src/versionedSquigglePackages.tsx
+++ b/packages/versioned-components/src/versionedSquigglePackages.tsx
@@ -18,6 +18,8 @@ export type SquigglePackages<
     }
   : never;
 
+// Caching promises is useful when `versionedSquiggleComponents` is used with `use()`.
+// Without a cache, `use()` would re-suspend even if the packages are already imported.
 const promiseCache: {
   [k in SquiggleVersion]?: Promise<SquigglePackages<k>>;
 } = {};
@@ -30,7 +32,10 @@ export function versionedSquigglePackages<Version extends SquiggleVersion>(
       Promise.all([
         squiggleLangByVersion(version),
         squiggleComponentsByVersion(version),
-      ]).then(([lang, components]) => resolve({ lang, components, version }));
+      ]).then(([lang, components]) =>
+        resolve({ lang, components, version } as SquigglePackages<Version>)
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     }) as Promise<SquigglePackages<any>>;
   }
   return promiseCache[version]!;


### PR DESCRIPTION
Fixes #3014.

What happened:
- latest versioned components lazily load packages through `use(versionedSquigglePackages)`, which calls `await import(...)`
- `await import(...)` looks instant when the dependency is already imported, but still works as a promise under the hood
- so it caused React to re-suspend at the closest `<Suspense>` boundary, i.e. the `loading.tsx`

So next-auth caused this because it causes re-renders on tab changes, but next-auth is not the problem here. Same problem also happened when you switched Squiggle versions (even if the version was loaded, `use(...)` still suspended)

One remaining issue here is related to SSR: on the initial load, the current sequence is:
1) SSR HTML, which shows some parts of the playground (but not CodeMIrror), because `await import` resolves on SSR immediately
2) then it suspends on the browser side `use(versionedSquigglePackages)` loads Squiggle lazily
3) then the full playground is rendered again