### PR TITLE
Announce Metaforecast shutdown in banner

### DIFF
--- a/apps/metaforecast/src/app/(nav)/layout.tsx
+++ b/apps/metaforecast/src/app/(nav)/layout.tsx
@@ -41,8 +41,8 @@ const Layout: FC<PropsWithChildren> = ({ children }) => {
         <div className="border-b border-yellow-200 bg-yellow-50">
           <div className="container mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
             <p className="text-center text-sm text-yellow-800">
-              We aren&apos;t currently maintaining Metaforecast. We hope to do
-              so again in the future.
+              Metaforecast is shutting down. The site will be taken offline on
+              July 9, 2026.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Updates the site banner to say Metaforecast is shutting down and will go offline on July 9, 2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)