### PR TITLE
Model page css changes

### DIFF
--- a/packages/hub/src/app/RootLayout.tsx
+++ b/packages/hub/src/app/RootLayout.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { clsx } from "clsx";
 import { Session } from "next-auth";
 import { useSession } from "next-auth/react";
 import { usePathname } from "next/navigation";
@@ -29,10 +28,9 @@ const InnerRootLayout: FC<PropsWithChildren> = ({ children }) => {
   const pathname = usePathname();
 
   const showFooter = !isModelRoute(pathname);
-  const backgroundColor = "bg-white";
 
   return (
-    <div className={clsx("min-h-screen flex flex-col", backgroundColor)}>
+    <div className={"min-h-screen flex flex-col bg-white"}>
       <PageMenu queryRef={queryData} />
       <div
         // This allows us to center children vertically if necessary, e.g. in `not-found.tsx`.

--- a/packages/hub/src/app/RootLayout.tsx
+++ b/packages/hub/src/app/RootLayout.tsx
@@ -7,7 +7,7 @@ import { FC, PropsWithChildren } from "react";
 import { useLazyLoadQuery } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import { isModelRoute, isModelSubroute } from "@/routes";
+import { isModelRoute } from "@/routes";
 
 import { PageFooter } from "../components/layout/RootLayout/PageFooter";
 import { PageMenu } from "../components/layout/RootLayout/PageMenu";
@@ -29,7 +29,7 @@ const InnerRootLayout: FC<PropsWithChildren> = ({ children }) => {
   const pathname = usePathname();
 
   const showFooter = !isModelRoute(pathname);
-  const backgroundColor = isModelSubroute(pathname) ? "bg-white" : "bg-gray-50";
+  const backgroundColor = "bg-white";
 
   return (
     <div className={clsx("min-h-screen flex flex-col", backgroundColor)}>

--- a/packages/hub/src/components/EntityCard.tsx
+++ b/packages/hub/src/components/EntityCard.tsx
@@ -1,16 +1,23 @@
-import { formatDistance } from "date-fns";
 import Link from "next/link";
 import { FC, PropsWithChildren } from "react";
 
-import { IconProps, LockIcon } from "@quri/ui";
+import { LockIcon } from "@quri/ui";
 
 import { EntityNode } from "./EntityInfo";
 import { Card } from "./ui/Card";
 
 export type { EntityNode };
 
+function formatDate(date: Date): string {
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  return date.toLocaleDateString("en-US", options);
+}
+
 type Props = PropsWithChildren<{
-  icon: FC<IconProps>;
   updatedAtTimestamp: number;
   href: string;
   showOwner: boolean;
@@ -20,7 +27,6 @@ type Props = PropsWithChildren<{
 }>;
 
 export const EntityCard: FC<Props> = ({
-  icon: Icon,
   updatedAtTimestamp,
   href,
   showOwner,
@@ -30,30 +36,36 @@ export const EntityCard: FC<Props> = ({
   children,
 }) => {
   return (
-    <Card>
-      <div className="flex">
-        <Icon size={20} className="mt-3 ml-1 mr-3 text-slate-300" />
-        <div className="w-full">
-          <Link className="group" href={href}>
-            <div className="flex items-center gap-1 mb-1">
-              <div className="font-semibold text-blue-500 group-hover:underline">
+    <div>
+      <Card>
+        <div className="flex w-full">
+          <div className="w-full">
+            <div className="mb-3">
+              <Link
+                className="text-gray-900 font-medium hover:underline"
+                href={href}
+              >
                 {showOwner ? ownerName + "/" : ""}
                 {slug}
+              </Link>
+            </div>
+            <div className="flex flex-row space-x-4 text-gray-500 text-xs">
+              {children && <div className="flex">{children}</div>}
+              {isPrivate && (
+                <div className="flex">
+                  {<LockIcon className="400" size={14} />}
+                </div>
+              )}
+              <div className="flex items-center">
+                <span className="mr-1">Updated</span>
+                <time dateTime={new Date(updatedAtTimestamp).toISOString()}>
+                  {formatDate(new Date(updatedAtTimestamp))}
+                </time>
               </div>
-              {isPrivate && <LockIcon className="text-slate-500" size={14} />}
             </div>
-            <div className="text-xs text-slate-500">
-              Updated{" "}
-              <time dateTime={new Date(updatedAtTimestamp).toISOString()}>
-                {formatDistance(new Date(updatedAtTimestamp), new Date(), {
-                  addSuffix: true,
-                })}
-              </time>
-            </div>
-          </Link>
-          {children && <div className="mt-2">{children}</div>}
+          </div>
         </div>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 };

--- a/packages/hub/src/components/EntityCard.tsx
+++ b/packages/hub/src/components/EntityCard.tsx
@@ -36,36 +36,28 @@ export const EntityCard: FC<Props> = ({
   children,
 }) => {
   return (
-    <div>
-      <Card>
-        <div className="flex w-full">
-          <div className="w-full">
-            <div className="mb-3">
-              <Link
-                className="text-gray-900 font-medium hover:underline"
-                href={href}
-              >
-                {showOwner ? ownerName + "/" : ""}
-                {slug}
-              </Link>
-            </div>
-            <div className="flex flex-row space-x-4 text-gray-500 text-xs">
-              {children && <div className="flex">{children}</div>}
-              {isPrivate && (
-                <div className="flex">
-                  {<LockIcon className="400" size={14} />}
-                </div>
-              )}
-              <div className="flex items-center">
-                <span className="mr-1">Updated</span>
-                <time dateTime={new Date(updatedAtTimestamp).toISOString()}>
-                  {formatDate(new Date(updatedAtTimestamp))}
-                </time>
-              </div>
-            </div>
+    <Card>
+      <div className="w-full">
+        <div className="mb-3">
+          <Link
+            className="text-gray-900 font-medium hover:underline"
+            href={href}
+          >
+            {showOwner ? ownerName + "/" : ""}
+            {slug}
+          </Link>
+        </div>
+        <div className="flex items-center space-x-4 text-gray-500 text-xs">
+          {children}
+          {isPrivate && <LockIcon className="400" size={14} />}
+          <div>
+            <span className="mr-1">Updated</span>
+            <time dateTime={new Date(updatedAtTimestamp).toISOString()}>
+              {formatDate(new Date(updatedAtTimestamp))}
+            </time>
           </div>
         </div>
-      </Card>
-    </div>
+      </div>
+    </Card>
   );
 };

--- a/packages/hub/src/components/ui/Card.tsx
+++ b/packages/hub/src/components/ui/Card.tsx
@@ -2,7 +2,7 @@ import { FC, PropsWithChildren } from "react";
 
 export const Card: FC<PropsWithChildren> = ({ children }) => {
   return (
-    <div className="px-5 py-3 rounded bg-white border border-gray-200">
+    <div className="px-5 py-3 rounded bg-white border border-gray-200 hover:bg-gray-50">
       {children}
     </div>
   );

--- a/packages/hub/src/components/ui/Card.tsx
+++ b/packages/hub/src/components/ui/Card.tsx
@@ -1,5 +1,9 @@
 import { FC, PropsWithChildren } from "react";
 
 export const Card: FC<PropsWithChildren> = ({ children }) => {
-  return <div className="shadow p-3 rounded bg-white">{children}</div>;
+  return (
+    <div className="px-5 py-3 rounded bg-white border border-gray-200">
+      {children}
+    </div>
+  );
 };

--- a/packages/hub/src/groups/components/GroupCard.tsx
+++ b/packages/hub/src/groups/components/GroupCard.tsx
@@ -2,8 +2,6 @@ import { FC } from "react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import { GroupIcon } from "@quri/ui";
-
 import { EntityCard } from "@/components/EntityCard";
 import { groupRoute } from "@/routes";
 
@@ -26,7 +24,6 @@ export const GroupCard: FC<Props> = ({ groupRef }) => {
 
   return (
     <EntityCard
-      icon={GroupIcon}
       updatedAtTimestamp={group.updatedAtTimestamp}
       href={groupRoute({
         slug: group.slug,

--- a/packages/hub/src/models/components/ModelCard.tsx
+++ b/packages/hub/src/models/components/ModelCard.tsx
@@ -2,8 +2,6 @@ import { FC } from "react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import { CodeBracketIcon } from "@quri/ui";
-
 import { EntityCard } from "@/components/EntityCard";
 import { ExportsDropdown, totalImportLength } from "@/lib/ExportsDropdown";
 import { modelRoute } from "@/routes";
@@ -70,7 +68,6 @@ export const ModelCard: FC<Props> = ({ modelRef, showOwner = true }) => {
 
   return (
     <EntityCard
-      icon={CodeBracketIcon}
       updatedAtTimestamp={model.updatedAtTimestamp}
       href={modelUrl}
       showOwner={showOwner}
@@ -78,23 +75,18 @@ export const ModelCard: FC<Props> = ({ modelRef, showOwner = true }) => {
       ownerName={model.owner.slug}
       slug={model.slug}
     >
-      {_totalImportLength > 0 && (
+      {_totalImportLength > 0 ? (
         <ExportsDropdown
           modelExports={modelExports}
           relativeValuesExports={relativeValuesExports}
           owner={model.owner.slug}
           slug={model.slug}
         >
-          <div className="flex">
-            <div className="cursor-pointer group items-center flex hover:bg-slate-200 text-slate-500 rounded-md px-1 py-1 text-xs">
-              <span className="mr-1.5 text-xs text-slate-700 bg-slate-200 group-hover:bg-slate-300 px-1 py-0.25 text-center rounded-full">
-                {_totalImportLength}
-              </span>
-              Exports
-            </div>
+          <div className="cursor-pointer items-center flex text-xs text-gray-500 hover:text-gray-900 hover:underline">
+            {`${_totalImportLength} exports`}
           </div>
         </ExportsDropdown>
-      )}
+      ) : null}
     </EntityCard>
   );
 };

--- a/packages/hub/src/models/components/ModelCard.tsx
+++ b/packages/hub/src/models/components/ModelCard.tsx
@@ -75,7 +75,7 @@ export const ModelCard: FC<Props> = ({ modelRef, showOwner = true }) => {
       ownerName={model.owner.slug}
       slug={model.slug}
     >
-      {_totalImportLength > 0 ? (
+      {_totalImportLength > 0 && (
         <ExportsDropdown
           modelExports={modelExports}
           relativeValuesExports={relativeValuesExports}
@@ -86,7 +86,7 @@ export const ModelCard: FC<Props> = ({ modelRef, showOwner = true }) => {
             {`${_totalImportLength} exports`}
           </div>
         </ExportsDropdown>
-      ) : null}
+      )}
     </EntityCard>
   );
 };

--- a/packages/hub/src/relative-values/components/RelativeValuesDefinitionCard.tsx
+++ b/packages/hub/src/relative-values/components/RelativeValuesDefinitionCard.tsx
@@ -2,8 +2,6 @@ import { FC } from "react";
 import { useFragment } from "react-relay";
 import { graphql } from "relay-runtime";
 
-import { ScaleIcon } from "@quri/ui";
-
 import { EntityCard } from "@/components/EntityCard";
 import { relativeValuesRoute } from "@/routes";
 
@@ -32,7 +30,6 @@ export const RelativeValuesDefinitionCard: FC<Props> = ({
 
   return (
     <EntityCard
-      icon={ScaleIcon}
       updatedAtTimestamp={definition.updatedAtTimestamp}
       href={relativeValuesRoute({
         owner: definition.owner.slug,


### PR DESCRIPTION
Simplify the "Cards" page, to match the template designs a bit. 

<img width="1228" alt="image" src="https://github.com/quantified-uncertainty/squiggle/assets/377065/e3313b68-0dfe-48ed-874e-aaca3aaa93b2">

Still more work to do, but this is a start.