### PR TITLE
Fix VS Code extension

### DIFF
--- a/packages/vscode-ext/package.json
+++ b/packages/vscode-ext/package.json
@@ -18,10 +18,6 @@
     "Programming Languages",
     "Visualization"
   ],
-  "activationEvents": [
-    "onLanguage:squiggle",
-    "onCommand:squiggle.preview"
-  ],
   "main": "./dist/client/extension.js",
   "contributes": {
     "languages": [
@@ -126,10 +122,10 @@
     "build:grammar": "rm -rf syntaxes && mkdir -p syntaxes && cp ../textmate-grammar/dist/*.json ./syntaxes/",
     "build:media": "mkdir -p dist/media && cp ../../apps/website/public/img/squiggle-logo.png dist/media/icon.png && tailwindcss -i ./src/webview/main.css -o dist/media/components.css",
     "build:bundle": "esbuild ./src/client/extension.ts ./src/server/server.ts --format=cjs --platform=node --sourcemap --minify --bundle --external:vscode '--define:process.env.NODE_ENV=\"production\"' --outdir=./dist",
-    "build:webview": "esbuild ./src/webview/index.tsx --format=esm --platform=browser --sourcemap --minify --bundle '--define:process.env.NODE_ENV=\"production\"' --outdir=./dist/webview",
+    "build:webview": "esbuild ./src/webview/index.tsx --format=cjs --platform=browser --sourcemap --minify --bundle '--define:process.env.NODE_ENV=\"production\"' --outdir=./dist/webview",
     "build:ts": "tsc -b",
     "build": "pnpm run build:media && pnpm run build:grammar && pnpm run build:bundle && pnpm run build:webview && pnpm run build:ts",
-    "watch": "pnpm run compile:bundle --watch",
+    "watch": "pnpm run build:bundle --watch",
     "pretest": "pnpm run build && pnpm run lint",
     "lint": "pnpm lint:prettier && pnpm eslint",
     "lint:prettier": "prettier --check .",


### PR DESCRIPTION
Fixes #3326.

One line fix, I don't know why we had esm compilation instead of cjs, probably my stupid mistake from long time ago.