### PR TITLE
Add Number.log(x, base)

### DIFF
--- a/.changeset/log-with-base.md
+++ b/.changeset/log-with-base.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Support `log(x, base)` — logarithm in an arbitrary base

--- a/packages/squiggle-lang/__tests__/library/number_test.ts
+++ b/packages/squiggle-lang/__tests__/library/number_test.ts
@@ -10,6 +10,10 @@ describe("Numbers", () => {
   testEvalToBe("Number.abs(0)", "0");
   testEvalToBe("abs(5.5)", "5.5");
   testEvalToBe("Number.exp(10)", "22026.465794806718");
+  testEvalToBe("Number.log(1)", "0");
+  testEvalToBe("Number.log(8, 2)", "3");
+  testEvalToBe("Number.log(1000, 10)", "2.9999999999999996");
+  testEvalToBe("log(8, 2)", "3");
   testEvalToBe("Number.log10(10)", "1");
   testEvalToBe("Number.log2(10)", "3.321928094887362");
   testEvalToBe("Number.sum([])", "0");

--- a/packages/squiggle-lang/src/fr/number.ts
+++ b/packages/squiggle-lang/src/fr/number.ts
@@ -106,11 +106,20 @@ export const library = [
     examples: [makeFnExample(`exp(3.5)`)],
     fn: Math.exp,
   }),
-  maker.n2n({
+  maker.make({
     name: "log",
     displaySection: "Functions (Number)",
-    examples: [makeFnExample(`log(3.5)`)],
-    fn: Math.log,
+    description:
+      "Natural logarithm. With a second argument, returns the logarithm in that base.",
+    examples: [makeFnExample(`log(3.5)`), makeFnExample(`log(8, 2)`)],
+    definitions: [
+      makeDefinition([frNumber], frNumber, ([x]) => Math.log(x)),
+      makeDefinition(
+        [frNumber, namedInput("base", frNumber)],
+        frNumber,
+        ([x, base]) => Math.log(x) / Math.log(base)
+      ),
+    ],
   }),
   maker.n2n({
     name: "log10",


### PR DESCRIPTION
Adds a two-argument overload of `log` that returns the logarithm of `x` in the given base, e.g. `log(8, 2) → 3`. Includes tests and a changeset; API docs pick it up from the registry.

Fixes #3487

🤖 Generated with [Claude Code](https://claude.com/claude-code)