### PR TITLE
chore: bump next manifest pins to clear Dependabot alerts

### DIFF
--- a/apps/fermi-contest-2025-02/package.json
+++ b/apps/fermi-contest-2025-02/package.json
@@ -23,7 +23,7 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@inquirer/prompts": "^7.4.0",
     "dotenv": "^16.4.7",
-    "next": "15.2.6",
+    "next": "15.5.18",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -41,7 +41,7 @@
     "immutable": "^5.1.1",
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
-    "next": "15.2.6",
+    "next": "15.5.18",
     "next-auth": "5.0.0-beta.25",
     "next-safe-action": "^7.10.4",
     "pako": "^2.1.0",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -30,7 +30,7 @@
     "fumadocs-core": "14.0.2",
     "fumadocs-ui": "14.0.2",
     "katex": "^0.16.21",
-    "next": "15.4.8",
+    "next": "15.5.18",
     "pako": "^2.1.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
The apps pinned vulnerable `next` versions (15.2.6 / 15.4.8) in their manifests, so Dependabot kept flagging ~64 alerts even though the lockfile override already resolves `next` to 15.5.18. Aligning the manifest pins to 15.5.18 (no install change) clears them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)