### PR TITLE
Fix ast serialization for unit types; improve runners error handling

### DIFF
--- a/packages/prettier-plugin/src/printer.ts
+++ b/packages/prettier-plugin/src/printer.ts
@@ -168,7 +168,8 @@ export function createSquigglePrinter(
             node.exported ? "export " : "",
             node.variable.value,
             node.unitTypeSignature
-              ? typedPath(node).call(print, "unitTypeSignature")
+              ? // @ts-ignore
+                [" :: ", typedPath(node).call(print, "unitTypeSignature")]
               : "",
             " = ",
             typedPath(node).call(print, "value"),
@@ -192,7 +193,7 @@ export function createSquigglePrinter(
             ]),
             node.value.returnUnitType
               ? // @ts-ignore
-                typedPath(node).call(print, "value", "returnUnitType")
+                [" :: ", typedPath(node).call(print, "value", "returnUnitType")]
               : "",
             " = ",
             typedPath(node).call(print, "value", "body"),
@@ -291,7 +292,7 @@ export function createSquigglePrinter(
             node.value,
             node.unitTypeSignature
               ? // @ts-ignore
-                typedPath(node).call(print, "unitTypeSignature")
+                [" :: ", typedPath(node).call(print, "unitTypeSignature")]
               : "",
           ]);
         case "IdentifierWithAnnotation":
@@ -340,7 +341,7 @@ export function createSquigglePrinter(
             "}",
             node.returnUnitType
               ? // @ts-ignore
-                typedPath(node).call(print, "returnUnitType")
+                [" :: ", typedPath(node).call(print, "returnUnitType")]
               : "",
           ]);
         case "Dict": {
@@ -374,7 +375,7 @@ export function createSquigglePrinter(
             path.call(print, "falseExpression"),
           ];
         case "UnitTypeSignature":
-          return group([" :: ", typedPath(node).call(print, "body")]);
+          return typedPath(node).call(print, "body");
         case "InfixUnitType":
           return group([
             typedPath(node).call(print, "args", 0),

--- a/packages/squiggle-lang/__tests__/serialization_test.ts
+++ b/packages/squiggle-lang/__tests__/serialization_test.ts
@@ -1,4 +1,5 @@
 import { SampleSetDist } from "../src/dists/SampleSetDist/index.js";
+import { run } from "../src/run.js";
 import { squiggleCodec } from "../src/serialization/squiggle.js";
 import { isEqual, Value, vBool, vDist, vString } from "../src/value/index.js";
 import { vNumber } from "../src/value/VNumber.js";
@@ -32,7 +33,25 @@ describe("Serialization tests", () => {
       vDist(SampleSetDist.make([3, 1, 4, 1, 5, 9, 2, 6]).value as any)
     );
   });
-  // TODO - test lambdas
+
+  test("lambda", async () => {
+    const bindings = (
+      await run(`runTest() = {
+  t = 1
+  3
+}`)
+    ).getBindings();
+    if (!bindings.ok) {
+      throw bindings.value;
+    }
+
+    const lambda = bindings.value.get("runTest");
+    if (!lambda) {
+      throw new Error("No lambda");
+    }
+    const lambda2 = serializeAndDeserialize(lambda?._value);
+    expect(lambda2).toBeDefined();
+  });
 
   test("with tags", () => {
     let value = vNumber(5);

--- a/packages/squiggle-lang/src/ast/peggyHelpers.ts
+++ b/packages/squiggle-lang/src/ast/peggyHelpers.ts
@@ -253,7 +253,7 @@ export function nodeLambda(
 export function nodeLetStatement(
   decorators: KindNode<"Decorator">[],
   variable: KindNode<"Identifier">,
-  unitTypeSignature: KindNode<"UnitTypeSignature">,
+  unitTypeSignature: KindNode<"UnitTypeSignature"> | null,
   value: ASTNode,
   exported: boolean,
   location: LocationRange
@@ -264,7 +264,7 @@ export function nodeLetStatement(
     kind: "LetStatement",
     decorators,
     variable,
-    unitTypeSignature,
+    unitTypeSignature: unitTypeSignature ?? null,
     value: patchedValue,
     exported,
     location,

--- a/packages/squiggle-lang/src/ast/serialize.ts
+++ b/packages/squiggle-lang/src/ast/serialize.ts
@@ -77,7 +77,9 @@ export function serializeAstNode(
         ...node,
         decorators: node.decorators.map(visit.ast),
         variable: visit.ast(node.variable),
-        unitTypeSignature: visit.ast(node.unitTypeSignature),
+        unitTypeSignature: node.unitTypeSignature
+          ? visit.ast(node.unitTypeSignature)
+          : null,
         value: visit.ast(node.value),
       };
     case "DefunStatement":
@@ -220,7 +222,7 @@ export function deserializeAstNode(
         ...node,
         imports: node.imports.map((item) => [
           visit.ast(item[0]) as KindNode<"String">,
-          visit.ast(item[0]) as KindNode<"Identifier">,
+          visit.ast(item[1]) as KindNode<"Identifier">,
         ]),
         statements: node.statements.map(visit.ast),
         symbols: Object.fromEntries(
@@ -240,9 +242,12 @@ export function deserializeAstNode(
         ...node,
         decorators: node.decorators.map(visit.ast) as KindNode<"Decorator">[],
         variable: visit.ast(node.variable) as KindNode<"Identifier">,
-        unitTypeSignature: visit.ast(
-          node.unitTypeSignature
-        ) as KindNode<"UnitTypeSignature">,
+        unitTypeSignature:
+          node.unitTypeSignature !== null
+            ? (visit.ast(
+                node.unitTypeSignature
+              ) as KindNode<"UnitTypeSignature">)
+            : null,
         value: visit.ast(node.value),
       };
     case "DefunStatement":

--- a/packages/squiggle-lang/src/ast/types.ts
+++ b/packages/squiggle-lang/src/ast/types.ts
@@ -187,7 +187,7 @@ type LetOrDefun = {
 type NodeLetStatement = N<
   "LetStatement",
   LetOrDefun & {
-    unitTypeSignature: NodeTypeSignature;
+    unitTypeSignature: NodeTypeSignature | null;
     value: ASTNode;
   }
 >;

--- a/packages/squiggle-lang/src/ast/unitTypeChecker.ts
+++ b/packages/squiggle-lang/src/ast/unitTypeChecker.ts
@@ -170,7 +170,7 @@ function subConstraintToString(
 }
 
 /* Create a TypeConstraint object from a type signature. */
-function createTypeConstraint(node?: ASTNode): TypeConstraint {
+function createTypeConstraint(node: ASTNode | null): TypeConstraint {
   if (!node) {
     return no_constraint();
   }

--- a/packages/squiggle-lang/src/public/SqProject/SqModuleOutput.ts
+++ b/packages/squiggle-lang/src/public/SqProject/SqModuleOutput.ts
@@ -168,7 +168,18 @@ export class SqModuleOutput {
     };
 
     const started = new Date();
-    const runResult = await params.runner.run(runParams);
+    let runResult;
+    try {
+      runResult = await params.runner.run(runParams);
+    } catch (e) {
+      return new SqModuleOutput({
+        module,
+        environment,
+        result: Err(new SqOtherError(String(e))),
+        executionTime: new Date().getTime() - started.getTime(),
+      });
+    }
+
     const executionTime = new Date().getTime() - started.getTime();
 
     // patch profile - add timings for import statements

--- a/packages/squiggle-lang/src/runners/AnyWorkerRunner.ts
+++ b/packages/squiggle-lang/src/runners/AnyWorkerRunner.ts
@@ -18,17 +18,21 @@ export async function runWithWorker(
     externalsEntrypoint,
   } satisfies SquiggleWorkerJob);
 
-  return new Promise<RunResult>((resolve) => {
+  return new Promise<RunResult>((resolve, reject) => {
     worker.addEventListener(
       "message",
       (e: MessageEvent<SquiggleWorkerResponse>) => {
         if (e.data.type === "internal-error") {
-          throw new Error(`Internal worker error: ${e.data.payload}`);
+          reject(new Error(`Internal worker error: ${e.data.payload}`));
+          return;
         }
         if (e.data.type !== "result") {
-          throw new Error(
-            `Unexpected message ${JSON.stringify(e.data)} from worker`
+          reject(
+            new Error(
+              `Unexpected message ${JSON.stringify(e.data)} from worker`
+            )
           );
+          return;
         }
         const { payload } = e.data;
 

--- a/packages/squiggle-lang/src/runners/PoolRunner.ts
+++ b/packages/squiggle-lang/src/runners/PoolRunner.ts
@@ -23,6 +23,7 @@ export class RunnerPool {
         Boolean(thread.runner && !thread.job)
     );
     if (unusedThread) {
+      // TODO - try/catch, kill worker if it errors
       unusedThread.job = unusedThread.runner.run(params);
       const result = await unusedThread.job;
       unusedThread.job = undefined;

--- a/packages/squiggle-lang/src/runners/worker.ts
+++ b/packages/squiggle-lang/src/runners/worker.ts
@@ -57,7 +57,7 @@ addEventListener("message", (e: MessageEvent<SquiggleWorkerJob>) => {
   } catch (e) {
     postTypedMessage({
       type: "internal-error",
-      payload: String(e),
+      payload: e instanceof Error ? e.stack ?? String(e) : String(e),
     });
   }
 });


### PR DESCRIPTION
Fixes #3334.

(caused by Peggy producing null unit nodes which were marked as non-nullable in TypeScript, which broke serialization)