### PR TITLE
Fix spurious density spikes near zero for sign-crossing sample sets

### DIFF
--- a/.changeset/fix-log-kde-sign-crossing.md
+++ b/.changeset/fix-log-kde-sign-crossing.md
@@ -1,0 +1,5 @@
+---
+"@quri/squiggle-lang": patch
+---
+
+Fix spurious density spikes near zero when rendering sign-crossing sample sets (e.g. the difference of two lognormals) — the log-KDE heuristic no longer fires on distributions that span both signs (#4103)

--- a/packages/squiggle-lang/__tests__/dists/SamplesToPointSetDist_test.ts
+++ b/packages/squiggle-lang/__tests__/dists/SamplesToPointSetDist_test.ts
@@ -1,0 +1,77 @@
+import { samplesToPointSetDist } from "../../src/dists/SampleSetDist/samplesToPointSetDist.js";
+import { XYShape } from "../../src/XYShape.js";
+
+// Deterministic pseudo-random numbers, so the test can't flake.
+const makeRng = (seed: number) => {
+  let state = seed;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return state / 4294967296;
+  };
+};
+
+// Box-Muller, driven by the seeded rng.
+const makeGaussian = (rng: () => number) => () => {
+  const u = Math.max(rng(), 1e-12);
+  const v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+};
+
+const lognormalFromCI =
+  (low: number, high: number, gaussian: () => number) => () => {
+    const mu = (Math.log(low) + Math.log(high)) / 2;
+    const sigma = (Math.log(high) - Math.log(low)) / (2 * 1.6448536269514722);
+    return Math.exp(mu + sigma * gaussian());
+  };
+
+const maxYIn = (shape: XYShape, minX: number, maxX: number) =>
+  Math.max(
+    ...shape.ys.filter((_, i) => shape.xs[i] >= minX && shape.xs[i] <= maxX)
+  );
+
+describe("samplesToPointSetDist", () => {
+  // https://github.com/quantified-uncertainty/squiggle/issues/4103
+  // The difference of two lognormals crosses zero. The log-KDE heuristic used
+  // to fire on it (it looks heavy-tailed in absolute values), producing sharp
+  // density spikes near zero that don't exist in the samples.
+  test("sign-crossing samples don't get spurious density spikes near zero", () => {
+    const gaussian = makeGaussian(makeRng(12345));
+    const a = lognormalFromCI(0.5, 1, gaussian);
+    const b = lognormalFromCI(0.5, 5, gaussian);
+    const samples = Array.from({ length: 1000 }, () => b() - a());
+
+    const { continuousDist } = samplesToPointSetDist({
+      samples,
+      continuousOutputLength: 1000,
+    });
+
+    expect(continuousDist).toBeDefined();
+    const maxNearZero = maxYIn(continuousDist!, -0.1, 0.1);
+    const maxElsewhere = Math.max(
+      maxYIn(continuousDist!, -Infinity, -0.1),
+      maxYIn(continuousDist!, 0.1, Infinity)
+    );
+    // With the log-KDE artifact, maxNearZero was 3x-50x maxElsewhere.
+    expect(maxNearZero).toBeLessThan(maxElsewhere * 1.5);
+  });
+
+  test("all-positive heavy-tailed samples still use log KDE", () => {
+    const gaussian = makeGaussian(makeRng(54321));
+    const lognormal = lognormalFromCI(0.01, 100, gaussian);
+    const samples = Array.from({ length: 1000 }, () => lognormal());
+
+    const auto = samplesToPointSetDist({
+      samples,
+      continuousOutputLength: 1000,
+    });
+    const linear = samplesToPointSetDist({
+      samples,
+      continuousOutputLength: 1000,
+      logScale: false,
+    });
+
+    // Log KDE concentrates many more points near zero than linear KDE does,
+    // so the auto result should differ from the forced-linear one.
+    expect(auto.continuousDist!.xs).not.toEqual(linear.continuousDist!.xs);
+  });
+});

--- a/packages/squiggle-lang/src/dists/SampleSetDist/samplesToPointSetDist.ts
+++ b/packages/squiggle-lang/src/dists/SampleSetDist/samplesToPointSetDist.ts
@@ -36,6 +36,15 @@ const shouldBeLogHeuristicFn = ({ p10, p90 }: { p10: number; p90: number }) => {
 };
 
 const checkIfShouldBeLog = (samples: number[]): boolean => {
+  // Log KDE splits samples at zero and runs KDE on each side in log space.
+  // For sign-crossing distributions (e.g. the difference of two lognormals)
+  // this produces spurious density spikes near zero, because samples close to
+  // zero become isolated far-out points in log space and each turns into a
+  // huge narrow spike after converting back. See #4103.
+  // `samples` is sorted, so checking the ends is enough.
+  if (samples[0] < 0 && samples[samples.length - 1] > 0) {
+    return false;
+  }
   const dist = SampleSetDist.make(samples);
   if (dist.ok) {
     const range = dist.value.range(0.8, true);


### PR DESCRIPTION
Fixes #4103.

## Problem
The density curve for sign-crossing sample sets (e.g. `c = b - a` where both are lognormals) showed sharp spikes near zero that don't exist in the samples.

## Cause
`samplesToPointSetDist` auto-picks log KDE using a heuristic based on absolute-value quantiles, so distributions spanning both signs qualified. Log KDE splits samples at zero and runs KDE in log space on each side; samples close to zero become isolated far-out points in log space, and each turns into a huge narrow spike after converting back (measured 3x–50x the true density).

## Fix
The heuristic no longer fires when samples span both signs — those now use plain linear KDE. Explicit `logScale: true` still works as before, and single-sign heavy-tailed distributions still get log KDE.

Before/after on the issue's repro (peak density in [-0.1, 0.1] vs elsewhere):
- before: 5.06 vs 0.47
- after: 0.39 vs 0.42

Verified visually in a local Hub against the repro from the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)