### PR TITLE
Zoomed-in variable focus is set manually when changed via keyboard shortcut

### DIFF
--- a/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
+++ b/packages/components/src/components/SquiggleViewer/ValueWithContextViewer.tsx
@@ -285,25 +285,15 @@ export const ValueWithContextViewer: FC<Props> = ({
     }
   };
 
-  // Store the header reference for the future `focusOnHeader()` handle, and auto-focus zoomed in values on mount.
-  const setHeaderRef = useCallback(
-    (el: HTMLElement | null) => {
-      headerRef.current = el;
-
-      // If `isZoomedIn` toggles from `false` to `true`, this callback identity will change and it will update the focus.
-      if (isZoomedIn) {
-        focusOnHeader();
-      }
-    },
-    [isZoomedIn, focusOnHeader]
-  );
-
   return (
     <ErrorBoundary>
       <div ref={containerRef}>
         {headerVisibility !== "hide" && (
           <header
-            ref={setHeaderRef}
+            ref={(el) => {
+              // Store the header reference for the future `focusOnHeader()` handle
+              headerRef.current = el;
+            }}
             tabIndex={viewerType === "tooltip" ? undefined : 0}
             className={clsx(
               "flex justify-between group pr-0.5 hover:bg-stone-100 rounded-sm focus-visible:outline-none",

--- a/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedInSqValue.ts
+++ b/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedInSqValue.ts
@@ -24,12 +24,14 @@ export function useZoomedInSqValueKeyEvent(selected: SqValuePath) {
       const newPath = findNode(selected)?.nextSibling()?.node.path;
       if (newPath) {
         setZoomedInPath(newPath);
+        itemStore.focusByPath(newPath);
       }
     },
     ArrowUp: () => {
       const newPath = findNode(selected)?.prevSibling()?.node.path;
       if (newPath) {
         setZoomedInPath(newPath);
+        itemStore.focusByPath(newPath);
       }
     },
     ArrowLeft: () => {

--- a/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
+++ b/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
@@ -41,6 +41,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
     },
     Enter: () => {
       setZoomedInPath(selected);
+      itemStore.focusByPath(selected);
     },
     " ": () => {
       toggleCollapsed(itemStore, selected);


### PR DESCRIPTION
Closes https://github.com/quantified-uncertainty/squiggle/issues/3142

Surprisingly simple, in the end. Might merge soon, because the bug is pretty bad.