### PR TITLE
D3 Negative Dists

### DIFF
--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -46,6 +46,45 @@ const _tickCountInterpolator = d3
   .range([3, 16]) // The range of circle radiuses
   .clamp(true);
 
+export function calculatePadding({
+  suggestedPadding,
+  hasXAxisTitle,
+  hasYAxisTitle,
+}: {
+  suggestedPadding: Padding;
+  hasXAxisTitle: boolean;
+  hasYAxisTitle: boolean;
+}): Padding {
+  const padding: Padding = { ...suggestedPadding };
+  if (hasXAxisTitle) {
+    padding.bottom = padding.bottom + 20;
+  }
+  if (hasYAxisTitle) {
+    padding.left = padding.left + 35;
+  }
+  return padding;
+}
+
+export function makeCartesianFrame({
+  context,
+  padding,
+  width,
+  height,
+}: {
+  context: CanvasRenderingContext2D;
+  padding: Padding;
+  width: number;
+  height: number;
+}) {
+  return new CartesianFrame({
+    context,
+    x0: padding.left,
+    y0: height - padding.bottom,
+    width: width - padding.left - padding.right,
+    height: height - padding.top - padding.bottom,
+  });
+}
+
 export function drawAxes({
   context,
   xScale, // will be mutated with the correct range
@@ -75,13 +114,11 @@ export function drawAxes({
 
   const tickSize = 2;
 
-  const padding: Padding = { ...suggestedPadding };
-  if (xAxisTitle) {
-    padding.bottom = padding.bottom + 30;
-  }
-  if (yAxisTitle) {
-    padding.left = padding.left + 35;
-  }
+  const padding: Padding = calculatePadding({
+    suggestedPadding,
+    hasXAxisTitle: !!xAxisTitle,
+    hasYAxisTitle: !!yAxisTitle,
+  });
 
   // measure tick sizes for dynamic padding
   if (showYAxis) {
@@ -97,14 +134,8 @@ export function drawAxes({
   }
 
   const frame =
-    _frame ||
-    new CartesianFrame({
-      context,
-      x0: padding.left,
-      y0: height - padding.bottom,
-      width: width - padding.left - padding.right,
-      height: height - padding.top - padding.bottom,
-    });
+    _frame || makeCartesianFrame({ context, padding, width, height });
+
   xScale.range([0, frame.width]);
   yScale.range([0, frame.height]);
 

--- a/packages/components/src/lib/draw/index.ts
+++ b/packages/components/src/lib/draw/index.ts
@@ -37,6 +37,7 @@ interface DrawAxesParams {
   yTickFormat?: string;
   xAxisTitle?: string;
   yAxisTitle?: string;
+  frame?: CartesianFrame;
 }
 
 const _tickCountInterpolator = d3
@@ -61,6 +62,7 @@ export function drawAxes({
   yTickFormat: yTickFormatSpecifier = defaultTickFormatSpecifier,
   xAxisTitle,
   yAxisTitle,
+  frame: _frame,
 }: DrawAxesParams) {
   const _xTickCount = xTickCount || _tickCountInterpolator(width * height);
   const _yTickCount = yTickCount || _tickCountInterpolator(height * width);
@@ -75,7 +77,7 @@ export function drawAxes({
 
   const padding: Padding = { ...suggestedPadding };
   if (xAxisTitle) {
-    padding.bottom = padding.bottom + 20;
+    padding.bottom = padding.bottom + 30;
   }
   if (yAxisTitle) {
     padding.left = padding.left + 35;
@@ -94,13 +96,15 @@ export function drawAxes({
     });
   }
 
-  const frame = new CartesianFrame({
-    context,
-    x0: padding.left,
-    y0: height - padding.bottom,
-    width: width - padding.left - padding.right,
-    height: height - padding.top - padding.bottom,
-  });
+  const frame =
+    _frame ||
+    new CartesianFrame({
+      context,
+      x0: padding.left,
+      y0: height - padding.bottom,
+      width: width - padding.left - padding.right,
+      height: height - padding.top - padding.bottom,
+    });
   xScale.range([0, frame.width]);
   yScale.range([0, frame.height]);
 
@@ -111,8 +115,8 @@ export function drawAxes({
       context.beginPath();
       context.strokeStyle = axisColor;
       context.lineWidth = 1;
-      context.moveTo(0, 0);
-      context.lineTo(frame.width, 0);
+      context.moveTo(0, yScale(0));
+      context.lineTo(frame.width, yScale(0));
       context.stroke();
     }
 
@@ -123,7 +127,7 @@ export function drawAxes({
     for (let i = 0; i < xTicks.length; i++) {
       const xTick = xTicks[i];
       const x = xScale(xTick);
-      const y = 0;
+      const y = yScale(0);
 
       context.beginPath();
       context.strokeStyle = labelColor;

--- a/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
+++ b/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
@@ -18,14 +18,15 @@ import { useViewerType } from "../../components/SquiggleViewer/ViewerProvider.js
 import { ErrorAlert } from "../../components/ui/Alert.js";
 import { sqScaleToD3 } from "../../lib/d3/index.js";
 import { hasMassBelowZero } from "../../lib/distributionUtils.js";
-import { CartesianFrame } from "../../lib/draw/CartesianFrame.js";
 import {
+  calculatePadding,
   distance,
   distributionColor,
   drawAxes,
   drawCircle,
   drawCursorLines,
   drawVerticalLine,
+  makeCartesianFrame,
 } from "../../lib/draw/index.js";
 import { Point } from "../../lib/draw/types.js";
 import { useCanvas, useCanvasCursor } from "../../lib/hooks/index.js";
@@ -192,29 +193,17 @@ const InnerDistributionsChart: FC<{
         top: discreteRadius,
         bottom: bottomPadding,
       };
-      const padding = suggestedPadding;
-      const frame = new CartesianFrame({
-        context,
-        x0: padding.left,
-        y0: height - padding.bottom,
-        width: width - padding.left - padding.right,
-        height: height - padding.top - padding.bottom,
-      });
 
-      drawAxes({
-        context,
-        width,
-        height,
+      const padding = calculatePadding({
         suggestedPadding,
-        xScale,
-        yScale,
-        showYAxis: false,
-        showXAxis,
-        xTickFormat: plot.xScale.tickFormat,
-        xAxisTitle: showAxisTitles ? plot.xScale.title : undefined,
-        showAxisLines: true, // Set this to true to show the axis lines
+        hasXAxisTitle: showAxisTitles && !!plot.xScale.title,
+        hasYAxisTitle: false,
       });
 
+      const frame = makeCartesianFrame({ context, padding, width, height });
+
+      xScale.range([0, frame.width]);
+      yScale.range([0, frame.height]);
       // samplesBar
       function samplesBarShowSettings(): { yOffset: number; color: string } {
         if (samplesBarSetting === "behind") {
@@ -612,7 +601,9 @@ export const DistributionsChart: FC<DistributionsChartProps> = ({
                 height={height}
                 samplesBarSetting={samplesState}
                 showCursorLine={nonTitleHeight > 30}
-                showPercentileLines={nonTitleHeight > 30}
+                showPercentileLines={
+                  !anyAreNonnormalized && nonTitleHeight > 30
+                }
                 showXAxis={showXAxis}
                 showAxisTitles={showAxisTitles}
               />

--- a/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
+++ b/packages/components/src/widgets/DistWidget/DistributionsChart.tsx
@@ -162,7 +162,6 @@ const InnerDistributionsChart: FC<{
     ]);
 
     const yScale = sqScaleToD3(plot.yScale);
-    // yScale.domain([0, Math.max(...domain.map((p) => p.y))]);
 
     yScale.domain([
       Math.min(0, ...domain.map((p) => p.y)),
@@ -215,7 +214,6 @@ const InnerDistributionsChart: FC<{
           return { yOffset: 0, color: getColor(0) };
         }
       }
-
       if (samplesBarSetting !== "none") {
         context.save();
         const { yOffset, color } = samplesBarShowSettings();
@@ -232,8 +230,6 @@ const InnerDistributionsChart: FC<{
         context.restore();
       }
 
-      context.globalCompositeOperation = "source-over";
-
       // shapes
       {
         frame.enter();
@@ -249,8 +245,8 @@ const InnerDistributionsChart: FC<{
 
           // continuous fill
           //In the case of one distribution, we don't want it to be transparent, so that we can show the samples lines. In the case of multiple distributions, we want them to be transparent so that we can see the other distributions.
-          context.fillStyle = isMulti ? getColor(i, 0.5) : getColor(i, 0.7);
-          context.globalAlpha = isMulti ? 0.4 : 0.9;
+          context.fillStyle = isMulti ? getColor(i, 0) : getColor(i, 0.7);
+          context.globalAlpha = isMulti ? 0.4 : 1;
           context.beginPath();
           d3
             .area<SqShape["continuous"][number]>()
@@ -405,7 +401,6 @@ const InnerDistributionsChart: FC<{
         });
       }
     },
-
     [
       height,
       discreteRadius,
@@ -601,6 +596,7 @@ export const DistributionsChart: FC<DistributionsChartProps> = ({
                 height={height}
                 samplesBarSetting={samplesState}
                 showCursorLine={nonTitleHeight > 30}
+                // We don't want to show percentile lines if it's not normalized, as they wouldn't make sense.
                 showPercentileLines={
                   !anyAreNonnormalized && nonTitleHeight > 30
                 }


### PR DESCRIPTION
Before:
<img width="1055" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/1acf4761-beb9-42a3-b387-08d1ba28bad2">

After:
<img width="1024" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/f7f44723-5799-4a02-a7ad-073c8a3827be">

Now it shows the full negative values.

Closes https://github.com/quantified-uncertainty/squiggle/issues/3122