### PR TITLE
fix: content string escaping + ignore metaforecast in CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+name: "CodeQL config"
+
+# Metaforecast is being wound down; don't scan it.
+paths-ignore:
+  - apps/metaforecast

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,7 @@ jobs:
           languages: ${{ matrix.language }}
           # JS/TS is analyzed directly from source — no build needed.
           build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/internal-packages/content/src/apiUtils.ts
+++ b/internal-packages/content/src/apiUtils.ts
@@ -8,8 +8,10 @@ import { type ApiModuleDoc } from "./collections/apiDocs.js";
 import { docTitleFromMeta } from "./collections/utils.js";
 
 // We need to escape the curly braces in the markdown for .jsx files.
+// Escape backslashes first so existing backslashes in the input can't
+// combine with the ones we add for the braces.
 function escapedStr(str: string) {
-  return str.replace(/{/g, "\\{").replace(/}/g, "\\}");
+  return str.replace(/\\/g, "\\\\").replace(/{/g, "\\{").replace(/}/g, "\\}");
 }
 
 function toMarkdown(documentation: FnDocumentation) {


### PR DESCRIPTION
- Fix the two CodeQL "incomplete string escaping" alerts in the content module by escaping backslashes before braces.
- Add a CodeQL config (`paths-ignore: apps/metaforecast`) so the winding-down app stops generating alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)