### PR TITLE
Ask for confirmation before deleting a model

### DIFF
--- a/apps/hub/src/app/models/[owner]/[slug]/DeleteModelAction.tsx
+++ b/apps/hub/src/app/models/[owner]/[slug]/DeleteModelAction.tsx
@@ -24,6 +24,7 @@ export const DeleteModelAction: FC<Props> = ({ model }) => {
           close={close}
           title={`Delete ${model.owner.slug}/${model.slug}`}
           submitText="Delete Model"
+          submitTheme="alert"
           action={deleteModelAction}
           formDataToInput={() => ({
             owner: model.owner.slug,

--- a/apps/hub/src/app/models/[owner]/[slug]/DeleteModelAction.tsx
+++ b/apps/hub/src/app/models/[owner]/[slug]/DeleteModelAction.tsx
@@ -1,14 +1,9 @@
-import { useAction } from "next-safe-action/hooks";
 import { useRouter } from "next/navigation";
 import { FC } from "react";
 
-import {
-  DropdownMenuActionItem,
-  TrashIcon,
-  useCloseDropdown,
-  useToast,
-} from "@quri/ui";
+import { DropdownMenuModalActionItem, TrashIcon } from "@quri/ui";
 
+import { SafeActionFormModal } from "@/components/ui/SafeActionFormModal";
 import { ownerRoute } from "@/lib/routes";
 import { deleteModelAction } from "@/models/actions/deleteModelAction";
 import { ModelCardDTO } from "@/models/data/cards";
@@ -20,35 +15,30 @@ type Props = {
 export const DeleteModelAction: FC<Props> = ({ model }) => {
   const router = useRouter();
 
-  const toast = useToast();
-
-  const closeDropdown = useCloseDropdown();
-
-  const { execute, isPending } = useAction(deleteModelAction, {
-    onSuccess: ({ data }) => {
-      if (data) {
-        router.push(ownerRoute(model.owner));
-      }
-      // we're going to redirect, so no need to close the dropdown
-      // TODO - keep the action in "acting" state while redirecting
-    },
-    onError: ({ error }) => {
-      toast(error.serverError ?? "Internal error", "error");
-      closeDropdown();
-    },
-  });
-
   return (
-    <DropdownMenuActionItem
+    <DropdownMenuModalActionItem
       title="Delete"
-      onClick={() => {
-        execute({
-          owner: model.owner.slug,
-          slug: model.slug,
-        });
-      }}
-      acting={isPending}
       icon={TrashIcon}
+      render={({ close }) => (
+        <SafeActionFormModal<Record<string, never>, typeof deleteModelAction>
+          close={close}
+          title={`Delete ${model.owner.slug}/${model.slug}`}
+          submitText="Delete Model"
+          action={deleteModelAction}
+          formDataToInput={() => ({
+            owner: model.owner.slug,
+            slug: model.slug,
+          })}
+          // we're going to redirect, so keep the modal open until the redirect finishes
+          closeOnSuccess={false}
+          onSuccess={() => {
+            router.push(ownerRoute(model.owner));
+          }}
+        >
+          This will delete the model and all of its revisions. This action
+          can&apos;t be undone.
+        </SafeActionFormModal>
+      )}
     />
   );
 };

--- a/apps/hub/src/components/ui/FormModal.tsx
+++ b/apps/hub/src/components/ui/FormModal.tsx
@@ -6,12 +6,14 @@ import {
   UseFormReturn,
 } from "react-hook-form";
 
-import { Button, Modal } from "@quri/ui";
+import { Button, ButtonTheme, Modal } from "@quri/ui";
 
 type Props<TFieldValues extends FieldValues> = PropsWithChildren<{
   onSubmit: (event?: BaseSyntheticEvent) => void;
   close: () => void;
   submitText: string;
+  // "alert" is useful for destructive actions.
+  submitTheme?: ButtonTheme;
   title: string;
   inFlight?: boolean;
   form: UseFormReturn<TFieldValues, unknown, any>;
@@ -23,6 +25,7 @@ export function FormModal<TFieldValues extends FieldValues>({
   onSubmit,
   close,
   submitText,
+  submitTheme = "primary",
   title,
   inFlight,
   form,
@@ -44,7 +47,7 @@ export function FormModal<TFieldValues extends FieldValues>({
           <Modal.Footer>
             <Button
               type="submit"
-              theme="primary"
+              theme={submitTheme}
               disabled={!form.formState.isValid || inFlight}
             >
               {submitText}

--- a/apps/hub/src/components/ui/SafeActionFormModal.tsx
+++ b/apps/hub/src/components/ui/SafeActionFormModal.tsx
@@ -2,6 +2,8 @@ import { HookSafeActionFn } from "next-safe-action/hooks";
 import { PropsWithChildren, ReactNode } from "react";
 import { FieldPath, FieldValues } from "react-hook-form";
 
+import { ButtonTheme } from "@quri/ui";
+
 import { FormModal } from "@/components/ui/FormModal";
 import { useSafeActionForm } from "@/lib/hooks/useSafeActionForm";
 
@@ -18,6 +20,7 @@ export function SafeActionFormModal<
   title,
   initialFocus,
   submitText,
+  submitTheme,
   children,
   close,
   closeOnSuccess = true,
@@ -29,6 +32,8 @@ export function SafeActionFormModal<
     title: string;
     initialFocus?: FieldPath<TFormShape>;
     submitText: string;
+    // "alert" is useful for destructive actions.
+    submitTheme?: ButtonTheme;
     // Intentionally explicit. In case of forms activated by dropdowns we could obtain this with `useCloseDropdown`, but it's not always the case.
     // The common pattern is to use this component in `DropdownMenuModalActionItem` and pass the close function from `render({ close })`.
     close: () => void;
@@ -56,6 +61,7 @@ export function SafeActionFormModal<
       close={close}
       title={title}
       submitText={submitText}
+      submitTheme={submitTheme}
       form={form}
       initialFocus={initialFocus}
       onSubmit={onSubmit}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "clsx";
 import { FC, PropsWithChildren } from "react";
 
-type ButtonTheme = "default" | "primary" | "alert";
+export type ButtonTheme = "default" | "primary" | "alert";
 
 export type ButtonProps = PropsWithChildren<{
   onClick?: () => void;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,8 @@
-export { Button, type ButtonProps } from "./components/Button.js";
+export {
+  Button,
+  type ButtonProps,
+  type ButtonTheme,
+} from "./components/Button.js";
 export { ButtonWithDropdown } from "./components/ButtonWithDropdown.js";
 export { Modal } from "./components/Modal.js";
 export { StyledTab } from "./components/StyledTab.js";


### PR DESCRIPTION
The Delete button in the model settings dropdown deleted the model immediately. It now opens a confirmation modal first, using the same pattern as other delete actions (e.g. question sets).

The modal's submit button uses a new optional `submitTheme` prop (red "alert" theme for destructive actions).

Fixes #4056

🤖 Generated with [Claude Code](https://claude.com/claude-code)