### PR TITLE
redirect squigglehub.org/playground -> docs/playground

### DIFF
--- a/apps/hub/next.config.mjs
+++ b/apps/hub/next.config.mjs
@@ -6,6 +6,11 @@ const nextConfig = {
   },
   redirects: async () => [
     {
+      source: "/playground",
+      destination: "https://squiggle-language.com/playground",
+      permanent: false, // we might host the playground on squiggle hub in the future
+    },
+    {
       source: "/users/:username/models/:slug*",
       destination: "/models/:username/:slug*",
       permanent: true,


### PR DESCRIPTION
Hidden tiny feature. The main reason is that `squigglehub.org` and `squiggle-language.com` start in the same way, and squigglehub.org is on top of my history autocompletion.

So every time I want to get to the playground I start typing `squig` and then realize I have to look for another domain, which takes me a few seconds.

(After creating this PR I realized that Firefox is smart enough to autocomplete `/playg`, in most cases... oh well.)