### PR TITLE
Fix arrow parsing; avoid extra block nodes in AST

### DIFF
--- a/.changeset/khaki-lamps-repair.md
+++ b/.changeset/khaki-lamps-repair.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Fix parsing of `x = {|...|...} -> ...` statements; avoid extra block nodes in AST

--- a/packages/squiggle-lang/__tests__/SqValue/context_test.ts
+++ b/packages/squiggle-lang/__tests__/SqValue/context_test.ts
@@ -12,7 +12,7 @@ y = 6
     const x = bindings.get("x");
     assertTag(x, "Dict");
     expect(nodeToString(x.context!.valueAst, { pretty: false })).toBe(
-      "(LetStatement :x (Block (Dict (KeyValue 'foo' 5))))"
+      "(LetStatement :x (Dict (KeyValue 'foo' 5)))"
     );
     expect(x.context?.valueAstIsPrecise).toBe(true);
 
@@ -26,7 +26,7 @@ y = 6
     assertTag(y, "Number");
 
     expect(nodeToString(y.context!.valueAst, { pretty: false })).toBe(
-      "(LetStatement :y (Block 6))"
+      "(LetStatement :y 6)"
     );
     expect(y!.context!.valueAstIsPrecise).toBe(true);
   });
@@ -41,7 +41,7 @@ z = 5
     assertTag(z, "Number");
 
     expect(nodeToString(z.context!.valueAst, { pretty: false })).toBe(
-      "(LetStatement :z (Block 5))"
+      "(LetStatement :z 5)"
     );
   });
 });

--- a/packages/squiggle-lang/src/ast/peggyParser.peggy
+++ b/packages/squiggle-lang/src/ast/peggyParser.peggy
@@ -8,8 +8,6 @@ start
   = _nl start:outerBlock _nl finalComment?
     { return start; }
 
-zeroOMoreArgumentsBlockOrExpression = lambda / innerBlockOrExpression
-
 outerBlock
   = imports:importStatementsList
     statements:statementsList
@@ -35,7 +33,6 @@ importStatement
 innerBlockOrExpression
   = quotedInnerBlock
   / finalExpression:expression
-    { return h.nodeBlock([finalExpression], location()); }
 
 quotedInnerBlock
   = '{' _nl
@@ -75,7 +72,7 @@ statement
   / defunStatement
 
 letStatement
-  = exported:("export" __nl)? variable:dollarIdentifier _ assignmentOp _nl value:zeroOMoreArgumentsBlockOrExpression
+  = exported:("export" __nl)? variable:dollarIdentifier _ assignmentOp _nl value:innerBlockOrExpression
     { return h.nodeLetStatement(variable, value, Boolean(exported), location()); }
 
 defunStatement


### PR DESCRIPTION
This fixes #3110, and also fixes #2670, and also simplifies grammar and AST (see tests in diff for examples).

Previously:
```
$ node dist/cli/index.js parse -e 'x=5'
(Program
  (LetStatement
    :x
    (Block 5)
  )
)
```

Now:
```
$ node dist/cli/index.js parse -e 'x=5'
(Program
  (LetStatement :x 5)
)
```

The arrow bug in particular was caused by parsing let statements as lambdas first, before falling back on arbitrary expressions. I don't know why it was there; there might be some obscure case where this is a technically breaking change, but all tests are parsed and I hope it's fine.

Note that this doesn't give us any significant performance improvements; I [already unwrap single-expression blocks](https://github.com/quantified-uncertainty/squiggle/blob/68e2c9189c8cf907f4dd531934c1c8b8a4cb8dd3/packages/squiggle-lang/src/expression/compile.ts#L189) during compilation.

(Which is good because otherwise I'd be worried about this change; I remember that some time ago skipping these block nodes wasn't safe).