### PR TITLE
Merges adjacent strings in notebooks

### DIFF
--- a/packages/components/src/stories/MarkdownViewer.stories.tsx
+++ b/packages/components/src/stories/MarkdownViewer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps } from "react";
 
 import { MarkdownViewer } from "../lib/MarkdownViewer.js";
 
@@ -9,7 +10,7 @@ import { MarkdownViewer } from "../lib/MarkdownViewer.js";
  * It's used for rendering docstrings, calculator descriptions, and builtin
  * function documentation.
  */
-const meta = {
+const meta: Meta<ComponentProps<typeof MarkdownViewer>> = {
   component: MarkdownViewer,
 } as const satisfies Meta<typeof MarkdownViewer>;
 export default meta;

--- a/packages/components/src/stories/MarkdownViewer.stories.tsx
+++ b/packages/components/src/stories/MarkdownViewer.stories.tsx
@@ -11,7 +11,7 @@ import { MarkdownViewer } from "../lib/MarkdownViewer.js";
  */
 const meta = {
   component: MarkdownViewer,
-} satisfies Meta<typeof MarkdownViewer>;
+} as const satisfies Meta<typeof MarkdownViewer>;
 export default meta;
 type Story = StoryObj<typeof meta>;
 

--- a/packages/components/src/stories/SquigglePlayground.stories.tsx
+++ b/packages/components/src/stories/SquigglePlayground.stories.tsx
@@ -251,6 +251,9 @@ Here is more text.",
   " ### This is an opening section
 Here is more text.
 ",
+  "- bullet 1",
+  "- bullet 2",
+  "- bullet 3",
 ]
 
 notebook = notNotebook -> Tag.notebook

--- a/packages/components/src/widgets/ArrayWidget.tsx
+++ b/packages/components/src/widgets/ArrayWidget.tsx
@@ -44,9 +44,9 @@ widgetRegistry.register("Array", {
     );
   },
   Chart: (value) => {
-    const values = useMemo(() => value.value.getValues(), [value]);
+    const values: SqValue[] = useMemo(() => value.value.getValues(), [value]);
 
-    const compressedValues = useMemo(() => {
+    const compressedValues: SqValue[] = useMemo(() => {
       if (!isNotebook(value)) return values;
       return compressStringValues(values);
     }, [values, value]);

--- a/packages/components/src/widgets/ArrayWidget.tsx
+++ b/packages/components/src/widgets/ArrayWidget.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from "react";
 
+import { SqStringValue, SqValue } from "@quri/squiggle-lang";
 import { DocumentTextIcon } from "@quri/ui";
 
+import { vString } from "../../../squiggle-lang/src/value/VString.js";
 import { ValueViewer } from "../components/SquiggleViewer/ValueViewer/index.js";
 import { SqValueWithContext } from "../lib/utility.js";
 import { widgetRegistry } from "./registry.js";
@@ -10,6 +12,26 @@ import { SqTypeWithCount } from "./SqTypeWithCount.js";
 function isNotebook(value: SqValueWithContext) {
   return Boolean(value.tags.notebook());
 }
+
+// Combines adjacent string values into a single string value. Helps with rendering in notebooks, so that there aren't unecessary breaks between strings.
+const compressStringValues = (values: SqValue[]): SqValue[] => {
+  return values.reduce((acc: SqValue[], curr) => {
+    // If current and previous are strings, combine them
+    if (
+      curr.tag === "String" &&
+      acc.length > 0 &&
+      acc[acc.length - 1].tag === "String"
+    ) {
+      acc[acc.length - 1] = new SqStringValue(
+        vString(acc[acc.length - 1].value + "\n" + curr.value),
+        acc[acc.length - 1].context
+      );
+      return acc;
+    }
+    // Otherwise add the current value as is
+    return [...acc, curr];
+  }, []);
+};
 
 widgetRegistry.register("Array", {
   heading: (value) => `List(${value.value.getValues().length})`,
@@ -23,9 +45,15 @@ widgetRegistry.register("Array", {
   },
   Chart: (value) => {
     const values = useMemo(() => value.value.getValues(), [value]);
+
+    const compressedValues = useMemo(() => {
+      if (!isNotebook(value)) return values;
+      return compressStringValues(values);
+    }, [values, value]);
+
     return (
       <div className="mt-0.5 space-y-1 pt-0.5">
-        {values.map((r, i) => (
+        {compressedValues.map((r, i) => (
           <ValueViewer
             parentValue={value}
             key={i}


### PR DESCRIPTION
Previously, having this in a notebook:
```
  "- bullet 1",
  "- bullet 2",
  "- bullet 3",
```

Would lead to there being three very far-apart bullets. Now this converts them into the markdown:
```
- bullet 1
- bullet 2
- bullet 3
```

This helps with summaries, which are used heavily by the Squiggle AI.

One difficult thing with it is that it kind of messes with the Context. I wasn't sure how to best go about this part.