### PR TITLE
Builtin override test

### DIFF
--- a/packages/squiggle-lang/__tests__/library/number_test.ts
+++ b/packages/squiggle-lang/__tests__/library/number_test.ts
@@ -42,3 +42,10 @@ describe("Numbers", () => {
   testEvalToBe("mod(5, -3)", "-1");
   testEvalToBe("mod(-5, -3)", "-2");
 });
+
+describe("Operators", () => {
+  testEvalToBe("2 + 3", "5");
+
+  // https://github.com/quantified-uncertainty/squiggle/issues/1336
+  testEvalToBe("add(x, y) = x * y; 2 + 3", "5");
+});


### PR DESCRIPTION
Fixes #1336.

Turns out it was fixed at some point by compiler improvements: infix operators are resolved through builtins, not through resolving identifier.

https://github.com/quantified-uncertainty/squiggle/blob/220063039fc42e25077d1c3b47bd2e055ab071ff/packages/squiggle-lang/src/compiler/compileExpression.ts#L52-L56

This PR is just a test to make sure it won't regress in the future.