### PR TITLE
Open MarkdownViewer links in a new tab

### DIFF
--- a/.changeset/markdown-links-new-tab.md
+++ b/.changeset/markdown-links-new-tab.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-components": patch
+---
+
+Links in MarkdownViewer open in a new tab (in-page anchor links excluded)

--- a/packages/components/src/lib/MarkdownViewer.tsx
+++ b/packages/components/src/lib/MarkdownViewer.tsx
@@ -64,6 +64,19 @@ export const MarkdownViewer: React.FC<MarkdownViewerProps> = ({
         rehypePlugins={[rehypeInlineCodeProperty]}
         remarkPlugins={[remarkGfm]}
         components={{
+          // Open links in a new tab, so that the user doesn't lose the state of the current page.
+          // In-page anchor links are excluded.
+          a: ({ href, children, ...rest }) => (
+            <a
+              {...rest}
+              href={href}
+              {...(href?.startsWith("#")
+                ? {}
+                : { target: "_blank", rel: "noreferrer" })}
+            >
+              {children}
+            </a>
+          ),
           pre: ({ children }) => <React.Fragment>{children}</React.Fragment>,
           code({ node, className, children, ...rest }) {
             const isInline =


### PR DESCRIPTION
Links rendered from markdown (model descriptions, string outputs) now open in a new tab so the user doesn't lose their editor state. In-page anchor links (`#...`) are excluded.

Fixes #3619

🤖 Generated with [Claude Code](https://claude.com/claude-code)