### PR TITLE
Remove DecoratedStatement, store decorators as a flat list in statement nodes

### DIFF
--- a/packages/components/src/components/CodeEditor/languageSupport/autocomplete.tsx
+++ b/packages/components/src/components/CodeEditor/languageSupport/autocomplete.tsx
@@ -28,17 +28,11 @@ export function getNameNodes(tree: Tree, from: number): NameNode[] {
     if (cursor.type.is("Statement") && direction === "sibling") {
       // Only for sibling nodes; `foo = { <cursor> }` shouldn't autocomplete `foo`.
 
-      // Unwrap decorated statements.
-      let node: SyntaxNode | null = cursor.node;
-      while (node && node.type.is("DecoratedStatement")) {
-        node = node.getChild("Statement");
-      }
-
-      const nameNode = node?.getChild("VariableName");
-      if (node && nameNode) {
+      const nameNode = cursor.node.getChild("VariableName");
+      if (nameNode) {
         nameNodes.push({
           node: nameNode,
-          type: node?.type.is("DefunStatement") ? "function" : "variable",
+          type: cursor.node.type.is("DefunStatement") ? "function" : "variable",
         });
       }
     } else if (cursor.type.is("DefunStatement") && direction !== "sibling") {

--- a/packages/components/src/components/CodeEditor/languageSupport/index.ts
+++ b/packages/components/src/components/CodeEditor/languageSupport/index.ts
@@ -61,26 +61,6 @@ export function getLezerParser({
           "Import/*/VariableName",
           "Program/*/LetStatement/VariableName",
           "Program/*/DefunStatement/VariableName",
-          /**
-           * TODO - this is a workaround for Lezer limitation that `*` only
-           * matches a single level.
-           *
-           * We only support up to 3 decorators.
-           *
-           * There might be a better way to do this, e.g. by providing a class
-           * that's used through CSS selectors, but it's complicated.
-           *
-           * I'm also unsure about the performance consequences of this.
-           *
-           * Alternatively, we could just support tooltips on _all_ variable
-           * names.
-           */
-          "Program/*/DecoratedStatement/*/LetStatement/VariableName",
-          "Program/*/DecoratedStatement/*/DecoratedStatement/*/LetStatement/VariableName",
-          "Program/*/DecoratedStatement/*/DecoratedStatement/*/DecoratedStatement/*/LetStatement/VariableName",
-          "Program/*/DecoratedStatement/*/DefunStatement/VariableName",
-          "Program/*/DecoratedStatement/*/DecoratedStatement/*/DefunStatement/VariableName",
-          "Program/*/DecoratedStatement/*/DecoratedStatement/*/DecoratedStatement/*/DefunStatement/VariableName",
         ].join(" ")]: [hoverableTag, t.constant(t.variableName)],
         Identifier: t.variableName,
         Field: t.variableName,

--- a/packages/components/src/components/CodeEditor/languageSupport/squiggle.grammar
+++ b/packages/components/src/components/CodeEditor/languageSupport/squiggle.grammar
@@ -40,8 +40,6 @@ commaSep<content> {
 // when trailing comma is allowed
 commaSep1<content> { "" | content ("," content?)* }
 
-LetStatement { export? VariableName { identifier } "=" expression }
-
 LambdaParameter {
     LambdaParameterName { identifier } (":" expression)?
 }
@@ -49,8 +47,6 @@ LambdaParameter {
 LambdaArgs {
     () | LambdaParameter ("," LambdaParameter)*
 }
-
-DefunStatement { export? VariableName { identifier } ~callOrDeclaration "(" LambdaArgs ")" "=" expression }
 
 Decorator {
     "@" DecoratorName { identifier }
@@ -60,10 +56,13 @@ Decorator {
     )
 }
 
+LetStatement { Decorator* export? VariableName { identifier } "=" expression }
+
+DefunStatement { Decorator* export? VariableName { identifier } ~callOrDeclaration "(" LambdaArgs ")" "=" expression }
+
 statement[@isGroup="Statement"] {
     LetStatement
     | DefunStatement
-    | DecoratedStatement { Decorator statement }
 }
 
 expression {

--- a/packages/components/test/grammar.test.ts
+++ b/packages/components/test/grammar.test.ts
@@ -76,7 +76,7 @@ x = 5
         )
         .toString()
     ).toBe(
-      'Program(DecoratedStatement(Decorator(At,DecoratorName,"(",Argument(String),")"),LetStatement(VariableName,Equals,Number)))'
+      'Program(LetStatement(Decorator(At,DecoratorName,"(",Argument(String),")"),VariableName,Equals,Number))'
     );
   });
 

--- a/packages/hub/src/graphql/types/ModelRevision.ts
+++ b/packages/hub/src/graphql/types/ModelRevision.ts
@@ -36,11 +36,11 @@ function astToVariableNames(ast: ASTNode): string[] {
 
   if (ast.type === "Program") {
     ast.statements.forEach((statement) => {
-      while (statement.type === "DecoratedStatement")
-        statement = statement.statement;
-      if (statement.type === "LetStatement" && statement.exported) {
-        exportedVariableNames.push(statement.variable.value);
-      } else if (statement.type === "DefunStatement" && statement.exported) {
+      if (
+        (statement.type === "LetStatement" ||
+          statement.type === "DefunStatement") &&
+        statement.exported
+      ) {
         exportedVariableNames.push(statement.variable.value);
       }
     });

--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -143,12 +143,6 @@ export function createSquigglePrinter(
             ? content
             : group(["{", indent([line, content]), line, "}"]);
         }
-        case "DecoratedStatement":
-          return [
-            typedPath(node).call(print, "decorator"),
-            hardline,
-            typedPath(node).call(print, "statement"),
-          ];
         case "Decorator":
           return group([
             "@",
@@ -167,6 +161,10 @@ export function createSquigglePrinter(
           ]);
         case "LetStatement":
           return group([
+            node.decorators.map((_, i) => [
+              typedPath(node).call(print, "decorators", i),
+              hardline,
+            ]),
             node.exported ? "export " : "",
             node.variable.value,
             " = ",
@@ -174,6 +172,10 @@ export function createSquigglePrinter(
           ]);
         case "DefunStatement":
           return group([
+            node.decorators.map((_, i) => [
+              typedPath(node).call(print, "decorators", i),
+              hardline,
+            ]),
             node.exported ? "export " : "",
             node.variable.value,
             group([

--- a/packages/prettier-plugin/test/decorators.test.ts
+++ b/packages/prettier-plugin/test/decorators.test.ts
@@ -11,7 +11,8 @@ x=5`)
     ).toBe(`@foo
 @bar(1, 2)
 @baz
-x = 5`);
+x = 5
+`);
   });
 
   test("multiline arguments", async () => {
@@ -28,7 +29,8 @@ x=5`)
   "aweuyraiuweyrlaiuewyriaweyari3"
 )
 @baz
-x = 5`);
+x = 5
+`);
   });
 
   test("on functions", async () => {
@@ -41,6 +43,7 @@ f(x)=x`)
     ).toBe(`@foo
 @bar(1, 2)
 @baz
-f(x) = x`);
+f(x) = x
+`);
   });
 });

--- a/packages/squiggle-lang/__tests__/SqValue/context_test.ts
+++ b/packages/squiggle-lang/__tests__/SqValue/context_test.ts
@@ -41,7 +41,7 @@ z = 5
     assertTag(z, "Number");
 
     expect(nodeToString(z.context!.valueAst, { pretty: false })).toBe(
-      "(LetStatement :z 5)"
+      "(LetStatement :z 5 (Decorator :name 'Z'))"
     );
   });
 });

--- a/packages/squiggle-lang/__tests__/ast/parse_test.ts
+++ b/packages/squiggle-lang/__tests__/ast/parse_test.ts
@@ -481,7 +481,7 @@ describe("Peggy parse", () => {
   });
 
   describe("Exports", () => {
-    testParse("export x = 5", "(Program (LetStatement export :x 5))");
+    testParse("export x = 5", "(Program (LetStatement :x 5 exported))");
     testParse("exportx = 5", "(Program (LetStatement :exportx 5))");
   });
 
@@ -498,7 +498,7 @@ x = 5
 @baz
 f(x) = x
 `,
-      "(Program (DecoratedStatement (Decorator :foo) (DecoratedStatement (Decorator :bar 1 2) (DecoratedStatement (Decorator :baz) (LetStatement :x 5)))) (DecoratedStatement (Decorator :foo) (DecoratedStatement (Decorator :bar 1 2) (DecoratedStatement (Decorator :baz) (DefunStatement :f (Lambda :x :x))))))"
+      "(Program (LetStatement :x 5 (Decorator :foo) (Decorator :bar 1 2) (Decorator :baz)) (DefunStatement :f (Lambda :x :x) (Decorator :foo) (Decorator :bar 1 2) (Decorator :baz)))"
     );
   });
 });

--- a/packages/squiggle-lang/__tests__/library/tag_test.ts
+++ b/packages/squiggle-lang/__tests__/library/tag_test.ts
@@ -36,7 +36,7 @@ describe("Tags", () => {
 a = 3
 Tag.getLocation(a)
 `,
-      '{source: "main", start: {line: 2, column: 1, offset: 10}, end: {line: 2, column: 6, offset: 15}}'
+      '{source: "main", start: {line: 1, column: 1, offset: 0}, end: {line: 2, column: 6, offset: 15}}'
     );
   });
 

--- a/packages/squiggle-lang/src/ast/parse.ts
+++ b/packages/squiggle-lang/src/ast/parse.ts
@@ -93,16 +93,14 @@ export function nodeToString(
         return sExpr([...node.args, node.body].map(toSExpr));
       case "Decorator":
         return sExpr([node.name, ...node.args].map(toSExpr));
-      case "DecoratedStatement":
-        return sExpr([node.decorator, node.statement].map(toSExpr));
       case "LetStatement":
+      case "DefunStatement":
         return sExpr([
-          node.exported ? "export" : undefined,
           toSExpr(node.variable),
           toSExpr(node.value),
+          node.exported ? "exported" : undefined,
+          ...node.decorators.map(toSExpr),
         ]);
-      case "DefunStatement":
-        return sExpr([node.variable, node.value].map(toSExpr));
       case "String":
         return `'${node.value}'`; // TODO - quote?
       case "Ternary":

--- a/packages/squiggle-lang/src/ast/peggyParser.peggy
+++ b/packages/squiggle-lang/src/ast/peggyParser.peggy
@@ -50,36 +50,27 @@ quotedInnerBlock
     '}'
     { return h.nodeBlock([finalExpression], location()); }
 
-statementsList = decoratedStatement|1.., statementSeparator|
+statementsList = statement|1.., statementSeparator|
 
-decoratedStatement
-  = decorator:decorator statement:decoratedStatement
+decorator
+  = '@' name:dollarIdentifier args:(_ '(' _nl @functionArguments _nl ')')?  __nl
     {
-      return h.nodeDecoratedStatement(decorator, statement, location())
+      return h.nodeDecorator(name, args ?? [], location());
     }
-  / letStatement
-  / defunStatement
-
-  decorator
-    = '@' name:dollarIdentifier args:(_ '(' _nl @functionArguments _nl ')')?  __nl
-      {
-        return h.nodeDecorator(name, args ?? [], location());
-      }
 
 statement
-  = decoratedStatement
-  / letStatement
+  = letStatement
   / defunStatement
 
 letStatement
-  = exported:("export" __nl)? variable:dollarIdentifier _ assignmentOp _nl value:innerBlockOrExpression
-    { return h.nodeLetStatement(variable, value, Boolean(exported), location()); }
+  = decorators:decorator* exported:("export" __nl)? variable:dollarIdentifier _ assignmentOp _nl value:innerBlockOrExpression
+    { return h.nodeLetStatement(decorators, variable, value, Boolean(exported), location()); }
 
 defunStatement
-  = exported:("export" __nl)? variable:dollarIdentifier '(' _nl args:functionParameters _nl ')' _ assignmentOp _nl body:innerBlockOrExpression
+  = decorators:decorator* exported:("export" __nl)? variable:dollarIdentifier '(' _nl args:functionParameters _nl ')' _ assignmentOp _nl body:innerBlockOrExpression
     {
       const value = h.nodeLambda(args, body, location(), variable);
-      return h.nodeDefunStatement(variable, value, Boolean(exported), location());
+      return h.nodeDefunStatement(decorators, variable, value, Boolean(exported), location());
     }
 
   assignmentOp "assignment" = '='

--- a/packages/squiggle-lang/src/ast/serialize.ts
+++ b/packages/squiggle-lang/src/ast/serialize.ts
@@ -72,16 +72,11 @@ export function serializeAstNode(
         ...node,
         statements: node.statements.map(visit.ast),
       };
-    case "DecoratedStatement":
-      return {
-        ...node,
-        decorator: visit.ast(node.decorator),
-        statement: visit.ast(node.statement),
-      };
     case "LetStatement":
     case "DefunStatement":
       return {
         ...node,
+        decorators: node.decorators.map(visit.ast),
         variable: visit.ast(node.variable),
         value: visit.ast(node.value),
       };
@@ -206,21 +201,17 @@ export function deserializeAstNode(
         ...node,
         statements: node.statements.map(visit.ast),
       };
-    case "DecoratedStatement":
-      return {
-        ...node,
-        decorator: visit.ast(node.decorator) as TypedNode<"Decorator">,
-        statement: visit.ast(node.statement) as TypedNode<"LetStatement">,
-      };
     case "LetStatement":
       return {
         ...node,
+        decorators: node.decorators.map(visit.ast) as TypedNode<"Decorator">[],
         variable: visit.ast(node.variable) as TypedNode<"Identifier">,
         value: visit.ast(node.value),
       };
     case "DefunStatement":
       return {
         ...node,
+        decorators: node.decorators.map(visit.ast) as TypedNode<"Decorator">[],
         variable: visit.ast(node.variable) as TypedNode<"Identifier">,
         value: visit.ast(node.value) as NamedNodeLambda,
       };

--- a/packages/squiggle-lang/src/ast/types.ts
+++ b/packages/squiggle-lang/src/ast/types.ts
@@ -170,6 +170,7 @@ type NodeDecorator = N<
 >;
 
 type LetOrDefun = {
+  decorators: NodeDecorator[];
   variable: NodeIdentifier;
   exported: boolean;
 };
@@ -185,14 +186,6 @@ type NodeDefunStatement = N<
   "DefunStatement",
   LetOrDefun & {
     value: NamedNodeLambda;
-  }
->;
-
-type NodeDecoratedStatement = N<
-  "DecoratedStatement",
-  {
-    decorator: NodeDecorator;
-    statement: NodeLetStatement | NodeDefunStatement | NodeDecoratedStatement;
   }
 >;
 
@@ -227,7 +220,6 @@ export type ASTNode =
   | NodeProgram
   | NodeBlock
   // statements
-  | NodeDecoratedStatement
   | NodeLetStatement
   | NodeDefunStatement
   // functions & lambdas

--- a/packages/squiggle-lang/src/ast/utils.ts
+++ b/packages/squiggle-lang/src/ast/utils.ts
@@ -6,20 +6,8 @@ export function locationContains(location: LocationRange, offset: number) {
 
 export function isBindingStatement(
   statement: ASTNode
-): statement is Extract<
-  ASTNode,
-  { type: "LetStatement" | "DefunStatement" | "DecoratedStatement" }
-> {
+): statement is Extract<ASTNode, { type: "LetStatement" | "DefunStatement" }> {
   return (
-    statement.type === "LetStatement" ||
-    statement.type === "DefunStatement" ||
-    statement.type === "DecoratedStatement"
+    statement.type === "LetStatement" || statement.type === "DefunStatement"
   );
-}
-
-export function undecorated(node: ASTNode) {
-  while (node.type === "DecoratedStatement") {
-    node = node.statement;
-  }
-  return node;
 }

--- a/packages/squiggle-lang/src/public/SqValueContext.ts
+++ b/packages/squiggle-lang/src/public/SqValueContext.ts
@@ -43,8 +43,6 @@ export class SqValueContext {
           ast = ast.statements[ast.statements.length - 1];
         } else if (ast.type === "KeyValue") {
           ast = ast.value;
-        } else if (ast.type === "DecoratedStatement") {
-          ast = ast.statement;
         } else if (isBindingStatement(ast)) {
           ast = ast.value;
         } else {


### PR DESCRIPTION
This is done on top of #3312. It fixes an annoying workaround in syntax highlighting there, as well as simplifies some other things.

The basic idea is the following: previously, we parsed `@hide @name("foo") x = 5` as `DecoratedStatement decorator (DecoratedStatement decorator (LetStatement x 5))`. Now we store it as `(LetStatement x 5 [decorator list])`.

The benefits: 
- we don't have to unwrap decorator statements in several places in our codebase
- styling in components is simplified and more robust

There are some minor user-facing consequences from this:
- when you click on the variable name in viewer, the position in the editor will include the full AST node, including the decorators
- `Tag.location` also stores the full AST node location, starting from the first decorator (in fact, the assignment without decorators doesn't even have its own location now; but you can extract the value or variable node from it trivially, if necessary)