### PR TITLE
Update newsletter link in footers

### DIFF
--- a/apps/hub/src/lib/constants.ts
+++ b/apps/hub/src/lib/constants.ts
@@ -6,7 +6,7 @@ export const DISCORD_URL = "https://discord.gg/nsTnQTgtG6";
 export const GITHUB_URL = "https://github.com/quantified-uncertainty/squiggle";
 export const GITHUB_DISCUSSION_URL =
   "https://github.com/quantified-uncertainty/squiggle/discussions";
-export const NEWSLETTER_URL = "https://quri.substack.com/t/squiggle";
+export const NEWSLETTER_URL = "https://quantifieduncertainty.org/";
 
 export const QURI_DONATE_URL = "https://quantifieduncertainty.org/donate";
 

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -17,7 +17,7 @@ export const Footer: FC = () => {
         <FaDiscord size="1em" className="mr-2" />
         Discord
       </a>
-      <a href="https://quri.substack.com/t/squiggle" className={linkClasses}>
+      <a href="https://quantifieduncertainty.org/" className={linkClasses}>
         <FaRss size="1em" className="mr-2" />
         Newsletter
       </a>


### PR DESCRIPTION
The footer newsletter link pointed to the old Substack; it now points to https://quantifieduncertainty.org/ as requested. Updated in both Hub and website footers.

Fixes #3956

🤖 Generated with [Claude Code](https://claude.com/claude-code)