### PR TITLE
chore: drop orphaned changesets blocking the release

### DIFF
--- a/.changeset/brave-chefs-explode.md
+++ b/.changeset/brave-chefs-explode.md
@@ -1,5 +1,0 @@
----
-"@quri/squiggle-ai": minor
----
-
-feat: Add Claude Opus 4.5 model and standardize maxTokens to 8192

--- a/.changeset/chilly-cats-appear.md
+++ b/.changeset/chilly-cats-appear.md
@@ -1,5 +1,0 @@
----
-"@quri/squiggle-ai": patch
----
-
-Add Anthropic Claude Haiku 4.5 model to Squiggle Hub AI

--- a/.changeset/green-bugs-drive.md
+++ b/.changeset/green-bugs-drive.md
@@ -1,5 +1,0 @@
----
-"@quri/squiggle-ai": patch
----
-
-feat: Add simple-evals script

--- a/.changeset/nice-bats-explain.md
+++ b/.changeset/nice-bats-explain.md
@@ -1,6 +1,0 @@
----
-"@quri/squiggle-ai": patch
-"@quri/hub": patch
----
-
-add support for OpenRouter as provider, add Grok Code Fast 1 model via OpenRouter 

--- a/.changeset/stupid-cameras-hope.md
+++ b/.changeset/stupid-cameras-hope.md
@@ -1,5 +1,0 @@
----
-"@quri/squiggle-ai": patch
----
-
-Update Claude Sonnet 3.7 -> 4.5


### PR DESCRIPTION
These 5 notes only target ignored private packages, so they're never consumed and permanently keep the release on the version path instead of publishing. Removing them unblocks publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)