### PR TITLE
Fix "Failed to create bin" warnings

### DIFF
--- a/packages/squiggle-lang/bin/squiggle.js
+++ b/packages/squiggle-lang/bin/squiggle.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../dist/cli/index.js";

--- a/packages/squiggle-lang/package.json
+++ b/packages/squiggle-lang/package.json
@@ -71,6 +71,7 @@
   },
   "files": [
     "dist",
+    "bin",
     "src",
     "!**/tsconfig*.tsbuildinfo",
     "!**/__tests__"
@@ -84,6 +85,6 @@
     "./runners/WebWorkerRunner": "./dist/runners/WebWorkerRunner.js"
   },
   "bin": {
-    "squiggle": "./dist/cli/index.js"
+    "squiggle": "./bin/squiggle.js"
   }
 }


### PR DESCRIPTION
Recipe from https://webpro.nl/scraps/compiled-bin-in-typescript-monorepo and https://github.com/pnpm/pnpm/issues/1801.

It wasn't causing any problems, but we had these annoying warnings in build logs that this PR will fix:
```
 WARN  Failed to create bin at /vercel/path0/apps/website/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/internal-packages/ai/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/apps/hub/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/internal-packages/content/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/packages/components/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/internal-packages/versioned-components/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/packages/prettier-plugin/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
 WARN  Failed to create bin at /vercel/path0/packages/vscode-ext/node_modules/.bin/squiggle. ENOENT: no such file or directory, open '/vercel/path0/packages/squiggle-lang/dist/cli/index.js'
```