### PR TITLE
Add users to groups directly

### DIFF
--- a/packages/hub/schema.graphql
+++ b/packages/hub/schema.graphql
@@ -2,6 +2,10 @@ type AcceptReusableGroupInviteTokenResult {
   membership: UserGroupMembership!
 }
 
+type AddUserToGroupResult {
+  membership: UserGroupMembership!
+}
+
 type AdminRebuildSearchIndexResult {
   ok: Boolean!
 }
@@ -226,6 +230,7 @@ type MoveModelResult {
 
 type Mutation {
   acceptReusableGroupInviteToken(input: MutationAcceptReusableGroupInviteTokenInput!): MutationAcceptReusableGroupInviteTokenResult!
+  addUserToGroup(input: MutationAddUserToGroupInput!): MutationAddUserToGroupResult!
 
   """Admin-only query for rebuilding the search index"""
   adminRebuildSearchIndex: MutationAdminRebuildSearchIndexResult!
@@ -270,6 +275,14 @@ input MutationAcceptReusableGroupInviteTokenInput {
 }
 
 union MutationAcceptReusableGroupInviteTokenResult = AcceptReusableGroupInviteTokenResult | BaseError
+
+input MutationAddUserToGroupInput {
+  group: String!
+  role: MembershipRole!
+  username: String!
+}
+
+union MutationAddUserToGroupResult = AddUserToGroupResult | BaseError | ValidationError
 
 union MutationAdminRebuildSearchIndexResult = AdminRebuildSearchIndexResult | BaseError
 

--- a/packages/hub/src/app/groups/[slug]/members/AddUserToGroupAction.tsx
+++ b/packages/hub/src/app/groups/[slug]/members/AddUserToGroupAction.tsx
@@ -7,27 +7,27 @@ import { PlusIcon, SelectStringFormField } from "@quri/ui";
 import { SelectUser, SelectUserOption } from "@/components/SelectUser";
 import { MutationModalAction } from "@/components/ui/MutationModalAction";
 
-import { InviteUserToGroupAction_group$key } from "@/__generated__/InviteUserToGroupAction_group.graphql";
-import { InviteUserToGroupActionMutation } from "@/__generated__/InviteUserToGroupActionMutation.graphql";
+import { AddUserToGroupAction_group$key } from "@/__generated__/AddUserToGroupAction_group.graphql";
+import { AddUserToGroupActionMutation } from "@/__generated__/AddUserToGroupActionMutation.graphql";
 import { MembershipRole } from "@/__generated__/SetMembershipRoleActionMutation.graphql";
 
 const Mutation = graphql`
-  mutation InviteUserToGroupActionMutation(
-    $input: MutationInviteUserToGroupInput!
+  mutation AddUserToGroupActionMutation(
+    $input: MutationAddUserToGroupInput!
     $connections: [ID!]!
   ) {
-    result: inviteUserToGroup(input: $input) {
+    result: addUserToGroup(input: $input) {
       __typename
       ... on BaseError {
         message
       }
-      ... on InviteUserToGroupResult {
-        invite
-          @prependNode(
+      ... on AddUserToGroupResult {
+        membership
+          @appendNode(
             connections: $connections
-            edgeTypeName: "GroupInviteEdge"
+            edgeTypeName: "UserGroupMembershipEdge"
           ) {
-          ...GroupInviteCard
+          ...GroupMemberCard
         }
       }
     }
@@ -35,16 +35,16 @@ const Mutation = graphql`
 `;
 
 type Props = {
-  groupRef: InviteUserToGroupAction_group$key;
+  groupRef: AddUserToGroupAction_group$key;
   close: () => void;
 };
 
 type FormShape = { user: SelectUserOption; role: MembershipRole };
 
-export const InviteUserToGroupAction: FC<Props> = ({ groupRef, close }) => {
+export const AddUserToGroupAction: FC<Props> = ({ groupRef, close }) => {
   const group = useFragment(
     graphql`
-      fragment InviteUserToGroupAction_group on Group {
+      fragment AddUserToGroupAction_group on Group {
         id
         slug
       }
@@ -53,12 +53,12 @@ export const InviteUserToGroupAction: FC<Props> = ({ groupRef, close }) => {
   );
 
   return (
-    <MutationModalAction<InviteUserToGroupActionMutation, FormShape>
-      title="Invite"
+    <MutationModalAction<AddUserToGroupActionMutation, FormShape>
+      title="Add"
       icon={PlusIcon}
       close={close}
       mutation={Mutation}
-      expectedTypename="InviteUserToGroupResult"
+      expectedTypename="AddUserToGroupResult"
       defaultValues={{ role: "Member" }}
       formDataToVariables={(data) => ({
         input: {
@@ -69,12 +69,12 @@ export const InviteUserToGroupAction: FC<Props> = ({ groupRef, close }) => {
         connections: [
           ConnectionHandler.getConnectionID(
             group.id,
-            "GroupInviteList_invites"
+            "GroupMemberList_memberships"
           ),
         ],
       })}
-      submitText="Invite"
-      modalTitle={`Invite to group ${group.slug}`}
+      submitText="Add"
+      modalTitle={`Add to group ${group.slug}`}
     >
       {() => (
         <div className="space-y-2">

--- a/packages/hub/src/app/groups/[slug]/members/GroupMemberList.tsx
+++ b/packages/hub/src/app/groups/[slug]/members/GroupMemberList.tsx
@@ -9,8 +9,8 @@ import { DotsDropdown } from "@/components/ui/DotsDropdown";
 import { H2 } from "@/components/ui/Headers";
 
 import { useIsGroupAdmin } from "../hooks";
+import { AddUserToGroupAction } from "./AddUserToGroupAction";
 import { GroupMemberCard } from "./GroupMemberCard";
-import { InviteUserToGroupAction } from "./InviteUserToGroupAction";
 
 import { GroupMemberList$key } from "@/__generated__/GroupMemberList.graphql";
 import { GroupMemberListPaginationQuery } from "@/__generated__/GroupMemberListPaginationQuery.graphql";
@@ -23,7 +23,7 @@ const fragment = graphql`
   )
   @refetchable(queryName: "GroupMemberListPaginationQuery") {
     ...hooks_useIsGroupAdmin
-    ...InviteUserToGroupAction_group
+    ...AddUserToGroupAction_group
     ...GroupMemberCard_group
 
     memberships(first: $count, after: $cursor)
@@ -61,7 +61,7 @@ export const GroupMemberList: FC<Props> = ({ groupRef }) => {
           <DotsDropdown>
             {({ close }) => (
               <DropdownMenu>
-                <InviteUserToGroupAction groupRef={group} close={close} />
+                <AddUserToGroupAction groupRef={group} close={close} />
               </DropdownMenu>
             )}
           </DotsDropdown>

--- a/packages/hub/src/graphql/schema.ts
+++ b/packages/hub/src/graphql/schema.ts
@@ -28,6 +28,7 @@ import "./mutations/deleteMembership";
 import "./mutations/deleteModel";
 import "./mutations/deleteRelativeValuesDefinition";
 import "./mutations/deleteReusableGroupInviteToken";
+import "./mutations/addUserToGroup";
 import "./mutations/inviteUserToGroup";
 import "./mutations/moveModel";
 import "./mutations/reactToGroupInvite";


### PR DESCRIPTION
New "+ Add" button in the members list, powered by `addUserToGroup` mutation (mostly copy-pasted from `inviteUserToGroup`).

I still kept the code for `inviteUserToGroup`, but removed "+ Invite" button from the UI, only "+ Add" remains.

(It's easy to have both but it could be confusing.)