### PR TITLE
Fix dev email login provider

### DIFF
--- a/apps/hub/src/lib/server/auth.ts
+++ b/apps/hub/src/lib/server/auth.ts
@@ -45,6 +45,9 @@ function buildAuthConfig(): NextAuthConfig {
   ) {
     providers.push(
       Resend({
+        // Without a distinct id, this provider clashes with the real Resend
+        // provider above (both get id "resend") and can never be selected.
+        id: "dev-email",
         apiKey: "dummy-key-not-used",
         from: "dev@localhost",
         name: "Dev Email (Check Console)",


### PR DESCRIPTION
The "Dev Email (Check Console)" sign-in option never worked: both email providers registered under the same internal id, so the dev one could never be selected and the form always hit the real email sender. Giving it a distinct id fixes local-dev login; verified end-to-end (the link prints to the server console and logs in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)