### PR TITLE
ci: drop explicit CodeQL category to clear stale config

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,5 +37,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
-        with:
-          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Follow-up to #4110. The explicit `category` created a separate config instead of matching the old path-derived one. Removing it so the scan overwrites and clears the stale erroring config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)