### PR TITLE
fix: truncate on discrete / point-mass pointsets corrupts the distribution

### DIFF
--- a/packages/squiggle-lang/__tests__/dists/GenericDist_test.ts
+++ b/packages/squiggle-lang/__tests__/dists/GenericDist_test.ts
@@ -1,6 +1,7 @@
 import { BaseDist } from "../../src/dists/BaseDist.js";
 import { DistError } from "../../src/dists/DistError.js";
 import { SampleSetDist } from "../../src/dists/SampleSetDist/index.js";
+import * as SymbolicDist from "../../src/dists/SymbolicDist/index.js";
 import { Env } from "../../src/index.js";
 import { getDefaultRng } from "../../src/rng/index.js";
 import * as Result from "../../src/utility/result.js";
@@ -81,6 +82,30 @@ describe("sparkline", () => {
   runTest("triangular", triangularDist, Ok(`▁▁▂▃▄▅▆▇████▇▆▅▄▃▂▁▁`));
 
   runTest("exponential", exponentialDist, Ok(`█▅▄▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁`));
+});
+
+describe("truncate", () => {
+  // Regression test for https://github.com/quantified-uncertainty/squiggle/issues/2518
+  // A discrete-only distribution (like a point mass) has an empty continuous
+  // part. ContinuousShape.truncate used to append boundary sentinel points even
+  // to that empty part, turning it into a zero-integral non-empty shape, so
+  // MixedShape.normalize computed 0 / 0 = NaN and corrupted the distribution.
+  test("point mass survives truncation to a range that contains it", () => {
+    const pointMass = unpackResult(SymbolicDist.PointMass.make(0.5));
+    const truncated = unpackResult(pointMass.truncate(1e-6, 1 - 1e-6, { env }));
+
+    const mean = truncated.mean();
+    expect(Number.isNaN(mean)).toBe(false);
+    expect(mean).toBeCloseTo(0.5, 6);
+  });
+
+  test("continuous distribution truncation is unchanged", () => {
+    const truncated = unpackResult(normalDist5.truncate(3, 8, { env }));
+
+    const mean = truncated.mean();
+    expect(Number.isFinite(mean)).toBe(true);
+    expect(mean).toBeCloseTo(5, 0);
+  });
 });
 
 describe("isEqual", () => {

--- a/packages/squiggle-lang/src/PointSet/Continuous.ts
+++ b/packages/squiggle-lang/src/PointSet/Continuous.ts
@@ -141,6 +141,14 @@ export class ContinuousShape implements PointSet<ContinuousShape> {
   }
 
   truncate(leftCutoff: number | undefined, rightCutoff: number | undefined) {
+    // An empty continuous shape has no curve to close off, so appending the
+    // boundary sentinel points below would turn it into a non-empty,
+    // zero-integral shape. That breaks MixedShape.normalize for discrete-only
+    // distributions (0 / 0 = NaN). Leave the empty shape unchanged.
+    if (this.isEmpty()) {
+      return this;
+    }
+
     const lc = leftCutoff ?? -Infinity;
     const rc = rightCutoff ?? Infinity;
     const truncatedZippedPairs = XYShape.Zipped.filterByX(


### PR DESCRIPTION
## Summary

Truncating a discrete-only distribution (a point mass or a discrete mixture) no longer corrupts it into NaN. `ContinuousShape.truncate` now returns the empty continuous part unchanged instead of adding boundary points to it.

## Why this matters

Fixes #2518. A discrete-only distribution is internally a mixed shape with a populated discrete part and an empty continuous part. `ContinuousShape.truncate` appended boundary sentinel points (`leftCutoff - epsilon` and `rightCutoff + epsilon`) to close off the curve at the cutoffs, but it did this even when the continuous part was empty. That turned the empty part into a non-empty, zero-integral shape, so `isEmpty()` reported it as non-empty and `MixedShape.normalize` fell into its general branch and computed `newContinuousSum / continuousIntegralSum = 0 / 0 = NaN`, poisoning the whole distribution.

For example, `truncate(Dist.make(0.5), 1e-6, 1 - 1e-6)` returned a value at the left cutoff instead of the unchanged point mass at 0.5.

The fix guards `ContinuousShape.truncate` to return the empty continuous unchanged when `this.isEmpty()` is true. Boundary sentinels only make sense when there is an actual curve to close. With the guard, the discrete-only path keeps its continuous part empty, `normalize` takes the `continuous.isEmpty()` branch, and the distribution stays intact.

## Testing

Added a regression test in `packages/squiggle-lang/__tests__/dists/GenericDist_test.ts`: a point mass at 0.5 truncated to `[1e-6, 1 - 1e-6]` keeps mean 0.5 with no NaN, and a normal distribution truncated to an in-range window still behaves as before. Ran the package test file (`pnpm jest __tests__/dists/GenericDist_test.ts`), `tsc`, and lint locally, all passing. Confirmed the point-mass test fails (mean is NaN) without the guard.

Fixes #2518
