### PR TITLE
Node v20

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,6 +2,9 @@
   "name": "@quri/squiggle-components",
   "version": "0.9.4-0",
   "license": "MIT",
+  "engines": {
+    "node": "20.x"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/quantified-uncertainty/squiggle.git",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -2,6 +2,9 @@
   "name": "@quri/hub",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "db:migrate:dev": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma migrate dev",
     "db:migrate": "PRISMA_HIDE_UPDATE_MESSAGE=1 prisma migrate deploy",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,9 @@
   "name": "@quri/ui",
   "version": "0.2.1",
   "license": "MIT",
+  "engines": {
+    "node": "20.x"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/quantified-uncertainty/squiggle.git",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "private": true,
   "license": "MIT",
+  "engines": {
+    "node": "20.x"
+  },
   "scripts": {
     "dev": "next dev",
     "lint": "prettier --check . && next lint",


### PR DESCRIPTION
Context: in #3086, we had weird problems with pnpm not working correctly in CI, while it was fine on my machine.

I'm not sure if Node v18 in CI is to blame (I'm on v20 locally), but v20 has been out for quite some time now, so it makes sense to enable it for CI, which I did in 9cab5903e648ccae29fea342dbc3aff1104d2d7b.

Vercel still defaults to v18, unless [engines.node](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) is set. So we should upgrade it too.

Technically v20 support on Vercel is still [in beta](https://vercel.com/changelog/nodejs-20), but I don't expect that we'll hit any issues in practice.