### PR TITLE
Use shortest length in SampleSet.mapN

### DIFF
--- a/packages/squiggle-lang/__tests__/library/sampleSet_test.ts
+++ b/packages/squiggle-lang/__tests__/library/sampleSet_test.ts
@@ -1,5 +1,6 @@
 import * as fc from "fast-check";
 
+import { sq } from "../../src/sq.js";
 import { expectErrorToBeBounded, testRun } from "../helpers/helpers.js";
 import { testEvalToBe } from "../helpers/reducerHelpers.js";
 
@@ -30,10 +31,6 @@ describe("Various SampleSet functions", () => {
     "[2,3,4,5,6,7]"
   );
   testEvalToBe(
-    "SampleSet.toList(SampleSet.mapN([SampleSet.fromList([1,2,3,4,5,6]), SampleSet.fromList([6, 5, 4, 3, 2, 1])], {|x| x[0] > x[1] ? x[0] : x[1]}))",
-    "[6,5,4,4,5,6]"
-  );
-  testEvalToBe(
     "SampleSet.fromList([1, 2, 3])",
     "Error(Distribution Math Error: Too few samples when constructing sample set)"
   );
@@ -42,6 +39,24 @@ describe("Various SampleSet functions", () => {
   testEvalToBe(
     "SampleSet.fromList([5,5,5,5,5,5]) -> sampleN(10) -> List.length",
     "10"
+  );
+});
+
+describe("mapN", () => {
+  // equal length
+  testEvalToBe(
+    sq`SampleSet.mapN([SampleSet.fromList([1,2,3,4,5,6]), SampleSet.fromList([6,5,4,3,2,1])], {|x| x[0] > x[1] ? x[0] : x[1]}) -> SampleSet.toList`,
+    "[6,5,4,4,5,6]"
+  );
+
+  // unequal length
+  testEvalToBe(
+    sq`SampleSet.mapN([SampleSet.fromList([1,2,3,4,5,6]), SampleSet.fromList([6,5,4,3,2,1,1,1])], {|x| x[0] > x[1] ? x[0] : x[1]}) -> SampleSet.toList`,
+    "[6,5,4,4,5,6]"
+  );
+  testEvalToBe(
+    sq`SampleSet.mapN([SampleSet.fromList([1,2,3,4,5,6,1,1]), SampleSet.fromList([6,5,4,3,2,1])], {|x| x[0] > x[1] ? x[0] : x[1]}) -> SampleSet.toList`,
+    "[6,5,4,4,5,6]"
   );
 });
 

--- a/packages/squiggle-lang/src/dists/distOperations/algebraicCombination.ts
+++ b/packages/squiggle-lang/src/dists/distOperations/algebraicCombination.ts
@@ -129,7 +129,7 @@ const monteCarloStrategy: StrategyImplementation = ({
   }
   const s1 = s1r.value;
   const s2 = s2r.value;
-  return SampleSetDist.map2({ fn, t1: s1, t2: s2 });
+  return SampleSetDist.map2({ fn, dist1: s1, dist2: s2 });
 };
 
 const preferConvolutionToMonteCarlo = (args: CombinationArgs): boolean => {

--- a/packages/squiggle-lang/src/fr/sampleset.ts
+++ b/packages/squiggle-lang/src/fr/sampleset.ts
@@ -189,8 +189,8 @@ const baseLibrary = [
                 Ok(
                   doNumberLambdaCall(lambda, [vNumber(a), vNumber(b)], reducer)
                 ),
-              t1: dist1,
-              t2: dist2,
+              dist1,
+              dist2,
             })
           );
         }
@@ -231,9 +231,9 @@ const baseLibrary = [
                     reducer
                   )
                 ),
-              t1: dist1,
-              t2: dist2,
-              t3: dist3,
+              dist1,
+              dist2,
+              dist3,
             })
           );
         }
@@ -261,16 +261,13 @@ const baseLibrary = [
         ],
         frSampleSetDist,
         ([dists, lambda], reducer) => {
-          const sampleSetDists = dists.map((d) => {
-            return d;
-          });
           return unwrapDistResult(
             SampleSetDist.mapN({
               fn: (a) =>
                 Ok(
                   doNumberLambdaCall(lambda, [vArray(a.map(vNumber))], reducer)
                 ),
-              t1: sampleSetDists,
+              dists,
             })
           );
         }

--- a/packages/squiggle-lang/src/library/registry/helpers.ts
+++ b/packages/squiggle-lang/src/library/registry/helpers.ts
@@ -330,8 +330,8 @@ export function twoVarSample(
     return unwrapDistResult(
       SampleSetDist.map2({
         fn: sampleFn,
-        t1: s1,
-        t2: s2,
+        dist1: s1,
+        dist2: s2,
       })
     );
   } else if (v1 instanceof BaseDist && typeof v2 === "number") {


### PR DESCRIPTION
Previously, `SampleSet.mapN` passed an array with defined values up to the longest sampleset in its arguments.

Technically this is a breaking change, but it's very unlikely anyone relied on it:
- none of public models on squiggle hub use `mapN`
- GUCEM had a workaround for old behavior
- `SampleSet.map2` and `SampleSet.map3` truncate samplesets in the same way
- the old behavior was pretty useless/nonsensical because e.g. for `[1,2], [10,20,30,40], [100,200,300]`, the call back would get: `[1,10,100]`, then `[2,20,200]`, then `[30,300]` (not `[null, 30, 300]`!), then `[40]` (not `[null, 40, null]`). So you'd have to jump through hoops to figure out which dist was the source of the sample