### PR TITLE
Fix error location reporting

### DIFF
--- a/packages/squiggle-lang/__tests__/errors_test.ts
+++ b/packages/squiggle-lang/__tests__/errors_test.ts
@@ -1,9 +1,29 @@
 import { ErrorMessage } from "../src/errors/messages.js";
+import { run } from "../src/run.js";
 
 describe("errors", () => {
   test("otherError", () => {
     const error = ErrorMessage.otherError("hello");
     expect(error.toString()).toEqual("Error: hello");
     expect(error.message).toEqual("Error: hello");
+  });
+});
+
+describe("SqError.location", () => {
+  test("returns undefined for empty stack traces", async () => {
+    const result = await run(`a = []
+f() = a[0]
+
+x = f()
+`);
+    expect(result.result.ok).toBe(false);
+    if (result.result.ok) {
+      throw new Error("Expected code to fail");
+    }
+    const error = result.result.value.errors[0];
+    if (error.tag !== "runtime") {
+      throw new Error("Expected error to be a runtime error");
+    }
+    expect(error.location()?.start).toMatchObject({ line: 2, column: 7 });
   });
 });

--- a/packages/squiggle-lang/src/errors/IError.ts
+++ b/packages/squiggle-lang/src/errors/IError.ts
@@ -123,10 +123,6 @@ export class IRuntimeError extends Error {
     );
   }
 
-  getTopFrame(): StackTraceFrame | undefined {
-    return this.stackTrace.frames.at(-1);
-  }
-
   getFrameArray(): StackTraceFrame[] {
     return this.stackTrace.frames;
   }

--- a/packages/squiggle-lang/src/public/SqError.ts
+++ b/packages/squiggle-lang/src/public/SqError.ts
@@ -1,3 +1,4 @@
+import { LocationRange } from "../ast/types.js";
 import { ICompileError, IError, IRuntimeError } from "../errors/IError.js";
 import { StackTraceFrame } from "../reducer/StackTrace.js";
 import { Import } from "./SqProject/SqModule.js";
@@ -52,18 +53,13 @@ export class SqRuntimeError extends SqAbstractError<"runtime"> {
     });
   }
 
-  private getTopFrame(): SqFrame | undefined {
-    const frame = this._value.getTopFrame();
-    return frame ? new SqFrame(frame) : undefined;
-  }
-
   getFrameArray(): SqFrame[] {
     const frames = this._value.getFrameArray();
     return frames.map((frame) => new SqFrame(frame));
   }
 
-  location() {
-    return this.getTopFrame()?.location();
+  location(): LocationRange | undefined {
+    return this._value.stackTrace.getTopLocation();
   }
 }
 


### PR DESCRIPTION
Error location red line in editor was broken since 0.9.4; it highlighted the topmost location on stack:

https://www.squiggle-language.com/playground?v=0.9.4#code=eNqrVkpJTUsszSlxzk9JVbJSSlSwVYiOjclL09AEshKjDYDsmLwKIBsoEpOnVAsAhU8PAg%3D%3D

Caused by my changes around #3054; StackTrace frames go in the opposite direction compared to FrameStack frames.