### PR TITLE
feat: Add dev-only email auth provider with console login links

### DIFF
--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -11,8 +11,8 @@ The typical config looks like this:
 ```bash
 DATABASE_URL=postgres://postgres@localhost:5432/[your-db-name] # You need a Postgres database; on macOS the easiest option is https://postgresapp.com/
 NEXTAUTH_URL=http://localhost:3001
-SENDGRID_KEY=... # You'll need a working API key to sign in
-EMAIL_FROM=dev@squigglehub.org # Doesn't matter too much
+NEXTAUTH_SECRET=OwXOS457opeQzuhsKLItdhFDMrta2dcRlehqoQBGyKg= # Any random string works for local dev
+DEV_AUTH_ENABLED=true # Enables simple email auth - login links print to console (no email service needed)
 ROOT_EMAILS=[your-email] # Email of the root user on Squiggle Hub, to get extra permissions
 ```
 

--- a/apps/hub/src/lib/server/auth.ts
+++ b/apps/hub/src/lib/server/auth.ts
@@ -38,6 +38,24 @@ function buildAuthConfig(): NextAuthConfig {
     );
   }
 
+  // Dev-only: print login link to console
+  if (process.env.NODE_ENV === "development" && process.env["DEV_AUTH_ENABLED"] === "true") {
+    providers.push(
+      Resend({
+        apiKey: "dummy-key-not-used",
+        from: "dev@localhost",
+        name: "Dev Email (Check Console)",
+        async sendVerificationRequest({ identifier: email, url }) {
+          console.log("\n===========================================");
+          console.log("🔐 DEV LOGIN LINK");
+          console.log(`Email: ${email}`);
+          console.log(`\nClick here to sign in:\n${url}\n`);
+          console.log("===========================================\n");
+        },
+      })
+    );
+  }
+
   const config: NextAuthConfig = {
     adapter: PrismaAdapter(
       prisma as any // @auth/prisma-adapter doesn't support our PrismaClient from @quri/hub-db


### PR DESCRIPTION
## Summary

Add a development-only authentication provider that prints magic login links directly to the console when `DEV_AUTH_ENABLED=true`. This eliminates the need to configure an email service (like SendGrid or Resend) for local development.

While I eventually got SendGrid working, this should make it much easier to get started with local development without the extra setup hurdle.

## Changes

- Added dev-only email auth provider in `auth.ts` that logs login links to console
- Updated README.md to document `DEV_AUTH_ENABLED` and remove outdated SendGrid reference
- Added `NEXTAUTH_SECRET` to README (was missing from docs)