### PR TITLE
Revert: restore private packages to changesets ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,6 +16,9 @@
   "ignore": [
     "@quri/ops",
     "squiggle-website",
+    "@quri/hub",
+    "@quri/content",
+    "@quri/squiggle-ai",
     "@quri/evaluations"
   ],
   "changelog": "../internal-packages/ops/dist/changelog.cjs"


### PR DESCRIPTION
Un-ignoring the private app packages broke release versioning — they depend on other always-skipped private packages, so changesets refuses to version them. Restoring the ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)