### PR TITLE
ci: bump actions to Node 24 versions

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -10,10 +10,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@v6
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 22
         cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build, test, lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Turbo run

--- a/.github/workflows/cleanup-vercel-deployments.yml
+++ b/.github/workflows/cleanup-vercel-deployments.yml
@@ -9,7 +9,7 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Run cleanup script

--- a/.github/workflows/hub-scripts-image.yaml
+++ b/.github/workflows/hub-scripts-image.yaml
@@ -39,15 +39,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2 # for turbo-ignore
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           # no need for pnpm cache, we only install turbo-ignore

--- a/.github/workflows/metaforecast-image.yaml
+++ b/.github/workflows/metaforecast-image.yaml
@@ -37,15 +37,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2 # for turbo-ignore
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           # no need for pnpm cache, we only install turbo-ignore

--- a/.github/workflows/prisma-migrate-preview.yml
+++ b/.github/workflows/prisma-migrate-preview.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       should_run_hub: ${{ steps.check-hub.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Preview
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Migrate Hub

--- a/.github/workflows/prisma-migrate-prod.yml
+++ b/.github/workflows/prisma-migrate-prod.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Migrate Hub
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Migrate Metaforecast

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Build changelog script

--- a/.github/workflows/reset-preview-db.yml
+++ b/.github/workflows/reset-preview-db.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Preview
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ./.github/actions/install
 
       - name: Reset


### PR DESCRIPTION
Clears the Node 20 deprecation warning by bumping `actions/checkout` (v4→v7), `actions/setup-node` (v4→v6), and `pnpm/action-setup` (v4→v6) across all workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)