### PR TITLE
Fix Vercel preview branches

### DIFF
--- a/packages/hub/src/constants.ts
+++ b/packages/hub/src/constants.ts
@@ -2,7 +2,7 @@
 
 // Note that only `NEXT_PUBLIC_*` vars are affected; others can be used through `process.env.FOO` without issues.
 
-export const VERCEL_URL = process.env["NEXT_PUBLIC_VERCEL_URL"];
+export const VERCEL_URL = process.env["NEXT_PUBLIC_VERCEL_BRANCH_URL"];
 
 export const SAMPLE_COUNT_DEFAULT = 1000;
 export const XY_POINT_LENGTH_DEFAULT = 1000;


### PR DESCRIPTION
I've recently enabled [Standard Protection](https://vercel.com/docs/security/deployment-protection#migrating-to-standard-protection) for Squiggle Hub, which is now default on Vercel.

But our Relay configuration fetched `https://${VERCEL_URL}/api/graphql` during SSR, and `VERCEL_URL` is not available anymore.