### PR TITLE
AI workflow error handling

### DIFF
--- a/apps/hub/src/ai/data/storage.ts
+++ b/apps/hub/src/ai/data/storage.ts
@@ -31,10 +31,18 @@ export function decodeDbWorkflowToClientWorkflow(
     return {
       id: row.id,
       timestamp: row.createdAt.getTime(),
-      status: "error",
+      status: "finished",
       inputs: {},
       steps: [],
-      result: `Invalid workflow format in the database: ${e}`,
+      result: {
+        code: "",
+        isValid: false,
+        totalPrice: 0,
+        runTimeMs: 0,
+        llmRunCount: 0,
+        logSummary: "",
+        error: `Invalid workflow format in the database: ${e}`,
+      },
     } satisfies ClientWorkflow;
   }
 }

--- a/apps/hub/src/app/ai/WorkflowSummaryList/WorkflowStatusIcon.tsx
+++ b/apps/hub/src/app/ai/WorkflowSummaryList/WorkflowStatusIcon.tsx
@@ -12,7 +12,7 @@ export function isWorkflowOutdated(workflow: ClientWorkflow): boolean {
 
 function getWorkflowStatusForIcon(
   workflow: ClientWorkflow
-): ClientWorkflow["status"] {
+): "loading" | "finished" | "error" {
   if (workflow.status === "loading") {
     return isWorkflowOutdated(workflow) ? "error" : "loading";
   }
@@ -36,5 +36,7 @@ export const WorkflowStatusIcon: FC<{ workflow: ClientWorkflow }> = ({
       return <CheckCircleIcon className="text-emerald-400" size={16} />;
     case "error":
       return <ErrorIcon className="text-red-400" size={16} />;
+    default:
+      throw new Error(status satisfies never);
   }
 };

--- a/apps/hub/src/app/ai/WorkflowViewer/index.tsx
+++ b/apps/hub/src/app/ai/WorkflowViewer/index.tsx
@@ -3,7 +3,7 @@ import { format } from "date-fns";
 import { Children, FC } from "react";
 
 import { ClientWorkflow } from "@quri/squiggle-ai";
-import { ErrorIcon, StyledTab } from "@quri/ui";
+import { ErrorIcon, StyledTab, TextTooltip } from "@quri/ui";
 
 import { commonDateFormat } from "@/lib/constants";
 import { useAvailableHeight } from "@/lib/hooks/useAvailableHeight";
@@ -53,12 +53,26 @@ const FinishedWorkflowViewer: FC<WorkflowViewerProps<"finished">> = ({
         <Header
           workflow={workflow}
           renderLeft={() => (
-            <LineSeparatedList>
-              <span>{(workflow.result.runTimeMs / 1000).toFixed(2)}s</span>
-              <span>${workflow.result.totalPrice.toFixed(2)}</span>
-              <span>{workflow.result.llmRunCount} LLM runs</span>
-              <WorkflowDate workflow={workflow} />
-            </LineSeparatedList>
+            <div className="flex items-center gap-2">
+              <LineSeparatedList>
+                <span>{(workflow.result.runTimeMs / 1000).toFixed(2)}s</span>
+                <span>${workflow.result.totalPrice.toFixed(2)}</span>
+                <span>{workflow.result.llmRunCount} LLM runs</span>
+                <WorkflowDate workflow={workflow} />
+              </LineSeparatedList>
+              {workflow.result.error ? (
+                <div className="flex items-center gap-1">
+                  <TextTooltip text={workflow.result.error}>
+                    <span>
+                      <ErrorIcon
+                        className="cursor-pointer text-red-400"
+                        size={16}
+                      />
+                    </span>
+                  </TextTooltip>
+                </div>
+              ) : null}
+            </div>
           )}
           renderRight={() => (
             <div className="flex items-center gap-2">
@@ -137,18 +151,6 @@ export const WorkflowViewer: FC<WorkflowViewerProps> = ({
       return <FinishedWorkflowViewer {...props} workflow={workflow} />;
     case "loading":
       return <LoadingWorkflowViewer {...props} workflow={workflow} />;
-    case "error":
-      return (
-        <div className="mt-2 rounded-md border border-red-300 bg-red-50 p-4">
-          <h3 className="mb-2 text-lg font-semibold text-red-800">
-            Server Error
-          </h3>
-          <p className="mb-4 text-red-700">{workflow.result}</p>
-          <p className="text-sm text-red-600">
-            Please try refreshing the page or attempt your action again.
-          </p>
-        </div>
-      );
     default:
       throw workflow satisfies never;
   }

--- a/apps/hub/src/app/ai/api/create/route.ts
+++ b/apps/hub/src/app/ai/api/create/route.ts
@@ -105,7 +105,7 @@ function aiRequestToWorkflow(request: AiRequestBody) {
   const llmConfig: LlmConfig = {
     llmId: request.model ?? "Claude-Sonnet",
     priceLimit: 0.3,
-    durationLimitMinutes: 2,
+    durationLimitMinutes: 0.01,
     messagesInHistoryToKeep: 4,
     numericSteps: request.numericSteps,
     styleGuideSteps: request.styleGuideSteps,

--- a/apps/hub/src/app/ai/api/create/route.ts
+++ b/apps/hub/src/app/ai/api/create/route.ts
@@ -105,7 +105,7 @@ function aiRequestToWorkflow(request: AiRequestBody) {
   const llmConfig: LlmConfig = {
     llmId: request.model ?? "Claude-Sonnet",
     priceLimit: 0.3,
-    durationLimitMinutes: 0.01,
+    durationLimitMinutes: 2,
     messagesInHistoryToKeep: 4,
     numericSteps: request.numericSteps,
     styleGuideSteps: request.styleGuideSteps,

--- a/apps/hub/src/app/ai/useSquiggleWorkflows.tsx
+++ b/apps/hub/src/app/ai/useSquiggleWorkflows.tsx
@@ -63,7 +63,7 @@ export function useSquiggleWorkflows(preloadedWorkflows: AiWorkflow[]) {
           steps: [],
         },
         author: {
-          username: session.data?.user?.name ?? "Unknown",
+          username: session.data?.user?.username ?? "Unknown",
         },
       };
       setWorkflows((workflows) => [workflow, ...workflows]);

--- a/apps/hub/src/app/ai/useSquiggleWorkflows.tsx
+++ b/apps/hub/src/app/ai/useSquiggleWorkflows.tsx
@@ -109,8 +109,16 @@ export function useSquiggleWorkflows(preloadedWorkflows: AiWorkflow[]) {
       } catch (error) {
         updateWorkflow(id, (workflow) => ({
           ...workflow,
-          status: "error",
-          result: `Server error: ${error instanceof Error ? error.toString() : "Unknown error"}.`,
+          status: "finished",
+          result: {
+            code: "",
+            isValid: false,
+            totalPrice: 0,
+            runTimeMs: 0,
+            llmRunCount: 0,
+            logSummary: "",
+            error: `Server error: ${error instanceof Error ? error.toString() : "Unknown error"}.`,
+          },
         }));
       }
     },

--- a/internal-packages/ai/src/types.ts
+++ b/internal-packages/ai/src/types.ts
@@ -93,6 +93,7 @@ const stepUpdatedSchema = stepSchema.partial().required({
 export const clientWorkflowResultSchema = z.object({
   code: z.string().describe("Squiggle code snippet"),
   isValid: z.boolean(),
+  error: z.string().optional(),
   totalPrice: z.number(),
   runTimeMs: z.number(),
   llmRunCount: z.number(),
@@ -141,11 +142,6 @@ export const clientWorkflowSchema = z.discriminatedUnion("status", [
     ...commonClientWorkflowFields,
     status: z.literal("finished"),
     result: clientWorkflowResultSchema,
-  }),
-  z.object({
-    ...commonClientWorkflowFields,
-    status: z.literal("error"),
-    result: z.string(),
   }),
 ]);
 

--- a/internal-packages/ai/src/workflows/WorkflowTemplate.ts
+++ b/internal-packages/ai/src/workflows/WorkflowTemplate.ts
@@ -11,6 +11,7 @@ export type WorkflowInstanceParams<Shape extends IOShape> = {
   llmConfig?: LlmConfig;
   openaiApiKey?: string;
   anthropicApiKey?: string;
+  error?: string;
 };
 
 /**

--- a/internal-packages/ai/src/workflows/controllers.ts
+++ b/internal-packages/ai/src/workflows/controllers.ts
@@ -145,6 +145,6 @@ export function getDefaultTransitionRule<Shape extends IOShape>(
       }
     }
 
-    return h.fatal("Unknown step");
+    return h.fatal(ERROR_MESSAGES.UNKNOWN_STEP);
   };
 }


### PR DESCRIPTION
Failed workflows still show the latest working code:

<img width="667" alt="Screenshot 2024-12-27 at 16 18 58" src="https://github.com/user-attachments/assets/55dc7052-f340-4541-9203-ea6647aaaa78" />

<img width="1202" alt="Screenshot 2024-12-27 at 16 35 40" src="https://github.com/user-attachments/assets/cd0672ad-9061-4a40-aa9e-2b90e2907787" />

Workflows have an optional "error" field, which is usually filled by the transition rule's `h.fatal()` call.

Note that it's not the same as the error of the failed step; `h.fatal` can happen in other cases too, e.g. "UNKNOWN_STEP", and possibly "internal logic errors" on the workflow error.

So the error message is more low-level than the error of the last step (we can improve this later):

<img width="678" alt="Screenshot 2024-12-27 at 16 36 20" src="https://github.com/user-attachments/assets/2e5036ca-2c82-4e1d-9c39-3ce879e3153c" />

Workflows don't have the "error" state anymore, only "loading" and "finished". We haven't really been using error states anyway, and we didn't have events for error states.

Btw, the reason why workflows were failing silently and stayed in the infinite loading state before is related to this:
- transition rule did `h.fatal`
- workflow threw the exception
- but DB updates happened on `allStepsFinished` and `stepFinished` events in the route code, which didn't fire

---

Another fix in this PR: in the previous code (for admin mode) I used `user.name` instead of `user.username`, which caused all workflows in list to have a "Unknown" user icon, even in non-admin mode:
<img width="314" alt="Screenshot 2024-12-27 at 16 41 04" src="https://github.com/user-attachments/assets/f1e98c0b-374f-4e64-9980-f3b747f04468" />

This is now fixed.
