### PR TITLE
404 on access to private models

### DIFF
--- a/packages/hub/src/app/models/[owner]/[slug]/EditModelPage.tsx
+++ b/packages/hub/src/app/models/[owner]/[slug]/EditModelPage.tsx
@@ -36,6 +36,7 @@ export const EditModelPage: FC<{
     `,
     query
   );
+
   const model = extractFromGraphqlErrorUnion(result, "Model");
   const typename = model.currentRevision.content.__typename;
 

--- a/packages/hub/src/app/not-found.tsx
+++ b/packages/hub/src/app/not-found.tsx
@@ -1,6 +1,4 @@
 export default function NotFound() {
-  // Note: Next.js (13.4.9) in dev mode doesn't reload this page correctly.
-  // Restart `next dev` process if you edit this component.
   return (
     <div className="grid flex-1 place-items-center">
       <div className="flex h-10 items-center gap-4">


### PR DESCRIPTION
Closes #3414.

Unfortunately I had to settle on the generic 404, couldn't do your suggestion about a detailed error: 

> I think we should change the latter page to say something like,
> 
> ```
> 404: Resource Not Accessible
> 
> The requested model could not be retrieved or accessed with your current user permissions. This response is returned for both non-existent resources and those requiring access to maintain security.
> 
> What you can do:
> 1. Verify the URL is correct
> 2. Check your account permissions
> ```

That's because of Next.js limitations: `not-found.tsx` doesn't work on dynamic pages (there are several issues and discussions in Next.js repo on that), and `notFound()` -> `not-found.tsx` is the only way to return 404 HTTP status that I can think of.