### PR TITLE
Improve Squiggle CLI error handling and reporting

### DIFF
--- a/packages/squiggle-lang/__tests__/cli/errors_test.ts
+++ b/packages/squiggle-lang/__tests__/cli/errors_test.ts
@@ -1,0 +1,192 @@
+import { runCLI, stripAnsi } from "../helpers/cliHelpers.js";
+
+describe("run command error handling", () => {
+  test("parse error exits with code 1", async () => {
+    const result = await runCLI(["run", "--eval", "2+"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("parse error outputs to stderr", async () => {
+    const result = await runCLI(["run", "--eval", "2+"]);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).not.toBe("");
+  });
+
+  test("parse error shows 'Compile Error' header", async () => {
+    const result = await runCLI(["run", "--eval", "2+"]);
+    expect(stripAnsi(result.stderr)).toMatch(/Compile Error:/);
+  });
+
+  test("undefined variable shows 'Compile Error' header", async () => {
+    const result = await runCLI(["run", "--eval", "undefinedVar"]);
+    expect(result.exitCode).toBe(1);
+    expect(stripAnsi(result.stderr)).toMatch(/Compile Error:/);
+    expect(stripAnsi(result.stderr)).toMatch(/not defined/);
+  });
+
+  test("runtime error exits with code 1", async () => {
+    const result = await runCLI(["run", "--eval", "List.first([])"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("runtime error outputs to stderr", async () => {
+    const result = await runCLI(["run", "--eval", "List.first([])"]);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).not.toBe("");
+  });
+
+  test("runtime error shows 'Runtime Error' header", async () => {
+    const result = await runCLI(["run", "--eval", "List.first([])"]);
+    expect(stripAnsi(result.stderr)).toMatch(/Runtime Error:/);
+  });
+
+  test("runtime error includes stack trace", async () => {
+    const result = await runCLI(["run", "--eval", "List.first([])"]);
+    const stderr = stripAnsi(result.stderr);
+    expect(stderr).toMatch(/Stack trace:/);
+    expect(stderr).toMatch(/List\.first/);
+  });
+
+  test("runtime error in function includes stack trace with location", async () => {
+    const result = await runCLI([
+      "run",
+      "--eval",
+      "f(x) = List.first(x); f([])",
+    ]);
+    const stderr = stripAnsi(result.stderr);
+    expect(result.exitCode).toBe(1);
+    expect(stderr).toMatch(/Stack trace:/);
+    expect(stderr).toMatch(/line 1/);
+  });
+
+  test("valid code exits with code 0 and empty stderr", async () => {
+    const result = await runCLI(["run", "--eval", "2+2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("4\n");
+  });
+
+  test("valid void expression exits with code 0", async () => {
+    const result = await runCLI(["run", "--eval", "x = 5"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  test("error with --quiet still shows error on stderr", async () => {
+    const result = await runCLI(["run", "--eval", "List.first([])", "--quiet"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toBe("");
+    expect(stripAnsi(result.stderr)).toMatch(/Runtime Error:/);
+  });
+
+  test("error with --time still shows error and time", async () => {
+    const result = await runCLI(["run", "--eval", "2+", "--time"]);
+    expect(result.exitCode).toBe(1);
+    expect(stripAnsi(result.stderr)).toMatch(/Compile Error:/);
+  });
+
+  test("nonexistent file produces error", async () => {
+    const result = await runCLI(["run", "nonexistent_file_12345.squiggle"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("invalid import path produces error", async () => {
+    const result = await runCLI([
+      "run",
+      "--eval",
+      'import "absolute/path" as x',
+    ]);
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("parse command error handling", () => {
+  test("parse error exits with code 1", async () => {
+    const result = await runCLI(["parse", "--eval", "2+"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("parse error outputs to stderr", async () => {
+    const result = await runCLI(["parse", "--eval", "2+"]);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).not.toBe("");
+  });
+
+  test("valid code exits with code 0 and empty stderr", async () => {
+    const result = await runCLI(["parse", "--eval", "2+2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toBe("");
+  });
+
+  test("typed mode error exits with code 1", async () => {
+    const result = await runCLI([
+      "parse",
+      "--eval",
+      "2+",
+      "--mode",
+      "typed",
+    ]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toBe("");
+  });
+
+  test("raw mode error exits with code 1", async () => {
+    const result = await runCLI(["parse", "--eval", "2+", "--mode", "raw"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).not.toBe("");
+  });
+});
+
+describe("print-ir command error handling", () => {
+  test("parse error exits with code 1", async () => {
+    const result = await runCLI(["print-ir", "--eval", "2+"]);
+    expect(result.exitCode).toBe(1);
+  });
+
+  test("parse error outputs to stderr", async () => {
+    const result = await runCLI(["print-ir", "--eval", "2+"]);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).not.toBe("");
+  });
+
+  test("valid code exits with code 0", async () => {
+    const result = await runCLI(["print-ir", "--eval", "2+2"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+});
+
+describe("general CLI error handling", () => {
+  test("no arguments shows usage and exits with code 1", async () => {
+    const result = await runCLI([]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/Usage:/);
+  });
+
+  test("unknown command exits with non-zero code", async () => {
+    const result = await runCLI(["nonexistent-command"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("run with both filename and --eval produces error", async () => {
+    const result = await runCLI(["run", "file.squiggle", "--eval", "2+2"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("run without filename or --eval produces error", async () => {
+    const result = await runCLI(["run"]);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("--quiet and --show-bindings conflict produces error", async () => {
+    const result = await runCLI([
+      "run",
+      "--eval",
+      "2+2",
+      "--quiet",
+      "--show-bindings",
+    ]);
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/packages/squiggle-lang/__tests__/helpers/cliHelpers.ts
+++ b/packages/squiggle-lang/__tests__/helpers/cliHelpers.ts
@@ -26,6 +26,10 @@ export async function runCLI(args: string[]) {
     },
   });
 
+  // Capture process.exitCode set by our error handlers
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+
   let exitCode = 0;
   try {
     await program.parseAsync(args, { from: "user" });
@@ -36,6 +40,13 @@ export async function runCLI(args: string[]) {
       throw e;
     }
   }
+
+  // Use process.exitCode if it was set (by our error handlers),
+  // otherwise use the Commander exit code
+  if (process.exitCode !== undefined) {
+    exitCode = process.exitCode;
+  }
+  process.exitCode = originalExitCode;
 
   jest.restoreAllMocks();
   return { stdout, stderr, exitCode };

--- a/packages/squiggle-lang/src/cli/CliPrinter.ts
+++ b/packages/squiggle-lang/src/cli/CliPrinter.ts
@@ -1,3 +1,5 @@
+import { bold, red } from "./colors.js";
+
 export class CliPrinter {
   isFirstSection = true;
 
@@ -8,5 +10,15 @@ export class CliPrinter {
     }
     this.isFirstSection = false;
     lines.forEach((line) => console.log(line));
+  }
+
+  // Prints an error section to stderr with a colored header.
+  printError(header: string, details: string) {
+    if (!this.isFirstSection) {
+      console.error();
+    }
+    this.isFirstSection = false;
+    console.error(red(bold(header + ":")));
+    console.error(details);
   }
 }

--- a/packages/squiggle-lang/src/cli/commands/parse.ts
+++ b/packages/squiggle-lang/src/cli/commands/parse.ts
@@ -33,7 +33,8 @@ export function addParseCommand(program: Command) {
           if (ast.ok) {
             console.log(astNodeToString(ast.value, { colored: true }));
           } else {
-            console.log(red(ast.value.toString()));
+            process.exitCode = 1;
+            console.error(red(ast.value.toString()));
           }
           break;
         }
@@ -42,7 +43,8 @@ export function addParseCommand(program: Command) {
           if (ast.ok) {
             console.log(coloredJson(ast.value));
           } else {
-            console.log(red(ast.value.toString()));
+            process.exitCode = 1;
+            console.error(red(ast.value.toString()));
           }
           break;
         }
@@ -56,7 +58,8 @@ export function addParseCommand(program: Command) {
               })
             );
           } else {
-            console.log(red(typedAst.value.toString()));
+            process.exitCode = 1;
+            console.error(red(typedAst.value.toString()));
           }
           break;
         }

--- a/packages/squiggle-lang/src/cli/commands/playground.ts
+++ b/packages/squiggle-lang/src/cli/commands/playground.ts
@@ -1,7 +1,8 @@
 import { Command } from "@commander-js/extra-typings";
+import open from "open";
 
 export function addPlaygroundCommand(program: Command) {
-  program.command("playground").action(() => {
-    open("https://www.squiggle-language.com/playground");
+  program.command("playground").action(async () => {
+    await open("https://www.squiggle-language.com/playground");
   });
 }

--- a/packages/squiggle-lang/src/cli/commands/print-ir.ts
+++ b/packages/squiggle-lang/src/cli/commands/print-ir.ts
@@ -30,10 +30,12 @@ export function addPrintIrCommand(program: Command) {
         if (ir.ok) {
           console.log(irToString(ir.value, { colored: true }));
         } else {
-          console.log(red(ir.value.toString()));
+          process.exitCode = 1;
+          console.error(red(ir.value.toString()));
         }
       } else {
-        console.log(red(typedAstR.value.toString()));
+        process.exitCode = 1;
+        console.error(red(typedAstR.value.toString()));
       }
     });
 }

--- a/packages/squiggle-lang/src/cli/commands/run.tsx
+++ b/packages/squiggle-lang/src/cli/commands/run.tsx
@@ -6,6 +6,12 @@ import path from "path";
 import { FC } from "react";
 
 import { defaultEnv, Env } from "../../dists/env.js";
+import {
+  SqCompileError,
+  SqError,
+  SqImportError,
+  SqRuntimeError,
+} from "../../public/SqError.js";
 import { SqLinker } from "../../public/SqLinker.js";
 import { SqProject } from "../../public/SqProject/index.js";
 import {
@@ -36,11 +42,24 @@ type RunArgs = {
 
 const EVAL_SOURCE_ID = "[eval]";
 
+function errorHeader(error: SqError): string {
+  const inner =
+    error instanceof SqImportError ? error.wrappedError() : error;
+  if (inner instanceof SqCompileError) {
+    return "Compile Error";
+  } else if (inner instanceof SqRuntimeError) {
+    return "Runtime Error";
+  }
+  return "Error";
+}
+
 function getLinker(): SqLinker {
   return {
     resolve(name, fromId) {
       if (!name.startsWith("./") && !name.startsWith("../")) {
-        throw new Error("Only relative paths in imports are allowed");
+        throw new Error(
+          `Only relative paths in imports are allowed, got "${name}"`
+        );
       }
       const dir =
         fromId === EVAL_SOURCE_ID ? process.cwd() : path.dirname(fromId);
@@ -48,13 +67,19 @@ function getLinker(): SqLinker {
     },
     async loadModule(sourceId, hash) {
       if (hash) {
-        throw new Error("Hashes are not supported");
+        throw new Error("Hashes are not supported in CLI imports");
       }
-      const code = await fs.readFile(sourceId, "utf-8");
-      return new SqModule({
-        name: sourceId,
-        code,
-      });
+      try {
+        const code = await fs.readFile(sourceId, "utf-8");
+        return new SqModule({
+          name: sourceId,
+          code,
+        });
+      } catch (e) {
+        throw new Error(
+          `Failed to read import "${sourceId}": ${e instanceof Error ? e.message : String(e)}`
+        );
+      }
     },
   };
 }
@@ -206,10 +231,11 @@ async function run(args: RunArgs) {
 
   const printer = new CliPrinter();
   if (!output.result.ok) {
-    printer.printSection(
-      red("Error:"),
-      output.result.value.toStringWithDetails()
-    );
+    process.exitCode = 1;
+    const errors = output.result.value;
+    for (const error of errors.errors) {
+      printer.printError(errorHeader(error), error.toStringWithDetails());
+    }
   } else {
     const outputResult = output.result.value;
     switch (args.output) {

--- a/packages/squiggle-lang/src/cli/index.ts
+++ b/packages/squiggle-lang/src/cli/index.ts
@@ -4,4 +4,9 @@ const main = async () => {
   await makeProgram().parseAsync();
 };
 
-main();
+main().catch((error) => {
+  console.error(
+    error instanceof Error ? `Error: ${error.message}` : String(error)
+  );
+  process.exitCode = 1;
+});

--- a/packages/squiggle-lang/src/cli/utils.ts
+++ b/packages/squiggle-lang/src/cli/utils.ts
@@ -19,7 +19,13 @@ export function loadSrc({
   if (filename !== undefined && inline !== undefined) {
     program.error("Only one of filename and eval string should be set.");
   } else if (filename !== undefined) {
-    src = fs.readFileSync(filename, "utf-8");
+    try {
+      src = fs.readFileSync(filename, "utf-8");
+    } catch (e) {
+      program.error(
+        `Failed to read file "${filename}": ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
   } else if (inline !== undefined) {
     src = inline;
   } else {


### PR DESCRIPTION
## Summary
- Set `process.exitCode = 1` on all error paths (`run`, `parse`, `print-ir`) so scripts and CI can detect failures
- Output errors to stderr instead of stdout for proper stream separation
- Add error type classification matching the UI ("Compile Error", "Runtime Error") with colored headers
- Iterate individual errors from `SqErrorList` for better multi-error display
- Fix `playground` command: add missing `open` import (was throwing `ReferenceError`)
- Add top-level `.catch()` in `index.ts` for unhandled errors
- Wrap file-not-found errors in `loadSrc` with `program.error()` for clean output
- Add `printError` method to `CliPrinter` for stderr output
- Add 28 new tests covering all error paths with full coverage of exit codes, stderr/stdout separation, error classification headers, and stack traces

## Test plan
- [x] All 39 CLI tests pass (11 existing + 28 new)
- [x] `squiggle run -e "2+2"` → exit 0, output to stdout
- [x] `squiggle run -e "2+"` → "Compile Error:", exit 1, output to stderr
- [x] `squiggle run -e 'List.first([])'` → "Runtime Error:" with stack trace, exit 1
- [x] `squiggle run nonexistent.squiggle` → clean error message, exit 1
- [x] `squiggle parse -e "2+"` → exit 1, error to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)