### PR TITLE
Serialize AST with normalization

### DIFF
--- a/.changeset/silent-hats-scream.md
+++ b/.changeset/silent-hats-scream.md
@@ -1,0 +1,6 @@
+---
+"@quri/squiggle-lang": patch
+"@quri/squiggle-components": patch
+---
+
+Normalized AST serialization - significantly reduces the produced bundle size, in some cases

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules
 /.vscode/settings.json
 .turbo
 *.tsbuildinfo
+
+*.tgz

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -1,4 +1,5 @@
-import { ASTNode, parse } from "../../src/ast/parse.js";
+import { parse } from "../../src/ast/parse.js";
+import { ASTNode } from "../../src/ast/types.js";
 import {
   testEvalError,
   testEvalToBe,

--- a/packages/squiggle-lang/src/ast/operators.ts
+++ b/packages/squiggle-lang/src/ast/operators.ts
@@ -1,0 +1,27 @@
+export const infixFunctions = {
+  "+": "add",
+  "-": "subtract",
+  "!=": "unequal",
+  ".-": "Dist.dotSubtract",
+  ".*": "Dist.dotMultiply",
+  "./": "Dist.dotDivide",
+  ".^": "Dist.dotPow",
+  ".+": "Dist.dotAdd",
+  "*": "multiply",
+  "/": "divide",
+  "&&": "and",
+  "^": "pow", // or xor
+  "<": "smaller",
+  "<=": "smallerEq",
+  "==": "equal",
+  ">": "larger",
+  ">=": "largerEq",
+  "||": "or",
+  to: "to",
+};
+
+export const unaryFunctions = {
+  "-": "unaryMinus",
+  "!": "not",
+  ".-": "unaryDotMinus",
+};

--- a/packages/squiggle-lang/src/ast/parse.ts
+++ b/packages/squiggle-lang/src/ast/parse.ts
@@ -2,45 +2,21 @@ import { ICompileError } from "../errors/IError.js";
 import * as Result from "../utility/result.js";
 import { result } from "../utility/result.js";
 import { SExpr, SExprPrintOptions, sExprToString } from "../utility/sExpr.js";
-import { type ASTCommentNode, type ASTNode } from "./peggyHelpers.js";
 import {
   parse as peggyParse,
   SyntaxError as PeggySyntaxError,
 } from "./peggyParser.js";
-
-export { type ASTNode } from "./peggyHelpers.js";
-
-// Types copy-pasted from Peggy, but converted from interface to type.
-// We need a type because interfaces don't match JsonValue type that we use for serialization.
-
-/** Provides information pointing to a location within a source. */
-export type Location = {
-  /** Line in the parsed source (1-based). */
-  line: number;
-  /** Column in the parsed source (1-based). */
-  column: number;
-  /** Offset in the parsed source (0-based). */
-  offset: number;
-};
-
-/** The `start` and `end` position's of an object within the source. */
-export type LocationRange = {
-  /** Unlike in Peggy, this must be a string. */
-  source: string;
-  /** Position at the beginning of the expression. */
-  start: Location;
-  /** Position after the end of the expression. */
-  end: Location;
-};
+import {
+  AST,
+  type ASTCommentNode,
+  type ASTNode,
+  LocationRange,
+} from "./types.js";
 
 export type ParseError = {
   type: "SyntaxError";
   location: LocationRange;
   message: string;
-};
-
-export type AST = Extract<ASTNode, { type: "Program" }> & {
-  comments: ASTCommentNode[];
 };
 
 type ParseResult = result<AST, ICompileError>;

--- a/packages/squiggle-lang/src/ast/serialize.ts
+++ b/packages/squiggle-lang/src/ast/serialize.ts
@@ -1,0 +1,323 @@
+import {
+  SquiggleDeserializationVisitor,
+  SquiggleSerializationVisitor,
+} from "../serialization/squiggle.js";
+import { ASTNode, LocationRange, NamedNodeLambda } from "./types.js";
+
+type TypedNode<T extends ASTNode["type"]> = Extract<ASTNode, { type: T }>;
+
+/*
+ * Derive serialized AST type from ASTNode automatically.
+ */
+
+type SerializedNodeField<T> = T extends string | number | boolean | null
+  ? T
+  : T extends {
+        type: ASTNode["type"];
+        location: LocationRange;
+      }
+    ? number // convert ASTNode to number
+    : T extends [infer E1, infer E2]
+      ? [SerializedNodeField<E1>, SerializedNodeField<E2>] // convert tuples
+      : T extends [infer E1, infer E2][]
+        ? [SerializedNodeField<E1>, SerializedNodeField<E2>][] // convert arrays of tuples
+        : T extends (infer E)[]
+          ? SerializedNodeField<E>[] // convert ASTNode[] to number[], [ASTNode, ASTNode][] to [number, number][], etc.
+          : T extends Record<infer K, infer V>
+            ? Record<K, SerializedNodeField<V>> // convert { string: ASTNode } to { string: number }
+            : never;
+
+type TypedNodeToSerializedNode<
+  T extends ASTNode["type"],
+  Node extends { type: T; location: LocationRange },
+> = Pick<Node, "type" | "location"> & {
+  [K in keyof Node as Exclude<K, "type" | "location">]: SerializedNodeField<
+    Node[K]
+  >;
+};
+
+// Trick for mapping over a discriminated union, https://stackoverflow.com/a/51691257
+type Distribute<U> = U extends ASTNode
+  ? TypedNodeToSerializedNode<U["type"], U>
+  : never;
+
+export type SerializedASTNode = Distribute<ASTNode>;
+
+// It can be difficult to see if the type above is correct, but for debugging you can use something like this:
+// type T = Extract<SerializedASTNode, { type: "Program" }>;
+// Uncomment the line above and hover over it it VS Code to check the output.
+
+export function serializeAstNode(
+  node: ASTNode,
+  visit: SquiggleSerializationVisitor
+): SerializedASTNode {
+  switch (node.type) {
+    case "Program":
+      return {
+        ...node,
+        imports: node.imports.map((item) => [
+          visit.ast(item[0]),
+          visit.ast(item[1]),
+        ]),
+        statements: node.statements.map(visit.ast),
+        symbols: Object.fromEntries(
+          Object.entries(node.symbols).map(([key, value]) => [
+            key,
+            visit.ast(value),
+          ])
+        ),
+      };
+    case "Block":
+      return {
+        ...node,
+        statements: node.statements.map(visit.ast),
+      };
+    case "DecoratedStatement":
+      return {
+        ...node,
+        decorator: visit.ast(node.decorator),
+        statement: visit.ast(node.statement),
+      };
+    case "LetStatement":
+    case "DefunStatement":
+      return {
+        ...node,
+        variable: visit.ast(node.variable),
+        value: visit.ast(node.value),
+      };
+    case "Lambda":
+      return {
+        ...node,
+        args: node.args.map(visit.ast),
+        body: visit.ast(node.body),
+      };
+    case "Array":
+      return {
+        ...node,
+        elements: node.elements.map(visit.ast),
+      };
+    case "Dict":
+      return {
+        ...node,
+        elements: node.elements.map(visit.ast),
+        symbols: Object.fromEntries(
+          Object.entries(node.symbols).map(([key, value]) => [
+            key,
+            visit.ast(value),
+          ])
+        ),
+      };
+    case "KeyValue":
+      return {
+        ...node,
+        key: visit.ast(node.key),
+        value: visit.ast(node.value),
+      };
+    case "UnitValue":
+      return {
+        ...node,
+        value: visit.ast(node.value),
+      };
+    case "Call":
+      return {
+        ...node,
+        fn: visit.ast(node.fn),
+        args: node.args.map(visit.ast),
+      };
+    case "InfixCall":
+      return {
+        ...node,
+        args: [visit.ast(node.args[0]), visit.ast(node.args[1])],
+      };
+    case "UnaryCall":
+      return {
+        ...node,
+        arg: visit.ast(node.arg),
+      };
+    case "Pipe":
+      return {
+        ...node,
+        leftArg: visit.ast(node.leftArg),
+        fn: visit.ast(node.fn),
+        rightArgs: node.rightArgs.map(visit.ast),
+      };
+    case "Decorator":
+      return {
+        ...node,
+        name: visit.ast(node.name),
+        args: node.args.map(visit.ast),
+      };
+    case "DotLookup":
+      return {
+        ...node,
+        arg: visit.ast(node.arg),
+      };
+    case "BracketLookup":
+      return {
+        ...node,
+        arg: visit.ast(node.arg),
+        key: visit.ast(node.key),
+      };
+    case "Ternary":
+      return {
+        ...node,
+        condition: visit.ast(node.condition),
+        trueExpression: visit.ast(node.trueExpression),
+        falseExpression: visit.ast(node.falseExpression),
+      };
+    case "Identifier":
+      return node;
+    case "IdentifierWithAnnotation":
+      return {
+        ...node,
+        annotation: visit.ast(node.annotation),
+      };
+    case "Float":
+    case "String":
+    case "Boolean":
+      return node;
+    default:
+      throw node satisfies never;
+  }
+}
+
+export function deserializeAstNode(
+  node: SerializedASTNode,
+  visit: SquiggleDeserializationVisitor
+): ASTNode {
+  switch (node.type) {
+    case "Program":
+      return {
+        ...node,
+        imports: node.imports.map((item) => [
+          visit.ast(item[0]) as TypedNode<"String">,
+          visit.ast(item[0]) as TypedNode<"Identifier">,
+        ]),
+        statements: node.statements.map(visit.ast),
+        symbols: Object.fromEntries(
+          Object.entries(node.symbols).map(([key, value]) => [
+            key,
+            visit.ast(value),
+          ])
+        ),
+      };
+    case "Block":
+      return {
+        ...node,
+        statements: node.statements.map(visit.ast),
+      };
+    case "DecoratedStatement":
+      return {
+        ...node,
+        decorator: visit.ast(node.decorator) as TypedNode<"Decorator">,
+        statement: visit.ast(node.statement) as TypedNode<"LetStatement">,
+      };
+    case "LetStatement":
+      return {
+        ...node,
+        variable: visit.ast(node.variable) as TypedNode<"Identifier">,
+        value: visit.ast(node.value),
+      };
+    case "DefunStatement":
+      return {
+        ...node,
+        variable: visit.ast(node.variable) as TypedNode<"Identifier">,
+        value: visit.ast(node.value) as NamedNodeLambda,
+      };
+    case "Lambda":
+      return {
+        ...node,
+        args: node.args.map(visit.ast),
+        body: visit.ast(node.body),
+      };
+    case "Array":
+      return {
+        ...node,
+        elements: node.elements.map(visit.ast),
+      };
+    case "Dict":
+      return {
+        ...node,
+        elements: node.elements.map(
+          (node) => visit.ast(node) as TypedNode<"KeyValue" | "Identifier">
+        ),
+        symbols: Object.fromEntries(
+          Object.entries(node.symbols).map(([key, value]) => [
+            key,
+            visit.ast(value) as TypedNode<"KeyValue" | "Identifier">,
+          ])
+        ),
+      };
+    case "KeyValue":
+      return {
+        ...node,
+        key: visit.ast(node.key),
+        value: visit.ast(node.value),
+      };
+    case "UnitValue":
+      return {
+        ...node,
+        value: visit.ast(node.value),
+      };
+    case "Call":
+      return {
+        ...node,
+        fn: visit.ast(node.fn),
+        args: node.args.map(visit.ast),
+      };
+    case "InfixCall":
+      return {
+        ...node,
+        args: [visit.ast(node.args[0]), visit.ast(node.args[1])],
+      };
+    case "UnaryCall":
+      return {
+        ...node,
+        arg: visit.ast(node.arg),
+      };
+    case "Pipe":
+      return {
+        ...node,
+        leftArg: visit.ast(node.leftArg),
+        fn: visit.ast(node.fn),
+        rightArgs: node.rightArgs.map(visit.ast),
+      };
+    case "Decorator":
+      return {
+        ...node,
+        name: visit.ast(node.name) as TypedNode<"Identifier">,
+        args: node.args.map(visit.ast),
+      };
+    case "DotLookup":
+      return {
+        ...node,
+        arg: visit.ast(node.arg),
+      };
+    case "BracketLookup":
+      return {
+        ...node,
+        arg: visit.ast(node.arg),
+        key: visit.ast(node.key),
+      };
+    case "Ternary":
+      return {
+        ...node,
+        condition: visit.ast(node.condition),
+        trueExpression: visit.ast(node.trueExpression),
+        falseExpression: visit.ast(node.falseExpression),
+      };
+    case "Identifier":
+      return node;
+    case "IdentifierWithAnnotation":
+      return {
+        ...node,
+        annotation: visit.ast(node.annotation),
+      };
+    case "Float":
+    case "String":
+    case "Boolean":
+      return node;
+    default:
+      throw node satisfies never;
+  }
+}

--- a/packages/squiggle-lang/src/ast/types.ts
+++ b/packages/squiggle-lang/src/ast/types.ts
@@ -1,7 +1,10 @@
 import { infixFunctions, unaryFunctions } from "./operators.js";
 
-// Types copy-pasted from Peggy, but converted from interface to type.
-// We need a type because interfaces don't match JsonValue type that we use for serialization.
+/*
+ *`Location` and `LocationRange` types are copy-pasted from Peggy, but
+ * converted from interface to type. We need a type because interfaces don't
+ * match `JsonValue` type that we use for serialization.
+ */
 
 /** Provides information pointing to a location within a source. */
 export type Location = {
@@ -23,10 +26,6 @@ export type LocationRange = {
   end: Location;
 };
 
-export type AST = Extract<ASTNode, { type: "Program" }> & {
-  comments: ASTCommentNode[];
-};
-
 export type InfixOperator = keyof typeof infixFunctions;
 
 export type UnaryOperator = keyof typeof unaryFunctions;
@@ -36,6 +35,11 @@ type Node = {
 };
 
 type N<T extends string, V extends object> = Node & { type: T } & V;
+
+/*
+ * Specific `Node*` types are mostly not exported, because they're easy to
+ * obtain with `Extract<...>` (see `TypedNode` in `./peggyHelpers.ts`)
+ */
 
 type NodeBlock = N<
   "Block",
@@ -198,6 +202,10 @@ export type ASTNode =
   | NodeFloat
   | NodeString
   | NodeBoolean;
+
+export type AST = Extract<ASTNode, { type: "Program" }> & {
+  comments: ASTCommentNode[];
+};
 
 export type ASTCommentNode = {
   type: "lineComment" | "blockComment";

--- a/packages/squiggle-lang/src/ast/types.ts
+++ b/packages/squiggle-lang/src/ast/types.ts
@@ -30,11 +30,10 @@ export type InfixOperator = keyof typeof infixFunctions;
 
 export type UnaryOperator = keyof typeof unaryFunctions;
 
-type Node = {
+type N<T extends string, V extends object> = {
+  type: T;
   location: LocationRange;
-};
-
-type N<T extends string, V extends object> = Node & { type: T } & V;
+} & V;
 
 /*
  * Specific `Node*` types are mostly not exported, because they're easy to
@@ -60,7 +59,12 @@ type NodeProgram = N<
   }
 >;
 
-type NodeArray = N<"Array", { elements: ASTNode[] }>;
+type NodeArray = N<
+  "Array",
+  {
+    elements: ASTNode[];
+  }
+>;
 
 type NodeDict = N<
   "Dict",
@@ -80,16 +84,37 @@ type NodeKeyValue = N<
 >;
 export type AnyNodeDictEntry = NodeKeyValue | NodeIdentifier;
 
-type NodeUnitValue = N<"UnitValue", { value: ASTNode; unit: string }>;
+type NodeUnitValue = N<
+  "UnitValue",
+  {
+    value: ASTNode;
+    unit: string;
+  }
+>;
 
-type NodeCall = N<"Call", { fn: ASTNode; args: ASTNode[] }>;
+type NodeCall = N<
+  "Call",
+  {
+    fn: ASTNode;
+    args: ASTNode[];
+  }
+>;
 
 type NodeInfixCall = N<
   "InfixCall",
-  { op: InfixOperator; args: [ASTNode, ASTNode] }
+  {
+    op: InfixOperator;
+    args: [ASTNode, ASTNode];
+  }
 >;
 
-type NodeUnaryCall = N<"UnaryCall", { op: UnaryOperator; arg: ASTNode }>;
+type NodeUnaryCall = N<
+  "UnaryCall",
+  {
+    op: UnaryOperator;
+    arg: ASTNode;
+  }
+>;
 
 type NodePipe = N<
   "Pipe",
@@ -100,9 +125,21 @@ type NodePipe = N<
   }
 >;
 
-type NodeDotLookup = N<"DotLookup", { arg: ASTNode; key: string }>;
+type NodeDotLookup = N<
+  "DotLookup",
+  {
+    arg: ASTNode;
+    key: string;
+  }
+>;
 
-type NodeBracketLookup = N<"BracketLookup", { arg: ASTNode; key: ASTNode }>;
+type NodeBracketLookup = N<
+  "BracketLookup",
+  {
+    arg: ASTNode;
+    key: ASTNode;
+  }
+>;
 
 type NodeFloat = N<
   "Float",
@@ -116,23 +153,39 @@ type NodeFloat = N<
 
 type NodeIdentifierWithAnnotation = N<
   "IdentifierWithAnnotation",
-  { variable: string; annotation: ASTNode }
+  {
+    variable: string;
+    annotation: ASTNode;
+  }
 >;
 
 type NodeIdentifier = N<"Identifier", { value: string }>;
 
-type NodeDecorator = N<"Decorator", { name: NodeIdentifier; args: ASTNode[] }>;
+type NodeDecorator = N<
+  "Decorator",
+  {
+    name: NodeIdentifier;
+    args: ASTNode[];
+  }
+>;
 
 type LetOrDefun = {
   variable: NodeIdentifier;
   exported: boolean;
 };
 
-type NodeLetStatement = N<"LetStatement", LetOrDefun & { value: ASTNode }>;
+type NodeLetStatement = N<
+  "LetStatement",
+  LetOrDefun & {
+    value: ASTNode;
+  }
+>;
 
 type NodeDefunStatement = N<
   "DefunStatement",
-  LetOrDefun & { value: NamedNodeLambda }
+  LetOrDefun & {
+    value: NamedNodeLambda;
+  }
 >;
 
 type NodeDecoratedStatement = N<

--- a/packages/squiggle-lang/src/ast/types.ts
+++ b/packages/squiggle-lang/src/ast/types.ts
@@ -1,0 +1,206 @@
+import { infixFunctions, unaryFunctions } from "./operators.js";
+
+// Types copy-pasted from Peggy, but converted from interface to type.
+// We need a type because interfaces don't match JsonValue type that we use for serialization.
+
+/** Provides information pointing to a location within a source. */
+export type Location = {
+  /** Line in the parsed source (1-based). */
+  line: number;
+  /** Column in the parsed source (1-based). */
+  column: number;
+  /** Offset in the parsed source (0-based). */
+  offset: number;
+};
+
+/** The `start` and `end` position's of an object within the source. */
+export type LocationRange = {
+  /** Unlike in Peggy, this must be a string. */
+  source: string;
+  /** Position at the beginning of the expression. */
+  start: Location;
+  /** Position after the end of the expression. */
+  end: Location;
+};
+
+export type AST = Extract<ASTNode, { type: "Program" }> & {
+  comments: ASTCommentNode[];
+};
+
+export type InfixOperator = keyof typeof infixFunctions;
+
+export type UnaryOperator = keyof typeof unaryFunctions;
+
+type Node = {
+  location: LocationRange;
+};
+
+type N<T extends string, V extends object> = Node & { type: T } & V;
+
+type NodeBlock = N<
+  "Block",
+  {
+    statements: ASTNode[];
+  }
+>;
+
+type NodeProgram = N<
+  "Program",
+  {
+    imports: [NodeString, NodeIdentifier][];
+    statements: ASTNode[];
+    // Var name -> statement node, for faster path resolution.
+    // Not used for evaluation.
+    // Note: symbols point to undecorated statements.
+    symbols: { [k in string]: ASTNode };
+  }
+>;
+
+type NodeArray = N<"Array", { elements: ASTNode[] }>;
+
+type NodeDict = N<
+  "Dict",
+  {
+    elements: AnyNodeDictEntry[];
+    // Static key -> node, for faster path resolution.
+    // Not used for evaluation.
+    symbols: { [k in number | string]: AnyNodeDictEntry };
+  }
+>;
+type NodeKeyValue = N<
+  "KeyValue",
+  {
+    key: ASTNode;
+    value: ASTNode;
+  }
+>;
+export type AnyNodeDictEntry = NodeKeyValue | NodeIdentifier;
+
+type NodeUnitValue = N<"UnitValue", { value: ASTNode; unit: string }>;
+
+type NodeCall = N<"Call", { fn: ASTNode; args: ASTNode[] }>;
+
+type NodeInfixCall = N<
+  "InfixCall",
+  { op: InfixOperator; args: [ASTNode, ASTNode] }
+>;
+
+type NodeUnaryCall = N<"UnaryCall", { op: UnaryOperator; arg: ASTNode }>;
+
+type NodePipe = N<
+  "Pipe",
+  {
+    leftArg: ASTNode;
+    fn: ASTNode;
+    rightArgs: ASTNode[];
+  }
+>;
+
+type NodeDotLookup = N<"DotLookup", { arg: ASTNode; key: string }>;
+
+type NodeBracketLookup = N<"BracketLookup", { arg: ASTNode; key: ASTNode }>;
+
+type NodeFloat = N<
+  "Float",
+  {
+    // floats are always positive, `-123` is an unary operation
+    integer: number;
+    fractional: string | null; // heading zeros are significant, so we can't store this as a number
+    exponent: number | null;
+  }
+>;
+
+type NodeIdentifierWithAnnotation = N<
+  "IdentifierWithAnnotation",
+  { variable: string; annotation: ASTNode }
+>;
+
+type NodeIdentifier = N<"Identifier", { value: string }>;
+
+type NodeDecorator = N<"Decorator", { name: NodeIdentifier; args: ASTNode[] }>;
+
+type LetOrDefun = {
+  variable: NodeIdentifier;
+  exported: boolean;
+};
+
+type NodeLetStatement = N<"LetStatement", LetOrDefun & { value: ASTNode }>;
+
+type NodeDefunStatement = N<
+  "DefunStatement",
+  LetOrDefun & { value: NamedNodeLambda }
+>;
+
+type NodeDecoratedStatement = N<
+  "DecoratedStatement",
+  {
+    decorator: NodeDecorator;
+    statement: NodeLetStatement | NodeDefunStatement | NodeDecoratedStatement;
+  }
+>;
+
+type NodeLambda = N<
+  "Lambda",
+  {
+    // Don't try to convert it to string[], ASTNode is intentional because we need locations.
+    args: ASTNode[];
+    body: ASTNode;
+    name?: string;
+  }
+>;
+
+export type NamedNodeLambda = NodeLambda & Required<Pick<NodeLambda, "name">>;
+
+type NodeTernary = N<
+  "Ternary",
+  {
+    condition: ASTNode;
+    trueExpression: ASTNode;
+    falseExpression: ASTNode;
+    kind: "IfThenElse" | "C";
+  }
+>;
+
+type NodeString = N<"String", { value: string }>;
+
+type NodeBoolean = N<"Boolean", { value: boolean }>;
+
+export type ASTNode =
+  // blocks
+  | NodeProgram
+  | NodeBlock
+  // statements
+  | NodeDecoratedStatement
+  | NodeLetStatement
+  | NodeDefunStatement
+  // functions & lambdas
+  | NodeLambda
+  // container types
+  | NodeArray
+  | NodeDict
+  | NodeKeyValue
+  // various calls
+  | NodeUnitValue
+  | NodeCall
+  | NodeInfixCall
+  | NodeUnaryCall
+  | NodePipe
+  | NodeDecorator
+  // [] and .foo
+  | NodeDotLookup
+  | NodeBracketLookup
+  // control flow - if/else
+  | NodeTernary
+  // identifiers
+  | NodeIdentifier
+  | NodeIdentifierWithAnnotation
+  // basic values
+  | NodeFloat
+  | NodeString
+  | NodeBoolean;
+
+export type ASTCommentNode = {
+  type: "lineComment" | "blockComment";
+  value: string;
+  location: LocationRange;
+};

--- a/packages/squiggle-lang/src/ast/utils.ts
+++ b/packages/squiggle-lang/src/ast/utils.ts
@@ -1,5 +1,4 @@
-import { LocationRange } from "./parse.js";
-import { ASTNode } from "./peggyHelpers.js";
+import { ASTNode, LocationRange } from "./types.js";
 
 export function locationContains(location: LocationRange, offset: number) {
   return location.start.offset <= offset && location.end.offset >= offset;

--- a/packages/squiggle-lang/src/errors/IError.ts
+++ b/packages/squiggle-lang/src/errors/IError.ts
@@ -1,4 +1,4 @@
-import { LocationRange } from "../ast/parse.js";
+import { LocationRange } from "../ast/types.js";
 import {
   SerializedStackTrace,
   StackTrace,

--- a/packages/squiggle-lang/src/expression/compile.ts
+++ b/packages/squiggle-lang/src/expression/compile.ts
@@ -1,5 +1,5 @@
-import { ASTNode } from "../ast/parse.js";
-import { infixFunctions, unaryFunctions } from "../ast/peggyHelpers.js";
+import { infixFunctions, unaryFunctions } from "../ast/operators.js";
+import { ASTNode } from "../ast/types.js";
 import { undecorated } from "../ast/utils.js";
 import { ICompileError } from "../errors/IError.js";
 import { Bindings } from "../reducer/Stack.js";

--- a/packages/squiggle-lang/src/expression/index.ts
+++ b/packages/squiggle-lang/src/expression/index.ts
@@ -10,7 +10,7 @@
  * The main difference between our IR and AST is that in IR, variable names are
  * resolved to stack and capture references.
  */
-import { ASTNode } from "../ast/parse.js";
+import { ASTNode } from "../ast/types.js";
 import {
   sExpr,
   SExpr,

--- a/packages/squiggle-lang/src/index.ts
+++ b/packages/squiggle-lang/src/index.ts
@@ -86,13 +86,13 @@ export {
 
 export {
   type AST,
+  type ASTCommentNode,
   type ASTNode,
   type LocationRange as SqLocation,
-} from "./ast/parse.js";
+} from "./ast/types.js";
 export { defaultEnv as defaultEnvironment } from "./dists/env.js";
 export { type Env, SqProject };
 
-export { type ASTCommentNode } from "./ast/peggyHelpers.js";
 export { type SqLinker } from "./public/SqLinker.js";
 export { type SqOutput, type SqOutputResult } from "./public/types.js";
 

--- a/packages/squiggle-lang/src/library/registry/core.ts
+++ b/packages/squiggle-lang/src/library/registry/core.ts
@@ -1,7 +1,7 @@
 import get from "lodash/get.js";
 import invert from "lodash/invert.js";
 
-import { infixFunctions, unaryFunctions } from "../../ast/peggyHelpers.js";
+import { infixFunctions, unaryFunctions } from "../../ast/operators.js";
 import { BuiltinLambda, Lambda } from "../../reducer/lambda.js";
 import {
   FnDefinition,

--- a/packages/squiggle-lang/src/public/SqProject/ProjectItem.ts
+++ b/packages/squiggle-lang/src/public/SqProject/ProjectItem.ts
@@ -1,4 +1,5 @@
-import { AST, LocationRange, parse } from "../../ast/parse.js";
+import { parse } from "../../ast/parse.js";
+import { AST, LocationRange } from "../../ast/types.js";
 import { Env } from "../../dists/env.js";
 import { ICompileError } from "../../errors/IError.js";
 import { RunOutput, RunParams } from "../../runners/BaseRunner.js";

--- a/packages/squiggle-lang/src/public/SqValue/SqTags.ts
+++ b/packages/squiggle-lang/src/public/SqValue/SqTags.ts
@@ -1,4 +1,4 @@
-import { LocationRange } from "../../ast/parse.js";
+import { LocationRange } from "../../ast/types.js";
 import { ValueTags } from "../../value/valueTags.js";
 import { SqValueContext } from "../SqValueContext.js";
 import { SqValue, wrapValue } from "./index.js";

--- a/packages/squiggle-lang/src/public/SqValueContext.ts
+++ b/packages/squiggle-lang/src/public/SqValueContext.ts
@@ -1,4 +1,4 @@
-import { ASTNode } from "../ast/parse.js";
+import { ASTNode } from "../ast/types.js";
 import { isBindingStatement } from "../ast/utils.js";
 import { RunContext } from "./SqProject/ProjectItem.js";
 import { SqValuePath, SqValuePathEdge } from "./SqValuePath.js";

--- a/packages/squiggle-lang/src/public/SqValuePath.ts
+++ b/packages/squiggle-lang/src/public/SqValuePath.ts
@@ -1,4 +1,4 @@
-import { ASTNode } from "../ast/parse.js";
+import { ASTNode } from "../ast/types.js";
 import { locationContains } from "../ast/utils.js";
 
 // Note that 'exports' is shown separately, but is not a valid path root.

--- a/packages/squiggle-lang/src/public/parse.ts
+++ b/packages/squiggle-lang/src/public/parse.ts
@@ -1,4 +1,5 @@
-import { AST, parse as astParse } from "../ast/parse.js";
+import { parse as astParse } from "../ast/parse.js";
+import { AST } from "../ast/types.js";
 import * as Result from "../utility/result.js";
 import { result } from "../utility/result.js";
 import { SqCompileError } from "./SqError.js";

--- a/packages/squiggle-lang/src/reducer/FrameStack.ts
+++ b/packages/squiggle-lang/src/reducer/FrameStack.ts
@@ -2,7 +2,7 @@
 // A "frame" is a pair of a scope (function or top-level scope, currently stored as a string) and a location inside it.
 // See this comment to deconfuse about what a frame is: https://github.com/quantified-uncertainty/squiggle/pull/1172#issuecomment-1264115038
 
-import { LocationRange } from "../ast/parse.js";
+import { LocationRange } from "../ast/types.js";
 import { BaseLambda } from "./lambda.js";
 
 export class Frame {

--- a/packages/squiggle-lang/src/reducer/Reducer.ts
+++ b/packages/squiggle-lang/src/reducer/Reducer.ts
@@ -1,6 +1,6 @@
 import jstat from "jstat";
 
-import { ASTNode, LocationRange } from "../ast/parse.js";
+import { ASTNode, LocationRange } from "../ast/types.js";
 import { Env } from "../dists/env.js";
 import { IRuntimeError } from "../errors/IError.js";
 import {

--- a/packages/squiggle-lang/src/reducer/RunProfile.ts
+++ b/packages/squiggle-lang/src/reducer/RunProfile.ts
@@ -1,4 +1,4 @@
-import { LocationRange } from "../ast/parse.js";
+import { LocationRange } from "../ast/types.js";
 
 function prefixSum(arr: number[]): number[] {
   const result: number[] = [];

--- a/packages/squiggle-lang/src/reducer/StackTrace.ts
+++ b/packages/squiggle-lang/src/reducer/StackTrace.ts
@@ -1,4 +1,4 @@
-import { LocationRange } from "../ast/parse.js";
+import { LocationRange } from "../ast/types.js";
 import { JsonValue } from "../utility/typeHelpers.js";
 import { FrameStack } from "./FrameStack.js";
 

--- a/packages/squiggle-lang/src/reducer/lambda.ts
+++ b/packages/squiggle-lang/src/reducer/lambda.ts
@@ -1,6 +1,6 @@
 import uniq from "lodash/uniq.js";
 
-import { LocationRange } from "../ast/parse.js";
+import { LocationRange } from "../ast/types.js";
 import {
   REArgumentDomainError,
   REArityError,

--- a/packages/squiggle-lang/src/runners/BaseRunner.ts
+++ b/packages/squiggle-lang/src/runners/BaseRunner.ts
@@ -1,4 +1,4 @@
-import { AST } from "../ast/parse.js";
+import { AST } from "../ast/types.js";
 import { Env } from "../dists/env.js";
 import { ICompileError, IRuntimeError } from "../errors/IError.js";
 import { RunProfile } from "../reducer/RunProfile.js";

--- a/packages/squiggle-lang/src/runners/worker.ts
+++ b/packages/squiggle-lang/src/runners/worker.ts
@@ -1,4 +1,4 @@
-import { AST } from "../ast/parse.js";
+import { AST } from "../ast/types.js";
 import { Env } from "../dists/env.js";
 import {
   SquiggleBundle,

--- a/packages/squiggle-lang/src/serialization/squiggle.ts
+++ b/packages/squiggle-lang/src/serialization/squiggle.ts
@@ -1,9 +1,15 @@
+import {
+  deserializeAstNode,
+  serializeAstNode,
+  SerializedASTNode,
+} from "../ast/serialize.js";
 import { Expression } from "../expression/index.js";
 import {
   deserializeExpression,
   SerializedExpression,
   serializeExpression,
 } from "../expression/serialize.js";
+import { ASTNode } from "../index.js";
 import { Lambda } from "../reducer/lambda.js";
 import { RunProfile, SerializedRunProfile } from "../reducer/RunProfile.js";
 import { deserializeValue } from "../value/deserializeValue.js";
@@ -28,32 +34,33 @@ type SquiggleShape = {
   lambda: [Lambda, SerializedLambda];
   tags: [ValueTags, SerializedValueTags];
   profile: [RunProfile, SerializedRunProfile];
+  ast: [ASTNode, SerializedASTNode];
 };
 
 const squiggleConfig: StoreConfig<SquiggleShape> = {
   value: {
     serialize: (node, visitor) => node.serialize(visitor),
-    deserialize: (serializedNode, visitor) =>
-      deserializeValue(serializedNode, visitor),
+    deserialize: deserializeValue,
   },
   expression: {
-    serialize: (node, visitor) => serializeExpression(node, visitor),
-    deserialize: (serializedNode, visitor) =>
-      deserializeExpression(serializedNode, visitor),
+    serialize: serializeExpression,
+    deserialize: deserializeExpression,
   },
   lambda: {
-    serialize: (node, visitor) => serializeLambda(node, visitor),
-    deserialize: (serializedNode, visitor) =>
-      deserializeLambda(serializedNode, visitor),
+    serialize: serializeLambda,
+    deserialize: deserializeLambda,
   },
   tags: {
     serialize: (node, visitor) => node.serialize(visitor),
-    deserialize: (serializedNode, visitor) =>
-      ValueTags.deserialize(serializedNode, visitor),
+    deserialize: ValueTags.deserialize,
   },
   profile: {
     serialize: (node) => node.serialize(),
-    deserialize: (serializedNode) => RunProfile.deserialize(serializedNode),
+    deserialize: RunProfile.deserialize,
+  },
+  ast: {
+    serialize: serializeAstNode,
+    deserialize: deserializeAstNode,
   },
   // TODO - we should serialize AST nodes too, otherwise serialized lambdas could blow up in size, in some cases
 };

--- a/packages/squiggle-lang/src/value/valueTags.ts
+++ b/packages/squiggle-lang/src/value/valueTags.ts
@@ -1,4 +1,4 @@
-import { LocationRange } from "../ast/parse.js";
+import { LocationRange } from "../ast/types.js";
 import {
   SquiggleDeserializationVisitor,
   SquiggleSerializationVisitor,

--- a/packages/squiggle-lang/src/value/valueTagsUtils.ts
+++ b/packages/squiggle-lang/src/value/valueTagsUtils.ts
@@ -1,4 +1,4 @@
-import { Location, LocationRange } from "../ast/parse.js";
+import { Location, LocationRange } from "../ast/types.js";
 import { ImmutableMap } from "../utility/immutableMap.js";
 import { Value, vArray, vNumber, vString } from "./index.js";
 import { ValueTags } from "./valueTags.js";


### PR DESCRIPTION
This PR implements the proper serialization of AST - the part that was missing from #3158.

AST is already JSON-compatible, so in #3158 I didn't normalize it. That could cause N^2 amount of JSON when we serialized expressions.

Pseudo-code example:

```
expression: {
  type: "Call",
  fn: ...,
  arg1: { // this is a nested expression
    ...,
    ast: ast1, // this is AST for the nested expression
  },
  arg2: {
    ...,
    ast: ast2,
  },
  ast: { // this is AST for the outer expression
    type: "Call",
    arg1: ast1, // as you can see, ast1 is duplicated
    arg2: ast2,
  }
```

This branch is done on top of #3268, for merging convenience.

PS: The reduction of expression-related data in the produced JSON bundle, in case of GUCEM codebase, is at least 2x (but might be 5x, hard to tell exactly).