### PR TITLE
Allow author-less revision builds again

### DIFF
--- a/apps/hub/src/lib/server/cli.ts
+++ b/apps/hub/src/lib/server/cli.ts
@@ -10,6 +10,6 @@ export function getCliUserEmail() {
 
 // If a script needs to update the current user, it can do so with this function.
 // Note that this is not threadsafe, and should only be used in scripts.
-export function setCliUserEmail(email: string) {
+export function setCliUserEmail(email: string | undefined) {
   cliUserEmail = email;
 }

--- a/apps/hub/src/scripts/buildRecentModelRevision/worker.ts
+++ b/apps/hub/src/scripts/buildRecentModelRevision/worker.ts
@@ -14,7 +14,7 @@ export type VariableRevisionInput = {
 export type WorkerRunMessage = {
   type: "run";
   data: {
-    userEmail: string;
+    userEmail?: string;
     code: string;
     seed: string;
     squiggleVersion: SquiggleVersion;
@@ -55,6 +55,8 @@ export async function runSquiggleCode({
   };
 }
 
+// IMPORTANT: This is not threadsafe, because of `setCliUserEmail` that sets a global variable.
+// Don't try to run multiple Squiggle models in parallel in a single worker, especially if they have different users.
 process.on("message", async (message: WorkerRunMessage) => {
   if (message.type === "run") {
     try {


### PR DESCRIPTION
Squiggle build runner is broken because in the previous PR (#3777) I did two incompatible things at the same time:
- required that `authorId` is set on revisions for them to be built (because the builder is now auth-aware)
- changed the builder to build _all_ revisions, not just the latest (not sure if this is the best thing to do but it simplified some code in builder, even if more expensive on compute)

So the builder now tries to build legacy revisions from 2023 which don't have authors.

I hoped that I'd be able to fill `authorId` fields retroactively, but it's not so easy, especially for group-owned models.

Instead, in this PR I'm allowing authorless builds again, but with "anonymous" user.

This PR also makes the build runner a bit more robust, e.g. it will produce fail builds on unknown Squiggle versions, instead of getting stuck.