### PR TITLE
Stop KDE from producing negative numbers

### DIFF
--- a/.changeset/wet-hotels-joke.md
+++ b/.changeset/wet-hotels-joke.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+KDE should force distributions to have pdfs above zero

--- a/packages/squiggle-lang/__tests__/library/dist_test.ts
+++ b/packages/squiggle-lang/__tests__/library/dist_test.ts
@@ -21,4 +21,8 @@ describe("Dist", () => {
     "diff([Dist.make(1),Dist.make(5),Dist.make(3)])",
     "[PointMass(4),PointMass(-2)]"
   );
+  testEvalToBe(
+    "Dist.logScore({estimate: mx(Sym.normal(5,2), Sym.uniform(-1000, 1000), [.5, .5]), answer: Sym.normal(5.2,2.2)})",
+    "0.5787500741731704"
+  );
 });

--- a/packages/squiggle-lang/src/dist/SampleSetDist/kde.ts
+++ b/packages/squiggle-lang/src/dist/SampleSetDist/kde.ts
@@ -96,7 +96,8 @@ export const kde = ({
     const ddy = ysum[i] - 2 * ysum[i + width] + ysum[i + 2 * width];
     dy += ddy;
     y += dy;
-    return normalizer * y;
+    // Sometimes the KDE can be very slightly negative due to floating point errors
+    return Math.max(normalizer * y, 0);
   });
 
   return { usedWidth: xWidth, xs, ys };


### PR DESCRIPTION
This closes https://github.com/quantified-uncertainty/squiggle/issues/2591