### PR TITLE
More flexible "External viewer actions"

### DIFF
--- a/.changeset/selfish-seahorses-flow.md
+++ b/.changeset/selfish-seahorses-flow.md
@@ -1,0 +1,7 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Improve stacktrace locations for imports
+
+Support `externalViewerActions` prop in `SquiggleChart` for wiring the viewer with something else than an editor

--- a/packages/components/src/components/CodeEditor/index.tsx
+++ b/packages/components/src/components/CodeEditor/index.tsx
@@ -1,6 +1,11 @@
 import { forwardRef, ReactNode, useImperativeHandle } from "react";
 
-import { SqError, SqProject, SqValuePath } from "@quri/squiggle-lang";
+import {
+  SqError,
+  SqLocation,
+  SqProject,
+  SqValuePath,
+} from "@quri/squiggle-lang";
 
 import { Simulation } from "../../lib/hooks/useSimulator.js";
 import { formatSquiggle } from "./useFormatSquiggleExtension.js";
@@ -31,7 +36,7 @@ export type CodeEditorProps = {
 
 export type CodeEditorHandle = {
   format(): void;
-  scrollTo(position: number, focus: boolean): void;
+  scrollTo(location: SqLocation, focus: boolean): void;
   getSourceId(): string;
 };
 
@@ -39,10 +44,10 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
   function CodeEditor(props, ref) {
     const { view, ref: editorRef } = useSquiggleEditorView(props);
 
-    const scrollTo = (position: number, focus: boolean) => {
+    const scrollTo = (location: SqLocation, focus: boolean) => {
       if (!view) return;
       view.dispatch({
-        selection: { anchor: position },
+        selection: { anchor: location.start.offset, head: location.end.offset },
         scrollIntoView: true,
       });
       focus && view.focus();

--- a/packages/components/src/components/CodeEditor/index.tsx
+++ b/packages/components/src/components/CodeEditor/index.tsx
@@ -32,6 +32,7 @@ export type CodeEditorProps = {
 export type CodeEditorHandle = {
   format(): void;
   scrollTo(position: number, focus: boolean): void;
+  getSourceId(): string;
 };
 
 export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
@@ -50,6 +51,7 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     useImperativeHandle(ref, () => ({
       format: () => formatSquiggle(view),
       scrollTo,
+      getSourceId: () => props.sourceId,
     }));
 
     return (

--- a/packages/components/src/components/SquiggleChart.tsx
+++ b/packages/components/src/components/SquiggleChart.tsx
@@ -9,6 +9,7 @@ import {
   StandaloneExecutionProps,
 } from "../lib/utility.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
+import { ExternalViewerActions } from "./SquiggleViewer/ViewerProvider.js";
 import { ViewerWithMenuBar } from "./ViewerWithMenuBar/index.js";
 
 // TODO: Right now, rootPathOverride is only used for Export pages on Squiggle Hub. When this happens, we don't want to show the header menu. This combination is awkward, but this interface is annoying to change, given it being in Versioned Components. Consider changing later.
@@ -16,6 +17,7 @@ import { ViewerWithMenuBar } from "./ViewerWithMenuBar/index.js";
 export type SquiggleChartProps = {
   code: string;
   rootPathOverride?: SqValuePath; // Note: This should be static. We don't support rootPathOverride to change once set. Used for Export pages on Squiggle Hub.
+  externalViewerActions?: ExternalViewerActions;
 } & (StandaloneExecutionProps | ProjectExecutionProps) &
   // `environment` is passed through StandaloneExecutionProps; this way we guarantee that it's not compatible with `project` prop
   Omit<PartialPlaygroundSettings, "environment">;
@@ -27,6 +29,7 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
     continues,
     environment,
     rootPathOverride,
+    externalViewerActions,
     ...settings
   }) {
     // We go through runnerState to bump executionId on code changes;
@@ -51,6 +54,7 @@ export const SquiggleChart: FC<SquiggleChartProps> = memo(
         playgroundSettings={settings}
         showMenu={!rootPathOverride}
         randomizeSeed={undefined}
+        externalViewerActions={externalViewerActions}
         defaultTab={
           rootPathOverride
             ? {

--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -10,6 +10,7 @@ import {
 } from "../lib/utility.js";
 import { CodeEditor, CodeEditorHandle } from "./CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
+import { useExternalActionsForEditor } from "./SquiggleViewer/ViewerProvider.js";
 import { ViewerWithMenuBar } from "./ViewerWithMenuBar/index.js";
 
 export type SquiggleEditorProps = {
@@ -53,6 +54,8 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
 
   const editorRef = useRef<CodeEditorHandle>(null);
 
+  const viewerExternalActions = useExternalActionsForEditor(editorRef.current);
+
   return (
     <div>
       <div
@@ -74,7 +77,7 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
       {!simulation ? null : (
         <ViewerWithMenuBar
           simulation={simulation}
-          editor={editorRef.current ?? undefined}
+          externalActions={viewerExternalActions}
           playgroundSettings={settings}
           xPadding={0}
           randomizeSeed={randomizeSeed}

--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -10,7 +10,7 @@ import {
 } from "../lib/utility.js";
 import { CodeEditor, CodeEditorHandle } from "./CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "./PlaygroundSettings.js";
-import { useExternalActionsForEditor } from "./SquiggleViewer/ViewerProvider.js";
+import { useExternalViewerActionsForEditor } from "./SquiggleViewer/ViewerProvider.js";
 import { ViewerWithMenuBar } from "./ViewerWithMenuBar/index.js";
 
 export type SquiggleEditorProps = {
@@ -54,7 +54,9 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
 
   const editorRef = useRef<CodeEditorHandle>(null);
 
-  const viewerExternalActions = useExternalActionsForEditor(editorRef.current);
+  const externalViewerActions = useExternalViewerActionsForEditor(
+    editorRef.current
+  );
 
   return (
     <div>
@@ -77,7 +79,7 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
       {!simulation ? null : (
         <ViewerWithMenuBar
           simulation={simulation}
-          externalActions={viewerExternalActions}
+          externalViewerActions={externalViewerActions}
           playgroundSettings={settings}
           xPadding={0}
           randomizeSeed={randomizeSeed}

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -11,6 +11,7 @@ import {
   type PlaygroundSettings,
 } from "../PlaygroundSettings.js";
 import { ProjectContext } from "../ProjectProvider.js";
+import { useExternalActionsForEditor } from "../SquiggleViewer/ViewerProvider.js";
 import {
   ViewerWithMenuBar,
   ViewerWithMenuBarHandle,
@@ -162,6 +163,10 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
     );
   };
 
+  const viewerExternalActions = useExternalActionsForEditor(
+    leftPanelRef.current?.getEditor()
+  );
+
   const renderRight = () => {
     if (simulation) {
       return (
@@ -171,7 +176,7 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
           <ViewerWithMenuBar
             simulation={simulation}
             // FIXME - this will cause viewer to be rendered twice on initial render
-            editor={leftPanelRef.current?.getEditor() ?? undefined}
+            externalActions={viewerExternalActions}
             playgroundSettings={settings}
             ref={rightPanelRef}
             useGlobalShortcuts={true}

--- a/packages/components/src/components/SquigglePlayground/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/index.tsx
@@ -11,7 +11,7 @@ import {
   type PlaygroundSettings,
 } from "../PlaygroundSettings.js";
 import { ProjectContext } from "../ProjectProvider.js";
-import { useExternalActionsForEditor } from "../SquiggleViewer/ViewerProvider.js";
+import { useExternalViewerActionsForEditor } from "../SquiggleViewer/ViewerProvider.js";
 import {
   ViewerWithMenuBar,
   ViewerWithMenuBarHandle,
@@ -163,7 +163,7 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
     );
   };
 
-  const viewerExternalActions = useExternalActionsForEditor(
+  const externalViewerActions = useExternalViewerActionsForEditor(
     leftPanelRef.current?.getEditor()
   );
 
@@ -176,7 +176,7 @@ export const SquigglePlayground: React.FC<SquigglePlaygroundProps> = (
           <ViewerWithMenuBar
             simulation={simulation}
             // FIXME - this will cause viewer to be rendered twice on initial render
-            externalActions={viewerExternalActions}
+            externalViewerActions={externalViewerActions}
             playgroundSettings={settings}
             ref={rightPanelRef}
             useGlobalShortcuts={true}

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -364,7 +364,7 @@ export function useViewerType() {
 
 // List of callbacks that should do something outside of the viewer.
 // The common case is to scroll the editor to the necessary position in the playground.
-type ExternalViewerActions = Partial<{
+export type ExternalViewerActions = Partial<{
   // TODO: this function is not imports-friendly yet.
   // E.g. in stacktraces, the user might want to click on an error location and
   // go to the source that's identified not just by an offset, but also its
@@ -382,9 +382,10 @@ type Props = PropsWithChildren<{
 
 // Configure external actions for the common case of editor actions, e.g. for the playground or `<SquiggleEditor>` component.
 export function useExternalActionsForEditor(
-  // Intentionally supports undefined - conditional hooks are not possible and
-  // this hook is often used in components that take an optional `editor` prop.
-  editor: CodeEditorHandle | undefined
+  // Intentionally supports null and undefined - conditional hooks are not
+  // possible and this hook is often used in components that take an optional
+  // `editor` prop, or wire the editor components with a ref.
+  editor: CodeEditorHandle | null | undefined
 ): ExternalViewerActions {
   return useMemo(() => {
     if (!editor) {

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -362,7 +362,13 @@ export function useViewerType() {
   return viewerType;
 }
 
+// List of callbacks that should do something outside of the viewer.
+// The common case is to scroll the editor to the necessary position in the playground.
 type ExternalViewerActions = Partial<{
+  // TODO: this function is not imports-friendly yet.
+  // E.g. in stacktraces, the user might want to click on an error location and
+  // go to the source that's identified not just by an offset, but also its
+  // sourceId.
   show: (offset: number, focus: boolean) => void;
 }>;
 
@@ -374,7 +380,10 @@ type Props = PropsWithChildren<{
   visibleRootPath?: SqValuePath;
 }>;
 
+// Configure external actions for the common case of editor actions, e.g. for the playground or `<SquiggleEditor>` component.
 export function useExternalActionsForEditor(
+  // Intentionally supports undefined - conditional hooks are not possible and
+  // this hook is often used in components that take an optional `editor` prop.
   editor: CodeEditorHandle | undefined
 ): ExternalViewerActions {
   return useMemo(() => {

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -390,8 +390,6 @@ export function useExternalViewerActionsForEditor(
     }
     const actions: ExternalViewerActions = {
       show: (location, focus) => {
-        // TODO - scroll to fit the full range on screen, and maybe select the entire range.
-        // TODO - check if sourceId matches the sourceId in editor.
         editor.scrollTo(location, focus);
       },
       isFocusable: (location) => {
@@ -399,6 +397,7 @@ export function useExternalViewerActionsForEditor(
         return editor.getSourceId() === location.source;
       },
       isDefaultSourceId: (sourceId) => {
+        // hide the sourceId in stacktraces if it's for the currently edited code
         return editor.getSourceId() === sourceId;
       },
     };

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -190,7 +190,7 @@ type ViewerContextShape = {
   globalSettings: PlaygroundSettings;
   zoomedInPath: SqValuePath | undefined;
   setZoomedInPath: (value: SqValuePath | undefined) => void;
-  externalActions?: ExternalViewerActions;
+  externalViewerActions?: ExternalViewerActions;
   itemStore: ItemStore;
   viewerType: ViewerType;
   initialized: boolean;
@@ -204,7 +204,7 @@ export const ViewerContext = createContext<ViewerContextShape>({
   globalSettings: defaultPlaygroundSettings,
   zoomedInPath: undefined,
   setZoomedInPath: () => undefined,
-  externalActions: undefined,
+  externalViewerActions: undefined,
   itemStore: new ItemStore(),
   viewerType: "normal",
   handle: {
@@ -326,15 +326,15 @@ export function useZoomOut() {
 }
 
 export function useScrollToEditorPath(path: SqValuePath) {
-  const { externalActions, findNode } = useViewerContext();
+  const { externalViewerActions, findNode } = useViewerContext();
   return () => {
-    if (externalActions?.show) {
+    if (externalViewerActions?.show) {
       const value = findNode(path)?.value();
       const taggedLocation = value?.tags.location();
       const location = taggedLocation || value?.context?.findLocation();
 
       if (location) {
-        externalActions?.show?.(location.start.offset, false);
+        externalViewerActions?.show?.(location.start.offset, false);
       }
     }
   };
@@ -374,14 +374,14 @@ export type ExternalViewerActions = Partial<{
 
 type Props = PropsWithChildren<{
   partialPlaygroundSettings: PartialPlaygroundSettings;
-  externalActions?: ExternalViewerActions;
+  externalViewerActions?: ExternalViewerActions;
   viewerType?: ViewerType;
   rootValue: SqValue | undefined;
   visibleRootPath?: SqValuePath;
 }>;
 
 // Configure external actions for the common case of editor actions, e.g. for the playground or `<SquiggleEditor>` component.
-export function useExternalActionsForEditor(
+export function useExternalViewerActionsForEditor(
   // Intentionally supports null and undefined - conditional hooks are not
   // possible and this hook is often used in components that take an optional
   // `editor` prop, or wire the editor components with a ref.
@@ -402,7 +402,7 @@ export const InnerViewerProvider = forwardRef<SquiggleViewerHandle, Props>(
   (
     {
       partialPlaygroundSettings: unstablePlaygroundSettings,
-      externalActions = {},
+      externalViewerActions = {},
       viewerType = "normal",
       rootValue,
       visibleRootPath,
@@ -449,7 +449,7 @@ export const InnerViewerProvider = forwardRef<SquiggleViewerHandle, Props>(
           rootValue: _rootValue,
           visibleRootPath,
           globalSettings,
-          externalActions,
+          externalViewerActions: externalViewerActions,
           zoomedInPath,
           setZoomedInPath: setZoomedInPathPath,
           itemStore,

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -369,14 +369,12 @@ export type ExternalViewerActions = Partial<{
   // go to the source that's identified not just by an offset, but also its
   // sourceId.
   show: (location: SqLocation, focus: boolean) => void;
-}>;
-
-type Props = PropsWithChildren<{
-  partialPlaygroundSettings: PartialPlaygroundSettings;
-  externalViewerActions?: ExternalViewerActions;
-  viewerType?: ViewerType;
-  rootValue: SqValue | undefined;
-  visibleRootPath?: SqValuePath;
+  // When the viewer can focus on the location, will it be able to do that?
+  // This affects, for example, whether the links in stacktraces are clickable.
+  isFocusable: (location: SqLocation) => boolean;
+  // Should the viewer omit the source id because it's trivial?
+  // E.g. in playground stacktraces we want to show source id only for imports, but not for the currently edited file.
+  isDefaultSourceId: (sourceId: string) => boolean;
 }>;
 
 // Configure external actions for the common case of editor actions, e.g. for the playground or `<SquiggleEditor>` component.
@@ -396,10 +394,25 @@ export function useExternalViewerActionsForEditor(
         // TODO - check if sourceId matches the sourceId in editor.
         editor.scrollTo(location.start.offset, focus);
       },
+      isFocusable: (location) => {
+        // only the edited source id is focusable
+        return editor.getSourceId() === location.source;
+      },
+      isDefaultSourceId: (sourceId) => {
+        return editor.getSourceId() === sourceId;
+      },
     };
     return actions;
   }, [editor]);
 }
+
+type Props = PropsWithChildren<{
+  partialPlaygroundSettings: PartialPlaygroundSettings;
+  externalViewerActions?: ExternalViewerActions;
+  viewerType?: ViewerType;
+  rootValue: SqValue | undefined;
+  visibleRootPath?: SqValuePath;
+}>;
 
 export const InnerViewerProvider = forwardRef<SquiggleViewerHandle, Props>(
   (

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -10,7 +10,7 @@ import {
   useState,
 } from "react";
 
-import { SqValue, SqValuePath } from "@quri/squiggle-lang";
+import { SqLocation, SqValue, SqValuePath } from "@quri/squiggle-lang";
 
 import { useStabilizeObjectIdentity } from "../../lib/hooks/useStabilizeObject.js";
 import { SqValueWithContext, valueHasContext } from "../../lib/utility.js";
@@ -334,7 +334,7 @@ export function useScrollToEditorPath(path: SqValuePath) {
       const location = taggedLocation || value?.context?.findLocation();
 
       if (location) {
-        externalViewerActions?.show?.(location.start.offset, false);
+        externalViewerActions?.show?.(location, false);
       }
     }
   };
@@ -369,7 +369,7 @@ export type ExternalViewerActions = Partial<{
   // E.g. in stacktraces, the user might want to click on an error location and
   // go to the source that's identified not just by an offset, but also its
   // sourceId.
-  show: (offset: number, focus: boolean) => void;
+  show: (location: SqLocation, focus: boolean) => void;
 }>;
 
 type Props = PropsWithChildren<{
@@ -392,7 +392,11 @@ export function useExternalViewerActionsForEditor(
       return {};
     }
     const actions: ExternalViewerActions = {
-      show: (offset, focus) => editor.scrollTo(offset, focus),
+      show: (location, focus) => {
+        // TODO - scroll to fit the foll range on screen, and maybe select the entire range.
+        // TODO - check if sourceId matches the sourceId in editor.
+        editor.scrollTo(location.start.offset, focus);
+      },
     };
     return actions;
   }, [editor]);

--- a/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
+++ b/packages/components/src/components/SquiggleViewer/ViewerProvider.tsx
@@ -392,7 +392,7 @@ export function useExternalViewerActionsForEditor(
       show: (location, focus) => {
         // TODO - scroll to fit the full range on screen, and maybe select the entire range.
         // TODO - check if sourceId matches the sourceId in editor.
-        editor.scrollTo(location.start.offset, focus);
+        editor.scrollTo(location, focus);
       },
       isFocusable: (location) => {
         // only the edited source id is focusable

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -10,6 +10,7 @@ import { useGetSubvalueByPath } from "./utils.js";
 import { ValueViewer } from "./ValueViewer/index.js";
 import {
   SquiggleViewerHandle,
+  useExternalActionsForEditor,
   useViewerContext,
   ViewerProvider,
 } from "./ViewerProvider.js";
@@ -68,11 +69,12 @@ const component = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
     { value, editor, ...partialPlaygroundSettings },
     ref
   ) {
+    const externalActions = useExternalActionsForEditor(editor);
     return (
       <ErrorBoundary>
         <ViewerProvider
           partialPlaygroundSettings={partialPlaygroundSettings}
-          editor={editor}
+          externalActions={externalActions}
           ref={ref}
           rootValue={value}
         >

--- a/packages/components/src/components/SquiggleViewer/index.tsx
+++ b/packages/components/src/components/SquiggleViewer/index.tsx
@@ -10,7 +10,7 @@ import { useGetSubvalueByPath } from "./utils.js";
 import { ValueViewer } from "./ValueViewer/index.js";
 import {
   SquiggleViewerHandle,
-  useExternalActionsForEditor,
+  useExternalViewerActionsForEditor,
   useViewerContext,
   ViewerProvider,
 } from "./ViewerProvider.js";
@@ -69,12 +69,12 @@ const component = forwardRef<SquiggleViewerHandle, SquiggleViewerProps>(
     { value, editor, ...partialPlaygroundSettings },
     ref
   ) {
-    const externalActions = useExternalActionsForEditor(editor);
+    const externalViewerActions = useExternalViewerActionsForEditor(editor);
     return (
       <ErrorBoundary>
         <ViewerProvider
           partialPlaygroundSettings={partialPlaygroundSettings}
-          externalActions={externalActions}
+          externalViewerActions={externalViewerActions}
           ref={ref}
           rootValue={value}
         >

--- a/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
+++ b/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
@@ -7,7 +7,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
   const {
     setZoomedInPath: setZoomedInPath,
     itemStore,
-    editor,
+    externalActions,
     findNode,
   } = useViewerContext();
 
@@ -52,7 +52,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
       const location = value?.context?.findLocation();
 
       if (location) {
-        editor?.scrollTo(location.start.offset, true);
+        externalActions?.show?.(location.start.offset, true);
       }
     },
   });

--- a/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
+++ b/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
@@ -52,7 +52,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
       const location = value?.context?.findLocation();
 
       if (location) {
-        externalViewerActions?.show?.(location, true);
+        externalViewerActions.show?.(location, true);
       }
     },
   });

--- a/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
+++ b/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
@@ -52,7 +52,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
       const location = value?.context?.findLocation();
 
       if (location) {
-        externalViewerActions?.show?.(location.start.offset, true);
+        externalViewerActions?.show?.(location, true);
       }
     },
   });

--- a/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
+++ b/packages/components/src/components/SquiggleViewer/keyboardNav/zoomedOutSqValue.ts
@@ -7,7 +7,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
   const {
     setZoomedInPath: setZoomedInPath,
     itemStore,
-    externalActions,
+    externalViewerActions,
     findNode,
   } = useViewerContext();
 
@@ -52,7 +52,7 @@ export function useZoomedOutSqValueKeyEvent(selected: SqValuePath) {
       const location = value?.context?.findLocation();
 
       if (location) {
-        externalActions?.show?.(location.start.offset, true);
+        externalViewerActions?.show?.(location.start.offset, true);
       }
     },
   });

--- a/packages/components/src/components/ViewerWithMenuBar/ViewerBody.tsx
+++ b/packages/components/src/components/ViewerWithMenuBar/ViewerBody.tsx
@@ -7,12 +7,11 @@ import {
   viewerTabToValue,
   viewerTabToVisibleRootPath,
 } from "../../lib/utility.js";
-import { CodeEditorHandle } from "../CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 import { SquiggleViewerWithoutProvider } from "../SquiggleViewer/index.js";
 import {
+  ExternalViewerActions,
   SquiggleViewerHandle,
-  useExternalActionsForEditor,
   ViewerProvider,
 } from "../SquiggleViewer/ViewerProvider.js";
 import { ErrorBoundary } from "../ui/ErrorBoundary.js";
@@ -21,13 +20,19 @@ type Props = {
   viewerTab: ViewerTab;
   outputResult: SqOutputResult;
   isSimulating: boolean;
-  editor?: CodeEditorHandle;
+  externalActions?: ExternalViewerActions;
   playgroundSettings: PartialPlaygroundSettings;
 };
 
 export const ViewerBody = forwardRef<SquiggleViewerHandle, Props>(
   function ViewerBody(
-    { outputResult, viewerTab, isSimulating, editor, playgroundSettings },
+    {
+      outputResult,
+      viewerTab,
+      isSimulating,
+      externalActions,
+      playgroundSettings,
+    },
     viewerRef
   ) {
     const body = () => {
@@ -63,8 +68,6 @@ export const ViewerBody = forwardRef<SquiggleViewerHandle, Props>(
         </div>
       );
     };
-
-    const externalActions = useExternalActionsForEditor(editor);
 
     return (
       <ViewerProvider

--- a/packages/components/src/components/ViewerWithMenuBar/ViewerBody.tsx
+++ b/packages/components/src/components/ViewerWithMenuBar/ViewerBody.tsx
@@ -12,6 +12,7 @@ import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
 import { SquiggleViewerWithoutProvider } from "../SquiggleViewer/index.js";
 import {
   SquiggleViewerHandle,
+  useExternalActionsForEditor,
   ViewerProvider,
 } from "../SquiggleViewer/ViewerProvider.js";
 import { ErrorBoundary } from "../ui/ErrorBoundary.js";
@@ -63,11 +64,13 @@ export const ViewerBody = forwardRef<SquiggleViewerHandle, Props>(
       );
     };
 
+    const externalActions = useExternalActionsForEditor(editor);
+
     return (
       <ViewerProvider
-        partialPlaygroundSettings={playgroundSettings}
-        editor={editor}
         ref={viewerRef}
+        partialPlaygroundSettings={playgroundSettings}
+        externalActions={externalActions}
         visibleRootPath={viewerTabToVisibleRootPath(viewerTab)}
         rootValue={
           outputResult.ok

--- a/packages/components/src/components/ViewerWithMenuBar/ViewerBody.tsx
+++ b/packages/components/src/components/ViewerWithMenuBar/ViewerBody.tsx
@@ -20,7 +20,7 @@ type Props = {
   viewerTab: ViewerTab;
   outputResult: SqOutputResult;
   isSimulating: boolean;
-  externalActions?: ExternalViewerActions;
+  externalViewerActions?: ExternalViewerActions;
   playgroundSettings: PartialPlaygroundSettings;
 };
 
@@ -30,7 +30,7 @@ export const ViewerBody = forwardRef<SquiggleViewerHandle, Props>(
       outputResult,
       viewerTab,
       isSimulating,
-      externalActions,
+      externalViewerActions,
       playgroundSettings,
     },
     viewerRef
@@ -73,7 +73,7 @@ export const ViewerBody = forwardRef<SquiggleViewerHandle, Props>(
       <ViewerProvider
         ref={viewerRef}
         partialPlaygroundSettings={playgroundSettings}
-        externalActions={externalActions}
+        externalViewerActions={externalViewerActions}
         visibleRootPath={viewerTabToVisibleRootPath(viewerTab)}
         rootValue={
           outputResult.ok

--- a/packages/components/src/components/ViewerWithMenuBar/index.tsx
+++ b/packages/components/src/components/ViewerWithMenuBar/index.tsx
@@ -14,9 +14,11 @@ import {
   ViewerTab,
   viewerTabsToShow,
 } from "../../lib/utility.js";
-import { CodeEditorHandle } from "../CodeEditor/index.js";
 import { PartialPlaygroundSettings } from "../PlaygroundSettings.js";
-import { SquiggleViewerHandle } from "../SquiggleViewer/ViewerProvider.js";
+import {
+  ExternalViewerActions,
+  SquiggleViewerHandle,
+} from "../SquiggleViewer/ViewerProvider.js";
 import { Layout } from "./Layout.js";
 import { RandomizeSeedButton } from "./RandomizeSeedButton.js";
 import { SimulatingIndicator } from "./SimulatingIndicator.js";
@@ -26,7 +28,7 @@ import { ViewerMenu } from "./ViewerMenu.js";
 
 type Props = {
   simulation: Simulation;
-  editor?: CodeEditorHandle;
+  externalActions?: ExternalViewerActions;
   playgroundSettings: PartialPlaygroundSettings;
   showMenu?: boolean;
   defaultTab?: ViewerTab;
@@ -46,7 +48,7 @@ export const ViewerWithMenuBar = forwardRef<ViewerWithMenuBarHandle, Props>(
       playgroundSettings,
       randomizeSeed,
       showMenu = true,
-      editor,
+      externalActions,
       defaultTab,
       useGlobalShortcuts: enableGlobalShortcuts = false,
       xPadding = 2,
@@ -115,12 +117,12 @@ export const ViewerWithMenuBar = forwardRef<ViewerWithMenuBarHandle, Props>(
         }
         viewer={
           <ViewerBody
+            externalActions={externalActions}
             viewerTab={viewerTab}
             outputResult={output}
             isSimulating={isSimulating(simulation)}
             playgroundSettings={playgroundSettings}
             ref={viewerRef}
-            editor={editor}
           />
         }
         xPadding={xPadding}

--- a/packages/components/src/components/ViewerWithMenuBar/index.tsx
+++ b/packages/components/src/components/ViewerWithMenuBar/index.tsx
@@ -28,7 +28,7 @@ import { ViewerMenu } from "./ViewerMenu.js";
 
 type Props = {
   simulation: Simulation;
-  externalActions?: ExternalViewerActions;
+  externalViewerActions?: ExternalViewerActions;
   playgroundSettings: PartialPlaygroundSettings;
   showMenu?: boolean;
   defaultTab?: ViewerTab;
@@ -48,7 +48,7 @@ export const ViewerWithMenuBar = forwardRef<ViewerWithMenuBarHandle, Props>(
       playgroundSettings,
       randomizeSeed,
       showMenu = true,
-      externalActions,
+      externalViewerActions,
       defaultTab,
       useGlobalShortcuts: enableGlobalShortcuts = false,
       xPadding = 2,
@@ -117,7 +117,7 @@ export const ViewerWithMenuBar = forwardRef<ViewerWithMenuBarHandle, Props>(
         }
         viewer={
           <ViewerBody
-            externalActions={externalActions}
+            externalViewerActions={externalViewerActions}
             viewerTab={viewerTab}
             outputResult={output}
             isSimulating={isSimulating(simulation)}

--- a/packages/components/src/components/ui/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/ui/SquiggleErrorAlert.tsx
@@ -18,16 +18,18 @@ type Props = {
 const LocationLine: FC<{
   location: NonNullable<ReturnType<SqFrame["location"]>>;
 }> = ({ location }) => {
-  const { editor } = useViewerContext();
+  const { externalActions } = useViewerContext();
 
-  const findInEditor = () => {
-    editor?.scrollTo(location.start.offset, true);
-  };
+  const onClick = externalActions?.show
+    ? () => externalActions.show?.(location.start.offset, true)
+    : undefined;
 
   return (
     <span
-      className={clsx(editor && "cursor-pointer text-blue-500 hover:underline")}
-      onClick={editor ? findInEditor : undefined}
+      className={clsx(
+        externalActions?.show && "cursor-pointer text-blue-500 hover:underline"
+      )}
+      onClick={onClick}
     >
       line {location.start.line}, column {location.start.column}
     </span>

--- a/packages/components/src/components/ui/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/ui/SquiggleErrorAlert.tsx
@@ -1,4 +1,3 @@
-import { clsx } from "clsx";
 import { FC, PropsWithChildren } from "react";
 
 import {
@@ -20,19 +19,21 @@ const LocationLine: FC<{
 }> = ({ location }) => {
   const { externalActions } = useViewerContext();
 
-  const onClick = externalActions?.show
-    ? () => externalActions.show?.(location.start.offset, true)
-    : undefined;
+  const text = `line ${location.start.line}, column ${location.start.column}`;
 
-  return (
-    <span
-      className={clsx(
-        externalActions?.show && "cursor-pointer text-blue-500 hover:underline"
-      )}
-      onClick={onClick}
+  return externalActions?.show ? (
+    <a
+      href="#"
+      onClick={(e) => {
+        e.preventDefault();
+        externalActions.show?.(location.start.offset, true);
+      }}
+      className="text-blue-500 hover:underline"
     >
-      line {location.start.line}, column {location.start.column}
-    </span>
+      {text}
+    </a>
+  ) : (
+    <span>{text}</span>
   );
 };
 

--- a/packages/components/src/components/ui/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/ui/SquiggleErrorAlert.tsx
@@ -17,16 +17,16 @@ type Props = {
 const LocationLine: FC<{
   location: NonNullable<ReturnType<SqFrame["location"]>>;
 }> = ({ location }) => {
-  const { externalActions } = useViewerContext();
+  const { externalViewerActions } = useViewerContext();
 
   const text = `line ${location.start.line}, column ${location.start.column}`;
 
-  return externalActions?.show ? (
+  return externalViewerActions?.show ? (
     <a
       href="#"
       onClick={(e) => {
         e.preventDefault();
-        externalActions.show?.(location.start.offset, true);
+        externalViewerActions.show?.(location.start.offset, true);
       }}
       className="text-blue-500 hover:underline"
     >

--- a/packages/components/src/components/ui/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/ui/SquiggleErrorAlert.tsx
@@ -18,9 +18,14 @@ type Props = {
 const LocationLine: FC<{ location: SqLocation }> = ({ location }) => {
   const { externalViewerActions } = useViewerContext();
 
-  const text = `line ${location.start.line}, column ${location.start.column}`;
+  const text =
+    `line ${location.start.line}, column ${location.start.column}` +
+    (externalViewerActions?.isDefaultSourceId?.(location.source)
+      ? ""
+      : `, file ${location.source}`);
 
-  return externalViewerActions.show ? (
+  return externalViewerActions.show &&
+    externalViewerActions.isFocusable?.(location) ? (
     <a
       href="#"
       onClick={(e) => {

--- a/packages/components/src/components/ui/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/ui/SquiggleErrorAlert.tsx
@@ -26,7 +26,7 @@ const LocationLine: FC<{
       href="#"
       onClick={(e) => {
         e.preventDefault();
-        externalViewerActions.show?.(location.start.offset, true);
+        externalViewerActions.show?.(location, true);
       }}
       className="text-blue-500 hover:underline"
     >

--- a/packages/components/src/components/ui/SquiggleErrorAlert.tsx
+++ b/packages/components/src/components/ui/SquiggleErrorAlert.tsx
@@ -4,6 +4,7 @@ import {
   SqCompileError,
   SqError,
   SqFrame,
+  SqLocation,
   SqRuntimeError,
 } from "@quri/squiggle-lang";
 
@@ -14,14 +15,12 @@ type Props = {
   error: SqError;
 };
 
-const LocationLine: FC<{
-  location: NonNullable<ReturnType<SqFrame["location"]>>;
-}> = ({ location }) => {
+const LocationLine: FC<{ location: SqLocation }> = ({ location }) => {
   const { externalViewerActions } = useViewerContext();
 
   const text = `line ${location.start.line}, column ${location.start.column}`;
 
-  return externalViewerActions?.show ? (
+  return externalViewerActions.show ? (
     <a
       href="#"
       onClick={(e) => {

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -202,7 +202,7 @@ export x=1`;
 export const ManyTypes: Story = {
   name: "Many types",
   args: {
-    linker: linker,
+    linker,
     onOpenExport: (sourceId, varName) => {
       // eslint-disable-next-line no-console
       console.log("Clicked Export with params", sourceId, varName);

--- a/packages/components/test/SquiggleEditor.test.tsx
+++ b/packages/components/test/SquiggleEditor.test.tsx
@@ -1,0 +1,33 @@
+import "@testing-library/jest-dom";
+
+import {
+  act,
+  getByText,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import { SquiggleEditor } from "../src/index.js";
+
+test("Viewer renders", async () => {
+  act(() => render(<SquiggleEditor defaultCode="2 to 3" />));
+  await waitFor(() => screen.getByText(/simulation/));
+
+  expect(screen.getByText(/simulation/)).toHaveTextContent(
+    /simulation #(\d+) in (\d+)ms/
+  );
+  expect(screen.getByTestId("multi-distribution-chart")).toHaveTextContent(
+    "Distribution plot"
+  );
+});
+
+test("Stacktrace links are clickable", async () => {
+  act(() => render(<SquiggleEditor defaultCode="2 to a" />));
+  await waitFor(() => screen.getByText(/simulation/));
+
+  const errorHeader = screen.getByText("Compile Error");
+  expect(errorHeader).toBeDefined();
+
+  expect(getByText(errorHeader.parentElement!, /column /)).toBeDefined();
+});

--- a/packages/components/test/SquiggleEditor.test.tsx
+++ b/packages/components/test/SquiggleEditor.test.tsx
@@ -30,4 +30,5 @@ test("Stacktrace links are clickable", async () => {
   expect(errorHeader).toBeDefined();
 
   expect(getByText(errorHeader.parentElement!, /column /)).toBeDefined();
+  expect(getByText(errorHeader.parentElement!, /column /).tagName).toBe("A");
 });

--- a/packages/components/test/SquigglePlayground.test.tsx
+++ b/packages/components/test/SquigglePlayground.test.tsx
@@ -1,0 +1,67 @@
+import "@testing-library/jest-dom";
+
+import {
+  act,
+  getByText,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import { SqLinker } from "@quri/squiggle-lang";
+
+import { SquigglePlayground } from "../src/index.js";
+
+test("Playground renders", async () => {
+  act(() => render(<SquigglePlayground defaultCode="2 to 3" />));
+  await waitFor(() => screen.getByText(/simulation/));
+
+  expect(screen.getByText(/simulation/)).toHaveTextContent(
+    /simulation #(\d+) in (\d+)ms/
+  );
+  expect(screen.getByTestId("multi-distribution-chart")).toHaveTextContent(
+    "Distribution plot"
+  );
+});
+
+test("Stacktrace lines are clickable", async () => {
+  act(() => render(<SquigglePlayground defaultCode="2 to a" />));
+  await waitFor(() => screen.getByText(/simulation/));
+
+  const errorHeader = screen.getByText("Compile Error");
+  expect(errorHeader).toBeDefined();
+
+  expect(getByText(errorHeader.parentElement!, /column /)).toBeDefined();
+  expect(getByText(errorHeader.parentElement!, /column /).tagName).toBe("A");
+});
+
+test("Stacktrace lines for imports are not clickable", async () => {
+  const linker: SqLinker = {
+    resolve: (name) => name,
+    loadSource: async (sourceName) => {
+      // Note how this function is async and can load sources remotely on demand.
+      switch (sourceName) {
+        case "source1":
+          return `export x = 1 + // syntax error`;
+        default:
+          throw new Error(`source ${sourceName} not found`);
+      }
+    },
+  };
+
+  const code = `
+import "source1" as s1
+x = 1
+`;
+
+  act(() => render(<SquigglePlayground defaultCode={code} linker={linker} />));
+  await waitFor(() => screen.getByText(/simulation/));
+
+  const errorHeader = screen.getByText("Compile Error");
+  expect(errorHeader).toBeDefined();
+
+  expect(getByText(errorHeader.parentElement!, /column /)).toBeDefined();
+  expect(getByText(errorHeader.parentElement!, /column /).tagName).not.toBe(
+    "A"
+  );
+});


### PR DESCRIPTION
We now pass `externalViewerActions` to `ViewerProvider` instead of an editor object, because `editor.scrollTo` doesn't make sense in some non-playground contexts, e.g. GUCEM.

To avoid boilerplate, there's a `useExternalViewerActionsForEditor` hook which converts the editor handle to the `externalViewerActions`.

Also, the viewer behavior regarding these actions is now more flexible and has a better support for imports, thanks to the two new methods: `isFocusable` and `isDefaultSourceId`.

Example screenshot from the modified story; the error here comes from the function defined in an import, and the line in imported file is not clickable (for now), but the top-level call location is clickable.
<img width="355" alt="Screenshot 2024-05-11 at 15 00 53" src="https://github.com/quantified-uncertainty/squiggle/assets/89368/71e85412-0bd8-4af7-8d9e-4bd627b99615">

I didn't commit this story to the repo, but I did implemented some basic tests.