### PR TITLE
fix(changesets): stop ignoring private app packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,9 +16,6 @@
   "ignore": [
     "@quri/ops",
     "squiggle-website",
-    "@quri/hub",
-    "@quri/content",
-    "@quri/squiggle-ai",
     "@quri/evaluations"
   ],
   "changelog": "../internal-packages/ops/dist/changelog.cjs"


### PR DESCRIPTION
The release workflow could never reach the publish step: changesets for the private app packages (hub, AI, content) were never consumed, so they piled up and kept the workflow on the version path (the "No commits between main and changeset-release/main" error).

These packages are private and never publish to npm, so ignoring them was redundant. Removing them from the ignore list lets their notes become changelogs and unblocks publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)