### PR TITLE
Add broken-site banner to Metaforecast

### DIFF
--- a/apps/metaforecast/src/app/(nav)/layout.tsx
+++ b/apps/metaforecast/src/app/(nav)/layout.tsx
@@ -41,8 +41,8 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
         <div className="bg-yellow-50 border-b border-yellow-200">
           <div className="container mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
             <p className="text-center text-sm text-yellow-800">
-              <strong>Notice:</strong> Metaforecast is currently experiencing
-              issues and may not work as expected. We are working on fixing it.
+              We aren&apos;t currently maintaining Metaforecast. We hope to
+              do so again in the future.
             </p>
           </div>
         </div>

--- a/apps/metaforecast/src/app/(nav)/layout.tsx
+++ b/apps/metaforecast/src/app/(nav)/layout.tsx
@@ -38,6 +38,14 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
             </div>
           </div>
         </nav>
+        <div className="bg-yellow-50 border-b border-yellow-200">
+          <div className="container mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
+            <p className="text-center text-sm text-yellow-800">
+              <strong>Notice:</strong> Metaforecast is currently experiencing
+              issues and may not work as expected. We are working on fixing it.
+            </p>
+          </div>
+        </div>
         <main>
           <ErrorBoundary>
             <div className="container mx-auto mb-10 max-w-7xl px-4 pt-5 sm:px-6 lg:px-8">


### PR DESCRIPTION
## Summary
- Adds a yellow warning banner below the nav bar on all Metaforecast pages
- Banner text: "Notice: Metaforecast is currently experiencing issues and may not work as expected. We are working on fixing it."

## Test plan
- [ ] Check Vercel preview deploy to confirm banner looks good
- [ ] Verify banner appears on all pages (home, about, status, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)