### PR TITLE
Improved search/replace logic, to protect against llm errors

### DIFF
--- a/packages/ai/.gitignore
+++ b/packages/ai/.gitignore
@@ -1,1 +1,2 @@
 /dist
+.env

--- a/packages/ai/__tests__/searchReplace_test.ts
+++ b/packages/ai/__tests__/searchReplace_test.ts
@@ -131,11 +131,6 @@ Replacement text
     @name("📊 Growth Rate Validation Test")
     growthRateTest = sTest.test("Growth rate should be within reasonable bounds", {
     >>>>>>> REPLACE
-      ||
-      meanValue = mean(growthRate)
-      sTest.expect(meanValue).toBeGreaterThan(0) && sTest.expect(meanValue).toBeLessThan(0.05)
-    }
-    >>>>>>> REPLACE
     <<<<<<< SEARCH
     totalPopulationProjection = List.upTo(2023, 2043)
       -> List.map({|year| {year: year, population: projectedPopulation(Date(year))}})
@@ -250,7 +245,7 @@ testSuite = sTest.describe(
 
       expect(result.success).toBe(false);
       expect(result.value).toBe(
-        "SEARCH/REPLACE syntax not correctly formatted"
+        "SEARCH/REPLACE error: Mismatched block count: SEARCH (1), REPLACE (0), separators (2)"
       );
     });
   });

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -29,7 +29,7 @@ Think step-by-step and explain the needed changes in a few short sentences.
 
 1. Use <<<<<<< SEARCH to start the search section.
 2. Include only the exact lines to be replaced, with surrounding context if needed for uniqueness. Use the exact same text as in the original code, do not change it at all.
-3. Use ======= as a divider between search and replace sections.
+3. Use ======= as a single divider between search and replace sections.
 4. Provide the new or modified code in the replace section.
 5. Use >>>>>>> REPLACE to end the replace section.
 6. For new files, use an empty SEARCH section.
@@ -40,6 +40,8 @@ If the file contains code or other data wrapped/escaped in json/xml/quotes or ot
 *SEARCH/REPLACE* blocks will replace *all* matching occurrences.
 Include enough lines to make the SEARCH blocks uniquely match the lines to change.
 
+IMPORTANT: Ensure that each SEARCH/REPLACE block is properly formatted with line breaks for readability. Do not put the entire block on a single line.
+
 Keep *SEARCH/REPLACE* blocks concise.
 Break large *SEARCH/REPLACE* blocks into a series of smaller blocks that each change a small portion of the file.
 Include just the changing lines, and a few surrounding lines if needed for uniqueness.
@@ -47,7 +49,7 @@ Do not include long runs of unchanging lines in *SEARCH/REPLACE* blocks.
 
 To move code within a file, use 2 *SEARCH/REPLACE* blocks: 1 to delete it from its current location, 1 to insert it in the new location.
 
-Example:
+Example of correct format:
 
 <explanation>
 Brief explanation of changes (1-2 sentences max)


### PR DESCRIPTION
We were getting errors with REPLACE blocks failing, and then that not being detected - this seeks to help a bit. 