### PR TITLE
Fix logKde for an edge case

### DIFF
--- a/.changeset/angry-lizards-count.md
+++ b/.changeset/angry-lizards-count.md
@@ -1,0 +1,6 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+- Fix log KDE for an edge case of 2 samples
+- Fix `PointSet.fromDist` crash

--- a/packages/squiggle-lang/__tests__/dists/LogKde_Test.ts
+++ b/packages/squiggle-lang/__tests__/dists/LogKde_Test.ts
@@ -26,6 +26,7 @@ const exampleSets = [
     3.33221889e-85,
     1.19359728e-131,
     -9.999999999999927,
+    -9.999999,
     4.51576558e-139,
     1.50278463e-105,
     9.999999999999998,
@@ -54,7 +55,7 @@ const exampleSets = [
 const block = (samples: number[], outputLength: number) => {
   const params = {
     samples: samples.sort((a, b) => a - b),
-    outputLength: outputLength,
+    outputLength,
     weight: 1,
     kernelWidth: 1,
   };

--- a/packages/squiggle-lang/src/XYShape.ts
+++ b/packages/squiggle-lang/src/XYShape.ts
@@ -482,6 +482,16 @@ export const PointwiseCombination = {
     const t2n = t2.xs.length;
     const outX: number[] = [];
     const outY: number[] = [];
+
+    // The loop below would fail if we don't have any points in one of the shapes.
+    if (!t1n) {
+      return Result.Ok(t2);
+    }
+
+    if (!t2n) {
+      return Result.Ok(t1);
+    }
+
     // Next index that we want to consume.
     // Possible range of values: [0..n+2], where:
     // - `n` signifies "we consumed all points"

--- a/packages/squiggle-lang/src/dists/SampleSetDist/kde.ts
+++ b/packages/squiggle-lang/src/dists/SampleSetDist/kde.ts
@@ -6,7 +6,7 @@
 
 import { nrd0 } from "./bandwidth.js";
 
-export type kdeParams = {
+export type KdeParams = {
   samples: number[];
   outputLength: number;
   weight: number;
@@ -19,7 +19,7 @@ export const kde = ({
   outputLength,
   weight,
   kernelWidth,
-}: kdeParams) => {
+}: KdeParams) => {
   let xWidth = kernelWidth ?? nrd0(samples);
   samples = samples.filter((v) => Number.isFinite(v)); // Not sure if this is needed?
   const len = samples.length;


### PR DESCRIPTION
Fixes #3382. The chart wasn't rendered when we had NaN values on x axis, which were produced when logKde was applied to two samples.

The code had a check for 1 or 2 samples, but turns out we need at least 3.

This PR also fixes an edge case in `PointSet.fromDist` transformation; previously, it could crash when applied to mixed distributions with zero discrete samples. I found it by accident, when I tried [mx(normal(5, 2), uniform(0, 10), beta(2, 6), [0.3, 0.2, 0.5]) -> PointSet.fromDist](https://www.squiggle-language.com/playground?v=0.9.0#code=eNqrVkpJTUsszSlxzk9JVbJSyq3QyMsvyk3M0TDVUTDS1FEozctMAwpoGOgoGBoA%2BUmpJYkaRjoKZkB2tIGesY6CgZ4RiDCN1VTQtVMIyM%2FMKwlOLdFLK8rPdcksLlGqBQDTzBzs) and got an exception on render (because the error happens in `dist.integral` call, called from the chart component through `.inv()`).