### PR TITLE
Disallow lookup function overrides & other minor cleanups

### DIFF
--- a/packages/squiggle-lang/__tests__/compile/call_test.ts
+++ b/packages/squiggle-lang/__tests__/compile/call_test.ts
@@ -21,7 +21,7 @@ describe("Compiling calls", () => {
   });
 
   describe("Index lookups", () => {
-    testCompileEnd("([0,1,2])[1]", "(Call $_atIndex_$ (Array 0 1 2) 1)");
+    testCompileEnd("([0,1,2])[1]", "(Call #indexLookup (Array 0 1 2) 1)");
   });
 
   describe("Pipes", () => {

--- a/packages/squiggle-lang/__tests__/compile/dict_test.ts
+++ b/packages/squiggle-lang/__tests__/compile/dict_test.ts
@@ -13,6 +13,6 @@ describe("Compile dicts", () => {
 
   testCompile("dict={property: 1}; dict.property", [
     '(Assign dict (Dict (kv "property" 1)))',
-    '(Call $_atIndex_$ (StackRef 0) "property")',
+    '(Call #indexLookup (StackRef 0) "property")',
   ]);
 });

--- a/packages/squiggle-lang/__tests__/compile/unary_test.ts
+++ b/packages/squiggle-lang/__tests__/compile/unary_test.ts
@@ -3,6 +3,6 @@ import { testCompile } from "../helpers/compileHelpers.js";
 describe("Compiling unary operators", () => {
   testCompile("a = [3,4]; -a[0]", [
     "(Assign a (Array 3 4))",
-    "(Call unaryMinus (Call $_atIndex_$ (StackRef 0) 0))",
+    "(Call unaryMinus (Call #indexLookup (StackRef 0) 0))",
   ]);
 });

--- a/packages/squiggle-lang/src/expression/constants.ts
+++ b/packages/squiggle-lang/src/expression/constants.ts
@@ -1,1 +1,1 @@
-export const INDEX_LOOKUP_FUNCTION = "$_atIndex_$";
+export const INDEX_LOOKUP_FUNCTION = "#indexLookup";

--- a/packages/squiggle-lang/src/library/index.ts
+++ b/packages/squiggle-lang/src/library/index.ts
@@ -3,6 +3,7 @@ import { INDEX_LOOKUP_FUNCTION } from "../expression/constants.js";
 import { BuiltinLambda, Lambda } from "../reducer/lambda.js";
 import { Bindings } from "../reducer/Stack.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
+import { Value } from "../value/index.js";
 import { vLambda } from "../value/vLambda.js";
 import { makeMathConstants } from "./math.js";
 import { makeDefinition } from "./registry/fnDefinition.js";
@@ -10,35 +11,32 @@ import { frAny } from "./registry/frTypes.js";
 import { makeSquiggleBindings, registry } from "./registry/index.js";
 import { makeVersionConstant } from "./version.js";
 
-const definitions = [
-  makeDefinition([frAny(), frAny()], frAny(), ([obj, key]) => {
-    if ("get" in obj) {
-      return obj.get(key);
-    } else {
-      throw new REOther("Trying to access key on wrong value");
-    }
-  }),
-];
-
 function makeLookupLambda(): Lambda {
-  return new BuiltinLambda(INDEX_LOOKUP_FUNCTION, definitions);
+  return new BuiltinLambda(INDEX_LOOKUP_FUNCTION, [
+    makeDefinition([frAny(), frAny()], frAny(), ([obj, key]) => {
+      if ("get" in obj) {
+        return obj.get(key);
+      } else {
+        throw new REOther("Trying to access key on wrong value");
+      }
+    }),
+  ]);
 }
 
 function makeStdLib(): Bindings {
-  let res: Bindings = ImmutableMap();
+  let res: Bindings = ImmutableMap<string, Value>().merge(
+    // global constants
+    makeMathConstants(),
+    makeVersionConstant(),
+    // field lookups
+    [[INDEX_LOOKUP_FUNCTION, vLambda(makeLookupLambda())]],
+    // most builtin functions
+    registry
+      .allNames()
+      .map((name) => [name, vLambda(registry.makeLambda(name))] as const)
+  );
 
-  // constants
-  res = res.merge(makeMathConstants());
-  res = res.merge(makeVersionConstant());
-
-  // field lookups
-  res = res.set(INDEX_LOOKUP_FUNCTION, vLambda(makeLookupLambda()));
-
-  // bind the entire FunctionRegistry
-  for (const name of registry.allNames()) {
-    res = res.set(name, vLambda(registry.makeLambda(name)));
-  }
-
+  // builtin functions defined in Squiggle - this is done last because these functions can depend on other builtins
   res = res.merge(makeSquiggleBindings(res));
 
   return res;

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -11,7 +11,7 @@ import {
 
 type Shorthand = { type: "infix" | "unary"; symbol: string };
 
-type example = {
+type Example = {
   text: string;
   isInteractive: boolean;
   useForTests: boolean;
@@ -20,7 +20,7 @@ type example = {
 export function makeFnExample(
   text: string,
   params: { isInteractive?: boolean; useForTests?: boolean } = {}
-): example {
+): Example {
   const { isInteractive = false, useForTests = true } = params;
   return { text, isInteractive, useForTests };
 }
@@ -30,7 +30,7 @@ export type FRFunction = {
   nameSpace: string;
   requiresNamespace: boolean;
   definitions: FnDefinition[];
-  examples?: example[];
+  examples?: Example[];
   description?: string;
   isExperimental?: boolean;
   isUnit?: boolean;
@@ -45,20 +45,7 @@ function organizedExamples(f: FRFunction) {
 
 type FnNameDict = Map<string, FnDefinition[]>;
 
-export type FnDocumentation = Pick<
-  FRFunction,
-  | "description"
-  | "requiresNamespace"
-  | "nameSpace"
-  | "definitions"
-  | "name"
-  | "examples"
-  | "isExperimental"
-  | "isUnit"
-  | "shorthand"
-  | "displaySection"
-  | "versionAdded"
-> & { signatures: string[] };
+export type FnDocumentation = FRFunction & { signatures: string[] };
 
 export class Registry {
   private constructor(
@@ -94,7 +81,7 @@ export class Registry {
     return new Registry(fns, dict);
   }
 
-  allExamplesWithFns(): { fn: FRFunction; example: example }[] {
+  allExamplesWithFns(): { fn: FRFunction; example: Example }[] {
     return this.functions
       .map((fn) => {
         return organizedExamples(fn).map((example) => ({ fn, example }));


### PR DESCRIPTION
I was looking into #3061. Didn't do it for most operators, only for `[]` and `.foo` lookups (`$` is allowed symbol in var identifiers).

Also cleaned up some types and library code.

I'll merge after tests, this doesn't really need a review.