### PR TITLE
Fix squiggle-lang workers in hub

### DIFF
--- a/packages/squiggle-lang/package.json
+++ b/packages/squiggle-lang/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm run build:peggy && pnpm run build:ts && pnpm run build:worker",
     "build:peggy": "peggy --cache --format es ./src/ast/peggyParser.peggy",
     "build:ts": "tsc -b",
-    "build:worker": "esbuild src/runners/worker.ts --bundle --minify --platform=browser --outfile=dist/runners/esbuild-worker.cjs",
+    "build:worker": "esbuild src/runners/worker.ts --bundle --minify --platform=browser --format=esm --outfile=dist/runners/esbuild-worker.js",
     "dev": "tsc -b -w",
     "clean": "rm -rf dist && rm -f src/ast/peggyParser.js && rm *.tsbuildinfo",
     "jest": "NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/squiggle-lang/src/runners/WebWorkerRunner.ts
+++ b/packages/squiggle-lang/src/runners/WebWorkerRunner.ts
@@ -14,18 +14,8 @@ export class WebWorkerRunner extends AnyWorkerRunner {
      * If you need to touch this code, make sure to check carefully both the components (storybook) and the hub editor.
      * This configuration and the esbuild configuration in `package.json` are extremely fragile.
      *
-     * In particular:
-     * 1. ESM is problematic:`{ type: "module" }` (with `.mjs` or `.js`)will seemingly work, but cause lots of Turbopack CLI errors; Turbopack fails to analyze `(url, { type: "module" })` parameters correctly, as of Next.js 15.0.3.
-     * 2. `.js` extension will collide with the default `"type": "module"` in `package.json`, which will lead to Next.js warnings.
-     *
-     * So, instead, we bundle the worker to the basic IIFE; see `package.json` for details.
-     *
-     * This might cause issues in the future, if we decide to depend on some library that's ESM-only; I'm not sure how good esbuild is for bundling ESM dependencies.
-     *
-     * But, for now, it seems like it's working.
+     * Details here: https://github.com/quantified-uncertainty/squiggle/pull/3456
      */
-
-    // Note: the version below is configured to work for pre-turbopack next.js in dev and prod.
     this.worker = new Worker(new URL("./esbuild-worker.js", import.meta.url), {
       type: "module",
     });

--- a/packages/squiggle-lang/src/runners/WebWorkerRunner.ts
+++ b/packages/squiggle-lang/src/runners/WebWorkerRunner.ts
@@ -24,8 +24,11 @@ export class WebWorkerRunner extends AnyWorkerRunner {
      *
      * But, for now, it seems like it's working.
      */
-    const url = new URL("./esbuild-worker.cjs", import.meta.url);
-    this.worker = new Worker(url);
+
+    // Note: the version below is configured to work for pre-turbopack next.js in dev and prod.
+    this.worker = new Worker(new URL("./esbuild-worker.js", import.meta.url), {
+      type: "module",
+    });
   }
 
   async getWorker(): Promise<Worker> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20965,7 +20965,7 @@ snapshots:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -21873,7 +21873,7 @@ snapshots:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.28.1(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.5.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.28.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.57.0)
       eslint-plugin-react: 7.33.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -21896,7 +21896,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.15.0
       eslint: 8.57.0
-      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.5.3)(eslint@8.57.0)
+      eslint-plugin-import: 2.28.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.28.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       get-tsconfig: 4.7.5
       globby: 13.1.3
       is-core-module: 2.13.1
@@ -21916,7 +21916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.5.3)(eslint@8.57.0):
+  eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.20.0(eslint@8.57.0)(typescript@5.6.3))(eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.28.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -23661,7 +23661,7 @@ snapshots:
       create-jest: 29.7.0(babel-plugin-macros@3.1.0)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@22.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@20.12.7)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2


### PR DESCRIPTION
The annoying downside of this PR is that it will spam the server logs with errors in dev mode:

```
error TP1001 new Worker(./esbuild-worker.js relative, {"type": "module"}) is not statically analyse-able
   6 |         }
   7 |         super();
>  8 |         this.worker = new Worker(new URL("./esbuild-worker.js", import.meta.url), {
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>  9 |             type: "module",
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 10 |         });
     | ^^^^^^^^^^^
  11 |     }
```

These errors are caused by turbopack, which is unable to analyze two-arg version of `new Worker`. ([source here](https://github.com/vercel/next.js/blob/5b7833e3da2b22e45e5b13c7001d4d728d093133/turbopack/crates/turbopack-ecmascript/src/references/mod.rs#L1416), but I can't say I understand how exactly pattern-matching is implemented, and it's not documented anywhere).

The closest issue I could find in Next.js is this: https://github.com/vercel/next.js/issues/72397; note that https://github.com/vercel/next.js/issues/72397#issuecomment-2468173281 specifically mentions the `{ type: "module" }`, which causes errors.

The version without `{ type: "module" }` would work if I compile the worker to `esbuild-worker.cjs`, and that's how I tried to do it previously, but `.cjs` files don't work on Vercel (they're served with the wrong content-type).

If there's no `.cjs` extension, and no `{ type: "module" }`, then turbopack, and I think webpack too, would still interpret the worker URL to be a module (probably because squiggle-lang is an ESM package, configured with `"type": "module"` in `package.json`), and inject "import" statements in dev, which then breaks the worker when the browser tries to run it, because the worker constructor didn't ask for it be to be a module.

There might be some combination of esbuild parameters that would solve it, but I couldn't find it.

To reiterate, these errors don't prevent `next dev --turbo` from functioning. The only issue that I can find is console errors, and I hope that those will be fixed on turbopack side eventually.