### PR TITLE
Add changeset for #4135

### DIFF
--- a/.changeset/truncate-discrete-pointsets.md
+++ b/.changeset/truncate-discrete-pointsets.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Fix `truncate` on discrete / point-mass pointset distributions corrupting them into NaN (#2518, #4135)


### PR DESCRIPTION
Adds the missing changeset for #4135 (truncate fix for discrete pointsets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)