### PR TITLE
Don't reconfigure project on empty runnerName

### DIFF
--- a/packages/components/src/lib/hooks/useSimulator.ts
+++ b/packages/components/src/lib/hooks/useSimulator.ts
@@ -267,6 +267,11 @@ export function useSimulator(args: SimulatorArgs): UseSimulatorResult {
   }, [project, args.environment, state.autorunMode]);
 
   useEffect(() => {
+    if (!args.runnerName) {
+      // Undefined runnerName shouldn't reset the project.
+      // (Consider the case where `setup.project` is set with a pre-configured runner)
+      return;
+    }
     project.setRunner(runnerByName(args.runnerName ?? defaultRunnerName));
     if (state.autorunMode) {
       runSimulation();


### PR DESCRIPTION
Simple fix that's necessary to enable webworker runners in our next release.

Will merge after CI.