### PR TITLE
More robust support for "export" keyword

### DIFF
--- a/.changeset/beige-toys-share.md
+++ b/.changeset/beige-toys-share.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-textmate-grammar": patch
+---
+
+More robust support for "export" keyword

--- a/packages/textmate-grammar/src/squiggle.tmLanguage.yaml
+++ b/packages/textmate-grammar/src/squiggle.tmLanguage.yaml
@@ -8,6 +8,7 @@ patterns:
 repository:
   statement:
     patterns:
+      - include: "#export-keyword"
       - include: "#let"
       - include: "#decorator-call"
       - include: "#decorator"
@@ -108,6 +109,9 @@ repository:
   keywords:
     match: \b(if|then|else|to)\b
     name: keyword.control.squiggle
+  export-keyword:
+    match: \bexport\b
+    name: keyword.other.squiggle
   integer:
     match: \b\d+([_a-zA-Z]+[_a-zA-Z0-9]*)?
     name: constant.numeric.integer.squiggle

--- a/packages/textmate-grammar/tests/main.squiggle
+++ b/packages/textmate-grammar/tests/main.squiggle
@@ -7,8 +7,17 @@ foo = 5
 //    ^ constant.numeric.integer.squiggle
 
 export bar = 6
-// <------ keyword.control.squiggle
+// <------ keyword.other.squiggle
 //     ^^^ variable.other.squiggle
+
+f(x) = x
+// <- entity.name.function.squiggle
+//     ^ variable.other.squiggle
+
+export f(x) = x
+// <------ keyword.other.squiggle
+//     ^ entity.name.function.squiggle
+//            ^ variable.other.squiggle
 
 @name("X var")
 // <- punctuation.decorator.squiggle


### PR DESCRIPTION
`export f(x) = ...` wasn't highlighting properly in VS Code (and in code snippets in docs, I assume).