### PR TITLE
Scroll-past-end for playground & editor components

### DIFF
--- a/.changeset/eleven-socks-melt.md
+++ b/.changeset/eleven-socks-melt.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Scroll past end in SquigglePlayground, and in SquiggleEditor when the height is fixed

--- a/packages/components/src/components/CodeEditor/index.tsx
+++ b/packages/components/src/components/CodeEditor/index.tsx
@@ -12,7 +12,7 @@ export type CodeEditorProps = {
   onSubmit?: () => void;
   // can be used as a hotkey (Cmd+Option+V, see `useViewNodeExtension`) or as an action for gutter markers
   onFocusByPath?: (path: SqValuePath) => void;
-  height?: number | string;
+  height?: number | "100%";
   lineWrapping?: boolean;
   sourceId: string; // TODO - remove this, it's not very useful since source ids in the new SqProject are not unique
   fontSize?: number;
@@ -55,7 +55,11 @@ export const CodeEditor = forwardRef<CodeEditorHandle, CodeEditorProps>(
     }));
 
     return (
-      <div style={{ fontSize: props.fontSize || "13px" }} ref={editorRef} />
+      <div
+        style={{ fontSize: props.fontSize || "13px" }}
+        className={props.height === "100%" ? "h-full max-h-full" : ""}
+        ref={editorRef}
+      />
     );
   }
 );

--- a/packages/components/src/components/CodeEditor/themeExtension.ts
+++ b/packages/components/src/components/CodeEditor/themeExtension.ts
@@ -1,4 +1,4 @@
-import { EditorView } from "@codemirror/view";
+import { EditorView, scrollPastEnd } from "@codemirror/view";
 
 import { heightFacet } from "./fields.js";
 import { extensionFromFacets } from "./utils.js";
@@ -9,14 +9,21 @@ export function themeExtension(initial: {
   return extensionFromFacets({
     facets: [heightFacet],
     initialValues: [initial.height ?? null],
-    makeExtension: ([height]) =>
+    makeExtension: ([height]) => [
       EditorView.theme({
         "&": {
-          ...(height === undefined ? {} : { height }),
+          ...(height
+            ? { height: height === "100%" ? "100%" : `${height}px` }
+            : {}),
+        },
+        ".cm-scroller": {
+          overflow: "auto",
         },
         ".cm-selectionMatch": { backgroundColor: "#33ae661a" },
         ".cm-content": { padding: 0 },
         ":-moz-focusring.cm-content": { outline: "none" },
       }),
+      height ? scrollPastEnd() : [],
+    ],
   });
 }

--- a/packages/components/src/components/SquiggleEditor.tsx
+++ b/packages/components/src/components/SquiggleEditor.tsx
@@ -17,6 +17,7 @@ export type SquiggleEditorProps = {
   defaultCode?: string;
   onCodeChange?(code: string): void;
   editorFontSize?: number;
+  editorHeight?: number | "100%"; // 100% makes sense only if you have a parent with a height.
   // environment comes from StandaloneExecutionProps
 } & (StandaloneExecutionProps | ProjectExecutionProps) &
   Omit<PartialPlaygroundSettings, "environment">;
@@ -27,6 +28,7 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
   project: propsProject,
   environment,
   editorFontSize,
+  editorHeight,
   ...defaultSettings
 }) => {
   const { settings, randomizeSeed } = usePlaygroundSettings({
@@ -66,6 +68,7 @@ export const SquiggleEditor: FC<SquiggleEditorProps> = ({
           defaultValue={defaultCode ?? ""}
           onChange={setCode}
           fontSize={editorFontSize}
+          height={editorHeight}
           showGutter={false}
           project={project}
           simulation={simulation}

--- a/packages/components/src/components/SquigglePlayground/LeftPlaygroundPanel/index.tsx
+++ b/packages/components/src/components/SquigglePlayground/LeftPlaygroundPanel/index.tsx
@@ -111,7 +111,7 @@ export const LeftPlaygroundPanel = forwardRef<LeftPlaygroundPanelHandle, Props>(
     );
 
     const renderBody = () => (
-      <div data-testid="squiggle-editor" style={{ display: "contents" }}>
+      <div data-testid="squiggle-editor" className="min-h-0">
         <CodeEditor
           ref={editorRef}
           // it's important to pass `code` and not `defaultCode` here;

--- a/packages/components/src/components/ui/PanelWithToolbar/index.tsx
+++ b/packages/components/src/components/ui/PanelWithToolbar/index.tsx
@@ -34,36 +34,33 @@ export function PanelWithToolbar<const ModalNames extends string[]>({
 
   const modal = modalName ? renderModal?.(modalName) : undefined;
 
-  //We want to center the title, so need similarly-widthed items on either side
-  const modalHeader = modal && (
+  const header = modal ? (
+    // We want to center the title, so need similarly-widthed items on either side
     <div className="flex h-full gap-2">
-      <ToolbarItem
-        className="w-20 flex-shrink-0 flex-grow-0"
-        onClick={closeModal}
-      >
+      <ToolbarItem className="w-20 shrink-0 grow-0" onClick={closeModal}>
         &larr; Back
       </ToolbarItem>
-      <div className="flex-shrink flex-grow self-center text-center text-sm font-semibold text-slate-600">
+      <div className="shrink grow self-center text-center text-sm font-semibold text-slate-600">
         {modal.title}
       </div>
-      <div className="invisible w-20 flex-shrink-0 flex-grow-0"></div>
+      <div className="invisible w-20 shrink-0 grow-0"></div>
+    </div>
+  ) : (
+    <div className="grid h-full place-items-stretch">
+      {renderToolbar({ openModal })}
     </div>
   );
 
   return (
     <div className="flex h-full flex-col">
-      <div className="mb-1 h-8 overflow-hidden border-b border-slate-200 bg-slate-50 px-4">
-        {modal ? (
-          modalHeader
-        ) : (
-          <div className="grid h-full place-items-stretch">
-            {renderToolbar({ openModal })}
-          </div>
-        )}
+      <div className="mb-1 h-8 shrink-0 overflow-hidden border-b border-slate-200 bg-slate-50 px-4">
+        {header}
       </div>
-      <div className="grid flex-1 place-items-stretch overflow-auto">
-        {modal ? <div className="px-4 py-4"> {modal.body} </div> : renderBody()}
-      </div>
+      {modal ? (
+        <div className="overflow-auto px-4 py-4">{modal.body}</div>
+      ) : (
+        renderBody()
+      )}
     </div>
   );
 }

--- a/packages/components/src/stories/SquiggleEditor.stories.tsx
+++ b/packages/components/src/stories/SquiggleEditor.stories.tsx
@@ -11,6 +11,11 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/**
+ * The default editor.
+ *
+ * Default behavior is the auto-resizeable according to the code height, without a scrollbar.
+ */
 export const Normal: Story = {
   name: "Normal",
   args: {
@@ -25,5 +30,15 @@ export const Variables: Story = {
   name: "Variables",
   args: {
     defaultCode: "x = 2\nnormal(x,2)",
+  },
+};
+
+/**
+ * If height if set, the editor will always be scrollable, with Codemirror's [scrollPastEnd](https://codemirror.net/docs/ref/#view.scrollPastEnd) extension.
+ */
+export const FixedHeight: Story = {
+  args: {
+    defaultCode: "x = 2\nd1 = normal(x,2)\nd2 = normal(x,2)",
+    editorHeight: 100,
   },
 };


### PR DESCRIPTION
Fixes #2331.

- editor in the playground is always scrollable up to the last line (same as e.g. VS Code)
- `<SquiggleEditor>` is auto-resized without the scrollbar by default, but I've added the `editorHeight` option for fixed heights on it too, just to check the behavior; when the height is set, scrollbar is always visible (when there's more than one line), and scroll behavior becomes similar to the playground
- there's no scroll-past-end on the viewer side; first, because it's hard to implement, and second, because it's possible to simulate by focusing